### PR TITLE
ci: add trusted automation baseline for v1.10.13

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -1,0 +1,45 @@
+name: Project Sync
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  add-to-project:
+    name: Add owner issue or PR to Development project
+    if: >
+      github.actor == 'Regstar2' &&
+      github.triggering_actor == 'Regstar2' &&
+      (
+        github.event_name == 'issues' ||
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.user.login == 'Regstar2' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        )
+      )
+    runs-on:
+      - self-hosted
+      - Windows
+      - X64
+    timeout-minutes: 5
+
+    steps:
+      - name: Add item to Development project
+        uses: actions/add-to-project@v2.0.0
+        with:
+          project-url: https://github.com/users/Regstar2/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag, for example v1.0.0
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    if: >
+      github.actor == 'Regstar2' &&
+      github.triggering_actor == 'Regstar2'
+    runs-on:
+      - self-hosted
+      - Windows
+      - X64
+    timeout-minutes: 120
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate and checkout exact release tag
+        shell: pwsh
+        run: |
+          $tag = $env:RELEASE_TAG
+
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+              throw 'Release tag is empty.'
+          }
+
+          if ($tag -notmatch '^v\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$') {
+              throw "Invalid release tag: $tag"
+          }
+
+          git fetch --tags --force
+          if ($LASTEXITCODE -ne 0) {
+              throw 'git fetch --tags failed.'
+          }
+
+          git rev-parse "refs/tags/$tag^{commit}" *> $null
+          if ($LASTEXITCODE -ne 0) {
+              throw "Tag '$tag' does not exist."
+          }
+
+          git checkout --detach "refs/tags/$tag"
+          if ($LASTEXITCODE -ne 0) {
+              throw "Failed to checkout tag '$tag'."
+          }
+
+      - name: Run release-source CI
+        shell: pwsh
+        run: |
+          if (-not (Test-Path './scripts/ci.ps1')) {
+              throw 'Required script scripts/ci.ps1 was not found.'
+          }
+
+          ./scripts/ci.ps1
+
+      - name: Prepare release output
+        shell: pwsh
+        run: |
+          if (Test-Path './dist') {
+              Remove-Item './dist' -Recurse -Force
+          }
+
+          New-Item -ItemType Directory -Path './dist' | Out-Null
+
+      - name: Build release artifacts
+        shell: pwsh
+        run: |
+          if (-not (Test-Path './scripts/release.ps1')) {
+              throw 'Required script scripts/release.ps1 was not found.'
+          }
+
+          ./scripts/release.ps1 -Version $env:RELEASE_TAG
+
+      - name: Verify release artifacts
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem './dist' -File -Recurse)
+
+          if ($files.Count -eq 0) {
+              throw 'Release produced no files in dist/.'
+          }
+
+          $apk = @($files | Where-Object Extension -eq '.apk')
+          $checksums = @($files | Where-Object Name -like '*.sha256')
+          if ($apk.Count -ne 1 -or $checksums.Count -ne 1) {
+              throw "Expected one APK and one SHA-256 file in dist/; found APK=$($apk.Count), checksum=$($checksums.Count)."
+          }
+
+          Write-Host 'Release artifacts:'
+          $files | ForEach-Object { Write-Host " - $($_.FullName)" }
+
+      - name: Publish GitHub Release
+        shell: pwsh
+        run: |
+          gh release view $env:RELEASE_TAG *> $null
+          if ($LASTEXITCODE -eq 0) {
+              throw "GitHub Release '$env:RELEASE_TAG' already exists."
+          }
+
+          $files = @(
+              Get-ChildItem './dist' -File -Recurse |
+              Select-Object -ExpandProperty FullName
+          )
+
+          $arguments = @('release', 'create', $env:RELEASE_TAG)
+          $arguments += $files
+          $arguments += @('--title', $env:RELEASE_TAG, '--generate-notes')
+
+          if ($env:RELEASE_TAG -match '-(alpha|beta|rc)(\.|$)') {
+              $arguments += '--prerelease'
+          }
+
+          & gh @arguments
+          if ($LASTEXITCODE -ne 0) {
+              throw "Failed to create GitHub Release '$env:RELEASE_TAG'."
+          }

--- a/.github/workflows/trusted-ci.yml
+++ b/.github/workflows/trusted-ci.yml
@@ -1,0 +1,49 @@
+name: Trusted CI
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trusted-ci:
+    name: Trusted Windows CI
+    if: >
+      github.actor == 'Regstar2' &&
+      github.triggering_actor == 'Regstar2' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.user.login == 'Regstar2' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        )
+      )
+    runs-on:
+      - self-hosted
+      - Windows
+      - X64
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout trusted ref
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - name: Run project CI
+        shell: pwsh
+        run: |
+          if (-not (Test-Path './scripts/ci.ps1')) {
+              throw 'Required script scripts/ci.ps1 was not found.'
+          }
+
+          ./scripts/ci.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 local.properties
 app/build/
 artifacts/
