### PR TITLE
v1.10.13: stabilize proxy runtime and sync relevant Flowseal changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable user-facing changes are listed here. Detailed notes for older releases: [docs/releases/](docs/releases/).
 
+## Unreleased — 1.10.13
+
+- MTProto WebSocket receive path now reassembles fragmented/continuation messages instead of dropping continuation frames.
+- Added 16 MiB protection for individual WebSocket frames and accumulated fragmented messages before payload allocation/delivery.
+- Failed/rejected MTProto WebSocket receive paths close the underlying connection.
+- Worker preconnect remains disabled by default. When explicitly enabled, a session pool miss no longer launches a duplicate background refill while the foreground Worker dial is already in progress; hits still replenish the pool.
+- Worker failover is regression-tested to stop after the first successful candidate.
+- Worker ordering for equal creation timestamps preserves stable persistence/insertion order instead of using random UUID order.
+- Reviewed relevant Flowseal runtime changes through `b2a8074`; Android-specific route keys, cooldown/watchdog/fake-TLS/diagnostics behavior are retained and disabled upstream 429 logic is not ported.
+- Added `docs/research/flowseal-upstream-2026-08-24.md` with port/no-port decisions. Automated Go/Android/debug-build validation passed on the implementation branch; the project owner also reported a successful manual proxy smoke test.
+
 ## 1.10.12
 
 - MTProto Proxy is now the default local frontend on shared port `1443`; SOCKS5/WS stays available as a compatibility mode.

--- a/app/src/main/java/com/amurcanov/tgwsproxy/worker/WorkerCandidateMapper.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/worker/WorkerCandidateMapper.kt
@@ -68,6 +68,9 @@ internal object WorkerCandidateMapper {
     }
 
     fun stableOrderComparator(): Comparator<WorkerEndpoint> {
-        return compareBy<WorkerEndpoint>({ it.createdAt }, { it.id })
+        // Kotlin's sortedWith is stable. For workers created in the same
+        // millisecond, preserve persistence/insertion order instead of using
+        // a random UUID as a tie-breaker, which made round-robin flaky.
+        return compareBy<WorkerEndpoint> { it.createdAt }
     }
 }

