### PR TITLE
docs: exercise trusted CI and automation smoke checks

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,10 +1,20 @@
 # Testing
 
-Manual checklist for validating builds and routing. Automated unit tests: `.\gradlew.bat testDebugUnitTest`.
+Manual checklist for validating builds and routing. Automated project checks are available through `.\scripts\ci.ps1`.
 
 The currently published application version is `1.10.12`; `v1.10.13` is the active development target. Do not mark a v1.10.13 check as passed unless it was actually run against the corresponding integrated build.
 
 ## Automated checks
+
+Preferred local/CI entry point:
+
+```powershell
+.\scripts\ci.ps1
+```
+
+The script covers Go module verification, native Go tests, Android unit tests, debug APK assembly, expected APK/native-library outputs and packaged-resource audit.
+
+Individual commands remain useful for diagnosis:
 
 ```powershell
 .\gradlew.bat testDebugUnitTest
@@ -16,6 +26,20 @@ Pop-Location
 ```
 
 If a command cannot run in the current environment, record that limitation instead of treating the check as successful.
+
+## GitHub automation smoke
+
+For changes that affect `.github/workflows/` or `scripts/ci.ps1`:
+
+- [ ] owner-created same-repository PR starts **Trusted CI** on the self-hosted `Windows`/`X64` runner;
+- [ ] Trusted CI checks out the PR head and `.\scripts\ci.ps1` completes successfully;
+- [ ] owner-created Issue/PR is added to Development Project #2 when `ADD_TO_PROJECT_PAT` is configured;
+- [ ] external/fork PR code is not executed on the persistent self-hosted runner;
+- [ ] no Project PAT or signing secret is printed in logs.
+
+Release automation is not considered functionally verified by a debug CI run. Before an automated public release, separately validate release signing, `scripts/release.ps1`, the exact release tag and the generated `dist/` artifacts.
+
+Automation contract: [../development/github-automation.md](../development/github-automation.md).
 
 ## Basic build
 

--- a/docs/versions/v1.10.13.md
+++ b/docs/versions/v1.10.13.md
@@ -14,7 +14,7 @@ This document describes the planned/in-progress scope for `v1.10.13`. It is not 
 |---|---|---|
 | #2 | Proxy runtime stability + relevant Flowseal changes | **Completed** |
 | #3 | Public project structure/documentation alignment | **Completed** |
-| #4 | Trusted CI / Project sync / release automation | Open |
+| #4 | Trusted CI / Project sync / release automation | **Implemented; live acceptance pending** |
 | #5 | In-app feedback + GitHub Issue Forms | Open |
 | #6 | Update delivery through GitHub Releases | Open |
 | #7 | Final release/localization/compliance audit | Final gate |
@@ -55,6 +55,21 @@ Private/local files are intentionally not part of the repository:
 - `docs/ai-prompts/`;
 - `docs/private/`;
 - `.codex/`, `.cursor/`, `.claude/`, `.ai/`.
+
+## Issue #4 — GitHub automation
+
+The automation implementation adds:
+
+- `scripts/ci.ps1` as the single project-specific CI entry point;
+- `scripts/release.ps1 -Version vX.Y.Z` for signed APK packaging, APK signature verification and SHA-256 output in `dist/`;
+- owner-only `trusted-ci.yml` on the persistent self-hosted Windows/X64 runner;
+- `project-sync.yml` for owner-created Issues and same-repository PRs targeting Development Project #2;
+- owner-gated `release.yml` that checks out the exact release tag, reruns CI, builds `dist/` and refuses to overwrite an existing GitHub Release;
+- public automation and smoke-test documentation.
+
+The workflow definitions and project-specific scripts are now integrated. Live acceptance remains intentionally separate: an actual owner event must demonstrate the self-hosted Trusted CI run and Project Sync with the configured `ADD_TO_PROJECT_PAT`. A connector-created validation PR did not expose an observable Actions run, so no successful CI/Project claim is made from that event.
+
+Release publication is also not exercised during Issue #4 because doing so would create a real tagged GitHub Release. Release signing and a safe RC/test-tag run remain part of release acceptance/final gate work.
 
 ## Versioning rule
 


### PR DESCRIPTION
## Purpose

Follow-up verification for Issue #4 after the automation workflows were bootstrapped into `main`.

This PR adds the public automation smoke checklist and is intentionally owner-created from a same-repository branch so that the new `pull_request_target` Trusted CI gate can be exercised on the self-hosted Windows/X64 runner.

Expected automation on PR open:
- Trusted CI runs `scripts/ci.ps1` on the exact PR head.
- Project Sync attempts to add this PR to Development Project #2 using `ADD_TO_PROJECT_PAT`.

Refs #4