+dist/
 external/upstreams/
 app/src/main/jniLibs/**/*.so
 *.jks

--- a/docs/development/github-automation.md
+++ b/docs/development/github-automation.md
@@ -1,0 +1,141 @@
+# GitHub automation
+
+This document describes the public automation contract for TgWsProxy Android. Private project-governance templates are not part of this repository.
+
+## Overview
+
+Project-specific commands live in PowerShell scripts. GitHub Actions only orchestrates those scripts.
+
+| Entry point | Purpose |
+|---|---|
+| `scripts/ci.ps1` | Native Go verification/tests, Android unit tests, debug APK build and packaged-resource audit |
+| `scripts/release.ps1 -Version vX.Y.Z` | Signed release APK build, signature verification, stable artifact naming and SHA-256 generation into `dist/` |
+| `.github/workflows/trusted-ci.yml` | Owner-only CI for trusted same-repository PRs and manual dispatch |
+| `.github/workflows/project-sync.yml` | Add owner-created Issues and same-repository PRs to the Development Project |
+| `.github/workflows/release.yml` | Validate a release tag, rerun CI, build `dist/`, then create a GitHub Release |
+
+## Trusted CI
+
+The persistent self-hosted runner is treated as a trusted owner machine.
+
+The workflow uses the labels:
+
+```text
+self-hosted, Windows, X64
+```
+
+For `pull_request_target`, self-hosted execution is allowed only when all of the following are true:
+
+- actor is `Regstar2`;
+- triggering actor is `Regstar2`;
+- PR author is `Regstar2`;
+- PR head belongs to this same repository.
+
+The workflow definition comes from the trusted base branch. Only after the metadata gate passes does it checkout the exact PR head SHA and execute `scripts/ci.ps1`.
+
+External/fork PR code must not run on the self-hosted runner.
+
+### Local equivalent
+
+From repository root:
+
+```powershell
+.\scripts\ci.ps1
+```
+
+The script fails on an unsuccessful mandatory check. It currently performs:
+
+1. `go mod verify` in `native/tgwsproxy/`;
+2. `go test ./...`;
+3. `testDebugUnitTest` and `assembleDebug` through the Gradle Wrapper;
+4. verification that the debug APK and `libtgwsproxy.so` were produced;
+5. `scripts/audit-apk-icons.ps1` against the built APK.
+
+## Development Project sync
+
+`project-sync.yml` adds owner-created Issues and owner-created same-repository Pull Requests to:
+
+```text
+https://github.com/users/Regstar2/projects/2
+```
+
+Required repository Actions secret:
+
+```text
+ADD_TO_PROJECT_PAT
+```
+
+The token value must exist only in GitHub Actions secrets. It must not be committed, printed in logs, placed in issue text or copied into diagnostics.
+
+The token needs only the permissions required by GitHub for adding repository Issues/PRs to the configured user-level Project.
+
+External issue/PR events are intentionally not sent to the self-hosted runner by this workflow.
+
+## Release automation
+
+`release.yml` runs only for an owner-triggered `v*` tag push or an owner `workflow_dispatch` that references an existing release tag.
+
+Release flow:
+
+```text
+exact tag
+  -> scripts/ci.ps1
+  -> clean dist/
+  -> scripts/release.ps1 -Version <tag>
+  -> verify APK + SHA-256 output
+  -> create GitHub Release
+```
+
+The workflow refuses to silently replace an existing GitHub Release.
+
+Alpha, beta and RC tags are created as GitHub prereleases.
+
+### Signing requirements
+
+A release APK must be signed. `scripts/release.ps1` requires these environment variables:
+
+```text
+KEYSTORE_FILE
+KEYSTORE_PASSWORD
+KEY_PASSWORD
+KEY_ALIAS    # optional; defaults to tgwsproxy
+```
+
+`KEYSTORE_FILE` may point to a keystore outside the repository. Signing material and passwords must not be committed.
+
+For local builds, the existing gitignored `release-signing.env` loader may populate these variables. On a self-hosted Actions runner, configure the runner/service environment or another secure secret-injection mechanism so that the release process receives them without storing the values in the checkout.
+
+The release script also requires Android SDK build-tools with `apksigner.bat`. It verifies the generated APK signature before copying anything into `dist/`.
+
+### Version gate
+
+The release tag without the leading `v` must exactly match `versionName` in `app/build.gradle.kts`. For example:
+
+```text
+v1.10.13 <-> versionName = "1.10.13"
+```
+
+This prevents publishing a tag whose APK reports a different application version.
+
+### Output
+
+For `v1.10.13` the expected output is:
+
+```text
+dist/TgWsProxy-Android-v1.10.13-arm64-v8a.apk
+dist/TgWsProxy-Android-v1.10.13-arm64-v8a.apk.sha256
+```
+
+`dist/` is generated locally and is ignored by Git.
+
+## Safe verification before the first release
+
+Before relying on this automation for a public release:
+
+1. verify the self-hosted runner reports the `self-hosted`, `Windows`, and `X64` labels;
+2. run `scripts/ci.ps1` locally;
+3. open an owner same-repository PR and confirm Trusted CI executes successfully;
+4. confirm an owner Issue/PR is added to Development Project #2;
+5. confirm no Project PAT or signing values appear in logs;
+6. run `scripts/release.ps1` only after release signing is configured and application version metadata matches the intended tag;
+7. test the release workflow with a deliberate release candidate/test tag before the first stable automated publication when practical.