--- a/docs/research/flowseal-upstream-2026-08-24.md
+++ b/docs/research/flowseal-upstream-2026-08-24.md
@@ -1,0 +1,148 @@
+# Flowseal upstream review — 2026-08-24
+
+## Purpose
+
+This note records the selective upstream review for TGWSProxyAndroid v1.10.13.
+The goal is runtime stability, not a wholesale replacement of the Android Go
+runtime with Flowseal's Python implementation.
+
+## Baseline and comparison range
+
+The previous repository audit recorded Flowseal commit
+`e9b74d7d7dcc3beceab4d34d18d91b8ec9fdf098` as the reference baseline.
+On 2026-08-24, `Flowseal/tg-ws-proxy` `main` is 31 commits ahead of that
+baseline, with latest reviewed commit
+`b2a8074c59c52cabde7fe295280b614cc6c01fce` from 2026-08-13.
+
+Primary runtime commits reviewed:
+
+| Commit | Upstream change | Android decision |
+| --- | --- | --- |
+| `8ac52f69` | automatic direct WS pool rotation | Already represented by Android `WsPool.rotate` / maintenance behavior; no direct port. |
+| `a0545cca` | do not retry an already-fronted connection after timeout | Flowseal-specific fronting state does not map cleanly to the current Android MTProto route adapter; not ported. |
+| `47b8db18` | direct WS refill backoff and no refill while an IP is blocked | Android already has direct-IP cooldown and separate pool maintenance. No risky shared-pool rewrite in this patch; the analogous duplicate-refill problem in the opt-in Worker preconnect path is addressed separately. |
+| `ecf3d6f3` | Worker fallback splitter correction | Current Android Worker MTProto path constructs its packet splitter after relay-init in `mtProtoWebSocketConn`; no literal port. |
+| `41e97c6a` | hard limit Worker pool | Android already caps Worker WS preconnect per key and keeps it disabled by default. |
+| `aee473c9` | CF Worker pool refactor to pool by DC, try available domains, and avoid refill-on-miss | Pool-by-DC is **not** ported because Android routes can vary by Worker domain, destination and media state. The safe part is ported: session cache misses no longer start a duplicate background refill while the foreground path is already dialing. |
+| `2995ae74` | preserve user CF domains | Android has its own persisted domain/pool model; no port. |
+| `0d459995` | generic fixes: Worker first-success break, WebSocket fragmentation/reassembly, 16 MiB frame/message guards, tests/lint | Fragmentation/reassembly and 16 MiB guards are ported for the MTProto WebSocket data plane. First-success behavior already existed in Android and is now covered by a regression test. Python packaging/lint changes are not applicable. |
+| `b2a8074c` | version bump | No runtime behavior to port. |
+
+Desktop/macOS UI, PyInstaller, Docker, translation and packaging commits in the
+same 31-commit range were reviewed as non-runtime/non-Android changes and are
+not imported.
+
+## Ported behavior
+
+### 1. Fragmented WebSocket message handling
+
+Flowseal now reassembles continuation frames before returning a WebSocket
+message. The Android `RawWebSocket.Recv()` path previously returned only text or
+binary frames and ignored continuation frames, so a fragmented upstream message
+could be truncated or lost.
+
+v1.10.13 adds an MTProto-specific bounded frame adapter around the existing
+`RawWebSocket`. It:
+
+- preserves the existing Android dial/TLS/routing implementation;
+- accepts binary, text and continuation data frames with Flowseal-compatible
+  tolerant reassembly semantics;
+- keeps ping/pong handling between fragments;
+- closes the underlying connection on rejected/failed receive paths;
+- applies the adapter centrally in `mtProtoWebSocketConn`, so direct WS,
+  Cloudflare proxy WS and Cloudflare Worker WS MTProto routes use the same
+  receive semantics.
+
+The legacy shared `RawWebSocket` implementation is intentionally not rewritten
+in this release, limiting the blast radius to the MTProto frontend introduced in
+the 1.10.x line.
+
+### 2. 16 MiB frame/message protection
+
+The adapter rejects an individual WebSocket frame larger than 16 MiB before
+allocating its payload buffer. It also rejects a fragmented message whose
+accumulated payload exceeds 16 MiB. These limits mirror current Flowseal
+behavior.
+
+Focused tests use a smaller injected limit to verify both guard paths without
+allocating large buffers during the unit suite.
+
+### 3. Worker preconnect miss behavior
+
+Android's Worker preconnect remains disabled by default. When explicitly
+enabled, `GetForSession` now behaves like the useful part of the current
+Flowseal Worker-pool refactor:
+
+- cache hit: return the preconnected socket and schedule a replacement refill;
+- cache miss: record the miss but do **not** start another background dial,
+  because the current request immediately performs a foreground Worker dial.
+
+This avoids two parallel attempts for the same Worker/destination after a miss.
+The existing `Get` method remains unchanged for other internal pool operations.
+
+### 4. Stop after first successful Worker
+
+No production logic change was required. Both the MTProto Worker connector and
+the older failover function already return immediately after a successful
+Worker connection. A regression test now uses two configured candidates and
+asserts that the second candidate is never dialed after the first succeeds.
+
+## Deliberately not ported
+
+### Pool-by-DC
+
+Flowseal can key its CF Worker idle pool by DC because its fallback destination
+for that pool is much less variable. TGWSProxyAndroid additionally tracks
+Worker domain, destination IP and media state and has Android-specific
+destination scoring/media logic. Collapsing those sockets into a DC-only bucket
+could reuse a WebSocket opened with the wrong `/apiws?dst=...` target. The
+existing Android-specific key is therefore retained.
+
+### Worker preconnect default
+
+The opt-in preconnect mechanism remains disabled by default. Existing project
+history already records Worker Pool as a diagnostics/development path, and this
+review found no evidence that changing the default is safe.
+
+### Upstream 429 Worker exhaustion reporting
+
+The reviewed upstream implementation currently short-circuits the 429 failure
+reporting path with an unconditional return/TODO. Dead or disabled logic is not
+ported.
+
+### Flowseal fronting and desktop-specific changes
+
+Flowseal's fronting retry state, desktop UI, macOS, PyInstaller, Docker,
+translation and packaging changes are not equivalent to the Android runtime and
+are outside this release.
+
+## 2026-08-24 instability evidence
+
+The repository and Issue #2 do not contain the original runtime diagnostics/log capture
+from the unstable 2026-08-24 session, so there is no confirmed single root cause.
+The owner later reported that the updated build was tested in normal use and worked.
+That is treated as a manual smoke-test signal, not as proof that every network/domain
+failure mode is eliminated.
+
+The changes above address concrete protocol/pool gaps identified by comparison
+with Flowseal. If instability recurs, capture at least:
+
+- active frontend and configured/selected/actual route;
+- DC/media classification and Worker destination mode;
+- fallback reason and connection close reason;
+- WS/Worker pool hit/miss/refill counters;
+- DNS/TCP/TLS/WebSocket stage failures;
+- network transition around Wi-Fi/mobile switching.
+
+## Verification
+
+Automated validation on the original implementation branch completed successfully for:
+
+- native Go tests;
+- Android unit tests;
+- debug APK build.
+
+The owner also reported a successful manual smoke test of the resulting proxy build.
+Issue #2 can therefore be closed as implemented and smoke-tested, while any future
+network/domain-specific instability should be tracked as a new reproducible issue with
+diagnostics rather than keeping this upstream-sync task open indefinitely.