--- a/docs/development/repository-structure.md
+++ b/docs/development/repository-structure.md
@@ -9,16 +9,27 @@
 | `README.md` / `README_EN.md` | Основное публичное описание проекта |
 | `CHANGELOG.md` | История версий |
 | `LICENSE` | GPLv3 |
+| `.github/workflows/` | Trusted CI, Project Sync и release automation |
 | `app/` | Модуль Android-приложения |
 | `native/tgwsproxy/` | Go proxy runtime (сборка `libtgwsproxy.so`) |
 | `docs/` | Публичная документация проекта |
-| `scripts/` | Скрипты сборки и утилиты |
+| `scripts/` | Локальные build/test/release entry point и утилиты |
 | `gradle/`, `gradlew*` | Gradle Wrapper |
 | `icon.png` | Исходник иконок приложения |
 
 В корне **нет** Go-исходников runtime: они находятся в `native/tgwsproxy/`.
 
 Приватные governance-файлы могут существовать локально, но не являются частью публичного репозитория. В частности, `/AGENTS.md` и `/.project-rules/` должны оставаться локальными и исключаются через `.gitignore`.
+
+## `.github/workflows/`
+
+| Workflow | Назначение |
+|---|---|
+| `trusted-ci.yml` | Owner-only проверки trusted same-repository PR на self-hosted Windows/X64 runner и ручной dispatch |
+| `project-sync.yml` | Добавление owner-created Issues/PR в Development Project #2 |
+| `release.yml` | Проверка release tag, повторный CI, сборка `dist/` и публикация GitHub Release |
+
+Подробности и trust model: [github-automation.md](github-automation.md).
 
 ## `app/`
 
@@ -64,7 +75,7 @@ Pop-Location
 |---------|------------|
 | `docs/product/` | Идея проекта, MVP scope, roadmap и другие публичные product docs |
 | `docs/architecture/` | Архитектура, tech stack, режимы, CF pool, Worker, уведомления |
-| `docs/development/` | Публичная структура репозитория и development notes |
+| `docs/development/` | Публичная структура репозитория, automation contract и development notes |
 | `docs/testing/` | Ручные чеклисты и release smoke checks |
 | `docs/releases/` | Release workflow, чеклисты, release notes |
 | `docs/versions/` | Документы по отдельным версиям/итерациям |
@@ -83,13 +94,15 @@ Pop-Location
 
 | Скрипт | Назначение |
 |--------|------------|
+| `ci.ps1` | Единый локальный/CI entry point: Go verify/tests, Android tests, debug APK и APK audit |
+| `release.ps1` | Signed release APK → signature verification → `dist/` + SHA-256 |
 | `build-native-android.ps1` | Go → `libtgwsproxy.so` |
 | `build-apk.ps1` | Gradle APK + копия в `artifacts/` |
+| `install-apk.ps1` | Установка локально собранного APK через ADB |
+| `audit-apk-icons.ps1` | Проверка упакованных icon resources |
 | `generate-icons.py` | Иконки из `icon.png` |
 | `sync-readme-screenshots.ps1` | Копирование скриншотов в `docs/assets/screenshots/` |
 | `cloudflare-worker/worker.js` | Worker script для ручного деплоя |
-
-Automation-specific `ci.ps1`/`release.ps1` относятся к отдельной задаче v1.10.13 и не считаются реализованными, пока соответствующий Issue не завершён.
 
 ## Не для Git
 