--- a/docs/versions/v1.10.13.md
+++ b/docs/versions/v1.10.13.md
@@ -4,24 +4,42 @@ Status: **in development**.
 
 Published baseline: `1.10.12` (`versionCode 50`).
 
-This document describes the planned/in-progress scope for `v1.10.13`. It is not release notes and must not be used as evidence that the listed work has shipped.
+This document describes the planned/in-progress scope for `v1.10.13`. It is not release notes and must not be used as evidence that the full version has shipped.
 
 ## Goals
 
 `v1.10.13` is a single stabilization/release-preparation iteration composed of several independent GitHub Issues:
 
-| Issue | Area | Status meaning |
+| Issue | Area | Status |
 |---|---|---|
-| #2 | Proxy runtime stability + relevant Flowseal changes | Runtime work; not completed by documentation changes |
-| #3 | Public project structure/documentation alignment | Repository/documentation task |
-| #4 | Trusted CI / Project sync / release automation | Separate automation task |
-| #5 | In-app feedback + GitHub Issue Forms | Separate product task |
-| #6 | Update delivery through GitHub Releases | Separate product task |
-| #7 | Final release/localization/compliance audit | Final gate after integration |
+| #2 | Proxy runtime stability + relevant Flowseal changes | **Completed** |
+| #3 | Public project structure/documentation alignment | **Completed** |
+| #4 | Trusted CI / Project sync / release automation | Open |
+| #5 | In-app feedback + GitHub Issue Forms | Open |
+| #6 | Update delivery through GitHub Releases | Open |
+| #7 | Final release/localization/compliance audit | Final gate |
 
-## Issue #3 deliverables
+## Issue #2 — runtime stability / Flowseal parity
 
-The documentation-alignment task adds or refreshes:
+The runtime task selectively ports relevant upstream behavior while preserving Android-specific routing and diagnostics:
+
+- bounded MTProto WebSocket fragmentation/continuation reassembly;
+- 16 MiB frame and accumulated-message guards;
+- close-on-rejected/failed MTProto receive paths;
+- Worker session pool misses no longer start duplicate background preconnect refills;
+- Worker preconnect remains disabled by default;
+- regression coverage that Worker failover stops after the first successful candidate;
+- stable Worker ordering no longer uses random UUID ordering for equal creation timestamps;
+- Android-specific route keys, cooldown, watchdog, fake TLS and diagnostics remain intact;
+- disabled/dead upstream 429 Worker reporting is not ported.
+
+Detailed comparison: `docs/research/flowseal-upstream-2026-08-24.md`.
+
+Automated validation for the implementation branch completed successfully for native Go tests, Android unit tests and debug APK build. The project owner also reported a successful manual smoke test of the updated proxy build. This closes the scoped upstream/stability task; any future domain/network-specific instability should be opened as a new reproducible issue with diagnostics.
+
+## Issue #3 — public project structure
+
+The documentation-alignment task added or refreshed:
 
 - `docs/product/idea.md`;
 - `docs/product/mvp-scope.md`;
@@ -40,7 +58,7 @@ Private/local files are intentionally not part of the repository:
 
 ## Versioning rule
 
-Do not bump `versionName`, `versionCode`, README version badges or release notes to `1.10.13` while only Issue #3 is implemented. Those metadata changes belong to the integrated release preparation after the remaining v1.10.13 scope is ready and verified.
+Do not treat the integrated release as published until the remaining `v1.10.13` issues and final release gate are complete. README version badges, final release notes/tag and release publication belong to the final integration/release step.
 
 ## Release gate
 

--- a/native/tgwsproxy/mtproto_websocket_frames.go
+++ b/native/tgwsproxy/mtproto_websocket_frames.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// mtProtoMaxWebSocketMessageLen mirrors the current Flowseal runtime guard.
+// The limit is applied both to individual frames and to the accumulated
+// fragmented message before it is exposed to the MTProto stream.
+const mtProtoMaxWebSocketMessageLen = 16 * 1024 * 1024
+
+// mtProtoSafeFrameSocket adds bounded WebSocket message reassembly to the
+// existing RawWebSocket without changing the Android-specific transport,
+// routing, cooldown, watchdog or diagnostics code around it.
+type mtProtoSafeFrameSocket struct {
+	raw           *RawWebSocket
+	frag          []byte
+	maxMessageLen int
+}
+
+func wrapMtProtoFrameSocket(socket mtProtoFrameSocket) mtProtoFrameSocket {
+	raw, ok := socket.(*RawWebSocket)
+	if !ok || raw == nil {
+		return socket
+	}
+	return &mtProtoSafeFrameSocket{
+		raw:           raw,
+		maxMessageLen: mtProtoMaxWebSocketMessageLen,
+	}
+}
+
+func (s *mtProtoSafeFrameSocket) messageLimit() int {
+	if s.maxMessageLen > 0 {
+		return s.maxMessageLen
+	}
+	return mtProtoMaxWebSocketMessageLen
+}
+
+func (s *mtProtoSafeFrameSocket) Send(data []byte) error {
+	return s.raw.Send(data)
+}
+
+func (s *mtProtoSafeFrameSocket) SendBatch(parts [][]byte) error {
+	return s.raw.SendBatch(parts)
+}
+
+func (s *mtProtoSafeFrameSocket) Close() {
+	s.raw.Close()
+}
+
+func (s *mtProtoSafeFrameSocket) Recv() ([]byte, error) {
+	limit := s.messageLimit()
+	for !s.raw.closed.Load() {
+		opcode, payload, fin, err := readMtProtoWebSocketFrame(s.raw, limit)
+		if err != nil {
+			s.raw.closed.Store(true)
+			_ = s.raw.conn.Close()
+			return nil, err
+		}
+
+		switch opcode {
+		case opClose:
+			closePayload := payload
+			if len(closePayload) > 2 {
+				closePayload = closePayload[:2]
+			}
+			reply := s.raw.buildFrame(opClose, closePayload, true)
+			s.raw.writeMu.Lock()
+			_, _ = s.raw.conn.Write(reply)
+			s.raw.writeMu.Unlock()
+			s.raw.closed.Store(true)
+			_ = s.raw.conn.Close()
+			return nil, io.EOF
+
+		case opPing:
+			pong := s.raw.buildFrame(opPong, payload, true)
+			s.raw.writeMu.Lock()
+			_, _ = s.raw.conn.Write(pong)
+			s.raw.writeMu.Unlock()
+			continue
+
+		case opPong:
+			continue
+
+		case opContinuation, opText, opBinary:
+			// Keep the same tolerant semantics as current Flowseal: continuation,
+			// text and binary data frames all participate in one accumulated
+			// message, while control frames may appear between fragments.
+			if fin && len(s.frag) == 0 {
+				return payload, nil
+			}
+			s.frag = append(s.frag, payload...)
+			if len(s.frag) > limit {
+				_ = s.raw.conn.Close()
+				s.raw.closed.Store(true)
+				return nil, fmt.Errorf("WS message too large: %d bytes", len(s.frag))
+			}
+			if !fin {
+				continue
+			}
+			message := append([]byte(nil), s.frag...)
+			s.frag = s.frag[:0]
+			return message, nil
+
+		default:
+			continue
+		}
+	}
+	return nil, io.EOF
+}
+
+func readMtProtoWebSocketFrame(ws *RawWebSocket, maxMessageLen int) (opcode int, payload []byte, fin bool, err error) {
+	if maxMessageLen <= 0 {
+		maxMessageLen = mtProtoMaxWebSocketMessageLen
+	}
+
+	var hdr [2]byte
+	if _, err = io.ReadFull(ws.bufReader, hdr[:]); err != nil {
+		return 0, nil, false, err
+	}
+
+	fin = (hdr[0] & 0x80) != 0
+	opcode = int(hdr[0] & 0x0F)
+	length := uint64(hdr[1] & 0x7F)
+
+	switch length {
+	case 126:
+		var extended [2]byte
+		if _, err = io.ReadFull(ws.bufReader, extended[:]); err != nil {
+			return 0, nil, false, err
+		}
+		length = uint64(binary.BigEndian.Uint16(extended[:]))
+	case 127:
+		var extended [8]byte
+		if _, err = io.ReadFull(ws.bufReader, extended[:]); err != nil {
+			return 0, nil, false, err
+		}
+		length = binary.BigEndian.Uint64(extended[:])
+	}
+
+	if length > uint64(maxMessageLen) {
+		return 0, nil, false, fmt.Errorf("WS frame too large: %d bytes", length)
+	}
+
+	hasMask := (hdr[1] & 0x80) != 0
+	var maskKey [4]byte
+	if hasMask {
+		if _, err = io.ReadFull(ws.bufReader, maskKey[:]); err != nil {
+			return 0, nil, false, err
+		}
+	}
+
+	payload = make([]byte, int(length))
+	if length > 0 {
+		if _, err = io.ReadFull(ws.bufReader, payload); err != nil {
+			return 0, nil, false, err
+		}
+	}
+	if hasMask {
+		xorMaskInPlace(payload, maskKey[:])
+	}
+	return opcode, payload, fin, nil
+}
+
+// GetForSession mirrors the useful part of Flowseal's Worker pool refactor:
+// a miss does not immediately start another background refill while the caller
+// is already about to dial the same Worker synchronously. Hits still trigger a
+// refill so the explicitly enabled preconnect pool can replenish itself.
+func (p *WorkerWsPool) GetForSession(key WorkerPoolKey) *RawWebSocket {
+	if !workerWsPreconnectActive() || workerWsPreconnectTargetSize() <= 0 || key.WorkerDomain == "" || key.Dst == "" {
+		return nil
+	}
+
+	now := p.now()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	bucket := p.idle[key]
+	for len(bucket) > 0 {
+		entry := bucket[0]
+		bucket = bucket[1:]
+		p.idle[key] = bucket
+
+		age := now - entry.created
+		if age > p.maxAge || entry.ws.closed.Load() {
+			go entry.ws.Close()
+			continue
+		}
+
+		stats.workerWsPreconnectHits.Add(1)
+		p.scheduleRefillLocked(key)
+		return entry.ws
+	}
+
+	stats.workerWsPreconnectMisses.Add(1)
+	return nil
+}
+
+var _ mtProtoFrameSocket = (*mtProtoSafeFrameSocket)(nil)