@@ -98,7 +111,7 @@ Automation-specific `ci.ps1`/`release.ps1` относятся к отдельн�
 | `AGENTS.md`, `.project-rules/` | Приватные project governance files |
 | `docs/ai-prompts/`, `docs/private/` | Приватные AI/governance материалы |
 | `.codex/`, `.cursor/`, `.claude/`, `.ai/` | Локальное состояние AI/dev tools |
-| `artifacts/` | Локальные APK и `.so` |
+| `artifacts/`, `dist/` | Локальные build/release artifacts |
 | `runtime-logs/`, `*.log` | Локальные логи и captures |
 | `secrets/`, `.env*`, `*.secret`, `*.secrets` | Секреты и локальное окружение |
 | `*.jks`, `*.keystore`, `*.p12`, `*.pfx`, `*.pem`, `*.key` | Signing/private key material |

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location $root
+
+function Invoke-CheckedCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$Arguments = @(),
+
+        [string]$WorkingDirectory = $root
+    )
+
+    Write-Host "`n==> $Label"
+    Push-Location $WorkingDirectory
+    try {
+        & $FilePath @Arguments
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            throw "$Label failed with exit code $exitCode."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+$go = Get-Command go -ErrorAction Stop
+$gradle = Join-Path $root 'gradlew.bat'
+if (-not (Test-Path $gradle)) {
+    throw "Gradle wrapper not found: $gradle"
+}
+
+$nativeDir = Join-Path $root 'native\tgwsproxy'
+if (-not (Test-Path $nativeDir)) {
+    throw "Native runtime directory not found: $nativeDir"
+}
+
+Invoke-CheckedCommand -Label 'Verify Go module' -FilePath $go.Source -Arguments @('mod', 'verify') -WorkingDirectory $nativeDir
+Invoke-CheckedCommand -Label 'Run native Go tests' -FilePath $go.Source -Arguments @('test', './...') -WorkingDirectory $nativeDir
+Invoke-CheckedCommand -Label 'Run Android unit tests and build debug APK' -FilePath $gradle -Arguments @('--no-daemon', 'testDebugUnitTest', 'assembleDebug', '--stacktrace')
+
+$debugApk = Join-Path $root 'app\build\outputs\apk\debug\app-debug.apk'
+if (-not (Test-Path $debugApk)) {
+    throw "Expected debug APK was not produced: $debugApk"
+}
+
+$nativeLib = Join-Path $root 'app\src\main\jniLibs\arm64-v8a\libtgwsproxy.so'
+if (-not (Test-Path $nativeLib)) {
+    throw "Expected native library was not produced: $nativeLib"
+}
+
+$auditScript = Join-Path $PSScriptRoot 'audit-apk-icons.ps1'
+if (-not (Test-Path $auditScript)) {
+    throw "APK audit script not found: $auditScript"
+}
+
+Write-Host "`n==> Audit packaged APK resources"
+& $auditScript -ApkPath $debugApk
+if ($LASTEXITCODE -ne 0) {
+    throw "APK audit failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "`nCI checks completed successfully."
+Write-Host "Debug APK: $debugApk"

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -1,0 +1,116 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Version
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location $root
+
+if ($Version -notmatch '^v\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$') {
+    throw "Invalid release version '$Version'. Expected vX.Y.Z or a SemVer-compatible prerelease tag."
+}
+
+$versionName = $Version.Substring(1)
+$gradleFile = Join-Path $root 'app\build.gradle.kts'
+$gradleText = Get-Content $gradleFile -Raw -Encoding UTF8
+$versionMatch = [regex]::Match($gradleText, 'versionName\s*=\s*"([^"]+)"')
+if (-not $versionMatch.Success) {
+    throw 'Could not read versionName from app/build.gradle.kts.'
+}
+if ($versionMatch.Groups[1].Value -ne $versionName) {
+    throw "Release tag $Version does not match app versionName '$($versionMatch.Groups[1].Value)'."
+}
+
+$signingLoader = Join-Path $PSScriptRoot 'load-release-signing.ps1'
+if (Test-Path $signingLoader) {
+    & $signingLoader | Out-Null
+}
+
+$requiredSigningVariables = @('KEYSTORE_FILE', 'KEYSTORE_PASSWORD', 'KEY_PASSWORD')
+foreach ($name in $requiredSigningVariables) {
+    $value = [Environment]::GetEnvironmentVariable($name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        throw "Required release signing environment variable '$name' is not configured."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($env:KEY_ALIAS)) {
+    $env:KEY_ALIAS = 'tgwsproxy'
+}
+
+$keystorePath = $env:KEYSTORE_FILE
+if (-not [System.IO.Path]::IsPathRooted($keystorePath)) {
+    $keystorePath = Join-Path $root $keystorePath
+}
+if (-not (Test-Path $keystorePath)) {
+    throw "Release keystore was not found: $keystorePath"
+}
+
+$dist = Join-Path $root 'dist'
+if (Test-Path $dist) {
+    Remove-Item $dist -Recurse -Force
+}
+New-Item -ItemType Directory -Path $dist -Force | Out-Null
+
+$buildScript = Join-Path $PSScriptRoot 'build-apk.ps1'
+if (-not (Test-Path $buildScript)) {
+    throw "Release build script not found: $buildScript"
+}
+
+Write-Host "==> Build signed release APK for $Version"
+& $buildScript -Configuration Release
+if ($LASTEXITCODE -ne 0) {
+    throw "Release APK build failed with exit code $LASTEXITCODE."
+}
+
+$sourceApk = Join-Path $root 'artifacts\apk\release\tgwsproxy-release.apk'
+if (-not (Test-Path $sourceApk)) {
+    throw "Expected release APK was not produced: $sourceApk"
+}
+
+$sdkRoot = $env:ANDROID_SDK_ROOT
+if ([string]::IsNullOrWhiteSpace($sdkRoot)) {
+    $sdkRoot = $env:ANDROID_HOME
+}
+if ([string]::IsNullOrWhiteSpace($sdkRoot) -and (Test-Path 'C:\Android\SDK')) {
+    $sdkRoot = 'C:\Android\SDK'
+}
+if ([string]::IsNullOrWhiteSpace($sdkRoot) -or -not (Test-Path $sdkRoot)) {
+    throw 'Android SDK root is not configured; apksigner is required for release verification.'
+}
+
+$buildToolsRoot = Join-Path $sdkRoot 'build-tools'
+$apksigner = Get-ChildItem $buildToolsRoot -Recurse -Filter 'apksigner.bat' -File -ErrorAction SilentlyContinue |
+    Sort-Object FullName -Descending |
+    Select-Object -First 1
+if (-not $apksigner) {
+    throw "apksigner.bat was not found under $buildToolsRoot."
+}
+
+Write-Host '==> Verify APK signature'
+& $apksigner.FullName verify --verbose --print-certs $sourceApk
+if ($LASTEXITCODE -ne 0) {
+    throw "APK signature verification failed with exit code $LASTEXITCODE."
+}
+
+$artifactName = "TgWsProxy-Android-$Version-arm64-v8a.apk"
+$artifactPath = Join-Path $dist $artifactName
+Copy-Item -Force $sourceApk $artifactPath
+
+$hash = (Get-FileHash -Path $artifactPath -Algorithm SHA256).Hash.ToLowerInvariant()
+$checksumPath = "$artifactPath.sha256"
+Set-Content -Path $checksumPath -Value "$hash  $artifactName" -Encoding ascii
+
+$files = @(Get-ChildItem $dist -File)
+if ($files.Count -ne 2) {
+    throw "Expected exactly APK and SHA-256 checksum in dist/, found $($files.Count) files."
+}
+
+Write-Host "Release artifacts prepared:"
+$files | ForEach-Object { Write-Host " - $($_.FullName)" }
+Write-Host "SHA-256: $hash"


### PR DESCRIPTION
## Summary

Implements the automation infrastructure from Issue #4 using the current project standard baseline.

### Added
- `scripts/ci.ps1` as the single project CI entry point
- `scripts/release.ps1 -Version vX.Y.Z` for signed APK packaging into `dist/`
- `.github/workflows/trusted-ci.yml`
- `.github/workflows/project-sync.yml`
- `.github/workflows/release.yml`
- public automation documentation

### Trust/security model
- self-hosted execution is limited to `Regstar2`
- PR CI requires an owner-authored same-repository PR before checkout/execution
- Project PAT is referenced only as `ADD_TO_PROJECT_PAT`
- release signing material is not stored in the repository
- release script verifies APK signature and writes SHA-256 alongside the APK

### Project-specific behavior
- CI runs `go mod verify`, Go tests, Android unit tests, debug APK build and packaged-resource audit
- Project sync handles owner-created Issues and owner-created same-repository PRs
- release workflow checks out the exact tag, reruns CI, builds only through `scripts/release.ps1`, verifies `dist/`, and refuses to overwrite an existing GitHub Release

This PR intentionally does not bump the application version and does not close #4 yet. After this workflow infrastructure is in `main`, a follow-up owner PR will be used to exercise Trusted CI on the actual self-hosted runner and record the result.

Refs #4