--- a/native/tgwsproxy/mtproto_websocket_frames_test.go
+++ b/native/tgwsproxy/mtproto_websocket_frames_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+type frameTestConn struct {
+	reader *bytes.Reader
+	writes bytes.Buffer
+	closed bool
+}
+
+func newFrameTestRaw(input []byte) (*RawWebSocket, *frameTestConn) {
+	conn := &frameTestConn{reader: bytes.NewReader(input)}
+	return &RawWebSocket{
+		conn:      conn,
+		bufReader: bufio.NewReader(conn),
+	}, conn
+}
+
+func (c *frameTestConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
+
+func (c *frameTestConn) Write(p []byte) (int, error) {
+	return c.writes.Write(p)
+}
+
+func (c *frameTestConn) Close() error {
+	c.closed = true
+	return nil
+}
+
+func (c *frameTestConn) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (c *frameTestConn) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (c *frameTestConn) SetDeadline(time.Time) error      { return nil }
+func (c *frameTestConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *frameTestConn) SetWriteDeadline(time.Time) error { return nil }
+
+func testServerFrame(opcode int, payload []byte, fin bool) []byte {
+	first := byte(opcode)
+	if fin {
+		first |= 0x80
+	}
+	length := len(payload)
+	switch {
+	case length < 126:
+		return append([]byte{first, byte(length)}, payload...)
+	case length < 65536:
+		frame := make([]byte, 4+length)
+		frame[0] = first
+		frame[1] = 126
+		binary.BigEndian.PutUint16(frame[2:4], uint16(length))
+		copy(frame[4:], payload)
+		return frame
+	default:
+		frame := make([]byte, 10+length)
+		frame[0] = first
+		frame[1] = 127
+		binary.BigEndian.PutUint64(frame[2:10], uint64(length))
+		copy(frame[10:], payload)
+		return frame
+	}
+}
+
+func TestMtProtoSafeFrameSocketReassemblesFragmentedMessage(t *testing.T) {
+	input := bytes.Join([][]byte{
+		testServerFrame(opBinary, []byte("AAA"), false),
+		testServerFrame(opPong, nil, true),
+		testServerFrame(opContinuation, []byte("BBB"), false),
+		testServerFrame(opContinuation, []byte("CCC"), true),
+	}, nil)
+	raw, _ := newFrameTestRaw(input)
+	socket := &mtProtoSafeFrameSocket{raw: raw, maxMessageLen: 64}
+
+	message, err := socket.Recv()
+	if err != nil {
+		t.Fatalf("recv fragmented message: %v", err)
+	}
+	if got, want := string(message), "AAABBBCCC"; got != want {
+		t.Fatalf("message=%q want=%q", got, want)
+	}
+}
+
+func TestMtProtoSafeFrameSocketRejectsOversizedFrameBeforePayloadRead(t *testing.T) {
+	var header [10]byte
+	header[0] = 0x80 | opBinary
+	header[1] = 127
+	binary.BigEndian.PutUint64(header[2:], 65)
+	raw, conn := newFrameTestRaw(header[:])
+	socket := &mtProtoSafeFrameSocket{raw: raw, maxMessageLen: 64}
+
+	_, err := socket.Recv()
+	if err == nil || !strings.Contains(err.Error(), "WS frame too large") {
+		t.Fatalf("err=%v", err)
+	}
+	if !conn.closed {
+		t.Fatal("oversized frame must close the underlying connection")
+	}
+}
+
+func TestMtProtoSafeFrameSocketRejectsOversizedReassembledMessage(t *testing.T) {
+	input := bytes.Join([][]byte{
+		testServerFrame(opBinary, []byte("1234"), false),
+		testServerFrame(opContinuation, []byte("5678"), false),
+	}, nil)
+	raw, conn := newFrameTestRaw(input)
+	socket := &mtProtoSafeFrameSocket{raw: raw, maxMessageLen: 7}
+
+	_, err := socket.Recv()
+	if err == nil || !strings.Contains(err.Error(), "WS message too large") {
+		t.Fatalf("err=%v", err)
+	}
+	if !conn.closed {
+		t.Fatal("oversized fragmented message must close the underlying connection")
+	}
+}
+
+func TestMtProtoSafeFrameSocketHandlesPingBetweenFragments(t *testing.T) {
+	input := bytes.Join([][]byte{
+		testServerFrame(opBinary, []byte("left"), false),
+		testServerFrame(opPing, []byte("p"), true),
+		testServerFrame(opContinuation, []byte("right"), true),
+	}, nil)
+	raw, conn := newFrameTestRaw(input)
+	socket := &mtProtoSafeFrameSocket{raw: raw, maxMessageLen: 64}
+
+	message, err := socket.Recv()
+	if err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if got, want := string(message), "leftright"; got != want {
+		t.Fatalf("message=%q want=%q", got, want)
+	}
+	if conn.writes.Len() == 0 {
+		t.Fatal("ping must produce a pong frame")
+	}
+}
+
+func TestMtProtoWebSocketConnWrapsRawSocketWithSafeReceiver(t *testing.T) {
+	raw, _ := newFrameTestRaw(testServerFrame(opBinary, []byte("payload"), true))
+	conn, err := mtProtoWebSocketConn(raw, buildTestInitWithSignedDC(t, 2), "worker.example")
+	if err != nil {
+		t.Fatalf("mtProtoWebSocketConn: %v", err)
+	}
+	defer conn.Close()
+
+	stream, ok := conn.(*mtProtoWebSocketStream)
+	if !ok {
+		t.Fatalf("stream type=%T", conn)
+	}
+	if _, ok := stream.socket.(*mtProtoSafeFrameSocket); !ok {
+		t.Fatalf("socket type=%T, want *mtProtoSafeFrameSocket", stream.socket)
+	}
+
+	buf := make([]byte, 32)
+	n, err := conn.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read: %v", err)
+	}
+	if got, want := string(buf[:n]), "payload"; got != want {
+		t.Fatalf("payload=%q want=%q", got, want)
+	}
+}

--- a/native/tgwsproxy/mtproto_worker_route.go
+++ b/native/tgwsproxy/mtproto_worker_route.go
@@ -290,7 +290,7 @@ func (c *mtProtoWorkerConnector) Connect(
 		}
 		var ws mtProtoFrameSocket
 		var err error
-		if pooled := workerPool.Get(poolKey); pooled != nil {
+		if pooled := workerPool.GetForSession(poolKey); pooled != nil {
 			ws = pooled
 			if logInfo != nil {
 				logInfo.Printf(

--- a/native/tgwsproxy/mtproto_worker_success_test.go
+++ b/native/tgwsproxy/mtproto_worker_success_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"tg-ws-proxy/mtproxyfrontend"
+)
+
+func TestMtProtoWorkerConnectorStopsAfterFirstSuccessfulCandidate(t *testing.T) {
+	withRuntimeSettings(t, func(settings runtimeSettings) runtimeSettings {
+		settings.Worker.Enabled = true
+		settings.Worker.Domain = "first.workers.dev"
+		settings.MtProtoWorkerPreconnect = false
+		settings.Worker.Failover = workerFailoverSettings{
+			Enabled:     true,
+			MaxAttempts: 2,
+			Candidates: []workerFailoverCandidate{
+				{ID: "first", Domain: "first.workers.dev"},
+				{ID: "second", Domain: "second.workers.dev"},
+			},
+		}
+		return settings
+	})
+
+	socket := &fakeMtProtoFrameSocket{}
+	var attempts []string
+	connector := &mtProtoWorkerConnector{
+		dial: func(domain, _ string, _ string) (mtProtoFrameSocket, error) {
+			attempts = append(attempts, domain)
+			return socket, nil
+		},
+	}
+
+	conn, result := connector.Connect(context.Background(), mtproxyfrontend.OutboundRequest{
+		DCID:      2,
+		Transport: mtproxyfrontend.TransportAbridged,
+		RelayInit: buildTestInitWithSignedDC(t, 2),
+	})
+	if result.Err != nil {
+		t.Fatalf("connect: %v", result.Err)
+	}
+	defer conn.Close()
+
+	if len(attempts) != 1 || attempts[0] != "first.workers.dev" {
+		t.Fatalf("attempts=%v, want only first successful candidate", attempts)
+	}
+	if result.ActualBackend != mtProtoWorkerBackend || result.Reason != "connected" {
+		t.Fatalf("route truth=%+v", result)
+	}
+}

--- a/native/tgwsproxy/mtproto_ws_route.go
+++ b/native/tgwsproxy/mtproto_ws_route.go
@@ -306,6 +306,7 @@ func defaultMtProtoCFProxyDial(domain, path, logPrefix string) (mtProtoFrameSock
 }
 
 func mtProtoWebSocketConn(ws mtProtoFrameSocket, relayInit []byte, remote string) (net.Conn, error) {
+	ws = wrapMtProtoFrameSocket(ws)
 	if err := ws.Send(relayInit); err != nil {
 		return nil, fmt.Errorf("write relay init to WebSocket %s: %w", remote, err)
 	}

--- a/native/tgwsproxy/worker_failover.go
+++ b/native/tgwsproxy/worker_failover.go
@@ -293,7 +293,7 @@ func tryWorkerFailoverConnect(
 			Dst:          dstIP,
 			Media:        false,
 		}
-		ws := workerPool.Get(poolKey)
+		ws := workerPool.GetForSession(poolKey)
 		var err error
 		if ws != nil {
 			logInfo.Printf("[%s] session_id=%s DC%d%s Worker WS preconnect hit host=%s workerId=%s worker_dst=%s",

--- a/native/tgwsproxy/worker_pool_session_test.go
+++ b/native/tgwsproxy/worker_pool_session_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWorkerPoolSessionMissDoesNotScheduleDuplicateRefill(t *testing.T) {
+	withWorkerWsPreconnect(t, true)
+	withPoolSize(t, 1)
+	stats.Reset()
+	dialer := &fakeWorkerDialer{}
+	pool := newWorkerWsPool(dialer)
+
+	if got := pool.GetForSession(testWorkerKey()); got != nil {
+		t.Fatal("first session get should miss")
+	}
+
+	time.Sleep(40 * time.Millisecond)
+	if got := dialer.count.Load(); got != 0 {
+		t.Fatalf("session miss scheduled %d duplicate background dial(s), want 0", got)
+	}
+	if got := stats.workerWsPreconnectMisses.Load(); got != 1 {
+		t.Fatalf("misses=%d want=1", got)
+	}
+}
+
+func TestWorkerPoolSessionHitSchedulesReplacementRefill(t *testing.T) {
+	withWorkerWsPreconnect(t, true)
+	withPoolSize(t, 1)
+	stats.Reset()
+	dialer := &fakeWorkerDialer{}
+	pool := newWorkerWsPool(dialer)
+	key := testWorkerKey()
+	pooled := newFakeWebSocket()
+	pool.idle[key] = []poolEntry{{ws: pooled, created: pool.now()}}
+
+	if got := pool.GetForSession(key); got != pooled {
+		t.Fatal("expected existing preconnected websocket")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if dialer.count.Load() > 0 && pool.IdleCount() > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("replacement refill was not scheduled after hit, dialed=%d idle=%d", dialer.count.Load(), pool.IdleCount())
+}


### PR DESCRIPTION
Implements Issue #2 on top of the current `main` after the completed project-structure work from #3.

### Runtime changes
- MTProto WebSocket continuation-frame reassembly.
- 16 MiB frame and accumulated-message guards.
- Failed/rejected MTProto receive paths close the underlying connection.
- Worker session pool misses no longer start duplicate background preconnect refills; hits still replenish the opt-in pool.
- Regression coverage that Worker failover stops after the first successful candidate.
- Stable Worker ordering for equal creation timestamps; random UUID order is no longer used as the tie-breaker.

### Upstream decisions
- Relevant Flowseal runtime changes were reviewed and selectively ported.
- Android-specific routing, destination/media-aware Worker pool keys, cooldown, watchdog, fake TLS and diagnostics are preserved.
- Worker preconnect remains disabled by default.
- Disabled upstream 429 reporting is not ported.
- Full comparison is recorded in `docs/research/flowseal-upstream-2026-08-24.md`.

### Version/repository boundaries
- The temporary `v1.10.13-validation.yml` workflow from the earlier draft was removed; permanent CI/release automation belongs to #4.
- `versionName`/`versionCode` are not bumped by #2; final integrated release metadata belongs to the final v1.10.13 release gate.
- `CHANGELOG.md` records these changes under `Unreleased — 1.10.13`.

### Verification
- The original implementation branch passed native Go tests, Android unit tests and debug APK build in GitHub Actions.
- The runtime source/tests integrated here are the validated implementation, rebased cleanly onto the current `main`.
- Project owner reports having tested the updated proxy build in normal use and that it worked. This is recorded as the manual smoke-test evidence for closing #2; it is not treated as proof that every possible domain/network outage is eliminated.

Closes #2