### PR TITLE
feat: add safe in-app feedback and GitHub Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a reproducible problem in TgWsProxy Android
+title: "[Bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem.
+
+        **Privacy:** do not include proxy credentials, Telegram content, IP addresses, secrets/tokens, private domains, or unreviewed raw logs. The app does not attach diagnostics automatically.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the problem and what you were trying to do.
+      placeholder: A clear, concise description of the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the smallest sequence that reproduces the problem.
+      placeholder: |
+        1. Open ...
+        2. Enable ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What did you expect to happen?
+    validations:
+      required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: You can copy this from Settings → Feedback → App and device info.
+      placeholder: 1.10.12 (50)
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version
+      placeholder: Android 14 (SDK 34)
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      description: Manufacturer and model only. Do not include serial numbers or device identifiers.
+      placeholder: Manufacturer Model
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network where the problem occurs
+      options:
+        - Wi-Fi
+        - Mobile data
+        - Both
+        - Not network-specific / Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add only information you have reviewed and intentionally want to make public. Do not paste unreviewed logs or credentials.
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      options:
+        - label: I reviewed this report and removed credentials, Telegram content, IP addresses, secrets/tokens, private domains, and other sensitive data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Suggest an improvement for TgWsProxy Android
+title: "[Feature] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem first, then the change you would like to see.
+
+        **Privacy:** do not include proxy credentials, Telegram content, IP addresses, secrets/tokens, private domains, or unreviewed raw logs.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem would this feature solve?
+      placeholder: Explain the user need or limitation.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or workflow you would like.
+      placeholder: A clear description of the requested change.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Describe workarounds or other approaches you considered.
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Optional. You can copy this from Settings → Feedback → App and device info.
+      placeholder: 1.10.12 (50)
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add only information you have reviewed and intentionally want to make public.
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      options:
+        - label: I reviewed this request and removed credentials, Telegram content, IP addresses, secrets/tokens, private domains, and other sensitive data.
+          required: true

--- a/app/src/main/java/com/amurcanov/tgwsproxy/FeedbackUi.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/FeedbackUi.kt
@@ -1,0 +1,141 @@
+package com.amurcanov.tgwsproxy
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+
+private const val BUG_REPORT_URL =
+    "https://github.com/Regstar2/tg-ws-proxy-android/issues/new?template=bug_report.yml"
+private const val FEATURE_REQUEST_URL =
+    "https://github.com/Regstar2/tg-ws-proxy-android/issues/new?template=feature_request.yml"
+
+internal fun safeFeedbackContext(context: Context): String {
+    val packageInfo = runCatching {
+        context.packageManager.getPackageInfo(context.packageName, 0)
+    }.getOrNull()
+    val versionName = packageInfo?.versionName ?: "unknown"
+    val versionCode = if (packageInfo == null) {
+        "unknown"
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        packageInfo.longVersionCode.toString()
+    } else {
+        @Suppress("DEPRECATION")
+        packageInfo.versionCode.toString()
+    }
+    val manufacturer = Build.MANUFACTURER.trim().ifBlank { "unknown" }
+    val model = Build.MODEL.trim().ifBlank { "unknown" }
+
+    return buildString {
+        appendLine("TgWsProxy: $versionName ($versionCode)")
+        appendLine("Android: ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})")
+        append("Device: $manufacturer $model")
+    }
+}
+
+private fun openFeedbackForm(context: Context, url: String) {
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+    } catch (_: Exception) {
+        val clipboard = ContextCompat.getSystemService(context, ClipboardManager::class.java)
+        clipboard?.setPrimaryClip(ClipData.newPlainText("GitHub feedback form", url))
+        Toast.makeText(context, context.getString(R.string.feedback_open_failed), Toast.LENGTH_LONG).show()
+    }
+}
+
+@Composable
+fun FeedbackSettingsCard(
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val safeContext = remember(context) { safeFeedbackContext(context) }
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(bottom = 12.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.feedback_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = stringResource(R.string.feedback_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            FilledTonalButton(
+                onClick = { openFeedbackForm(context, BUG_REPORT_URL) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.feedback_report_bug))
+            }
+            OutlinedButton(
+                onClick = { openFeedbackForm(context, FEATURE_REQUEST_URL) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.feedback_request_feature))
+            }
+            Text(
+                text = stringResource(R.string.feedback_safe_context_title),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = safeContext,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedButton(
+                onClick = {
+                    val clipboard = ContextCompat.getSystemService(context, ClipboardManager::class.java)
+                    clipboard?.setPrimaryClip(ClipData.newPlainText("TgWsProxy app/device info", safeContext))
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.feedback_context_copied),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.feedback_copy_context))
+            }
+            Text(
+                text = stringResource(R.string.feedback_privacy_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/amurcanov/tgwsproxy/SettingsHubUi.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/SettingsHubUi.kt
@@ -239,6 +239,7 @@ fun SettingsHomeScreen(
             onDiagnosticsLogsClick = { onNavigate(SettingsPage.DIAGNOSTICS_LOGS) },
             onAppClick = { onNavigate(SettingsPage.APP) },
         )
+        FeedbackSettingsCard()
         SettingsQuickActionsCard(
             onApplyRecommendedRoutes = onApplyRecommendedRoutes,
             onCheckRoutes = { onNavigate(SettingsPage.DIAGNOSTICS_LOGS) },

--- a/app/src/main/res/values-ru/feedback_strings.xml
+++ b/app/src/main/res/values-ru/feedback_strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feedback_title">Обратная связь</string>
+    <string name="feedback_subtitle">Сообщите о проблеме или предложите улучшение через GitHub.</string>
+    <string name="feedback_report_bug">Сообщить об ошибке</string>
+    <string name="feedback_request_feature">Предложить функцию</string>
+    <string name="feedback_safe_context_title">Информация о приложении и устройстве</string>
+    <string name="feedback_copy_context">Скопировать информацию</string>
+    <string name="feedback_context_copied">Информация о приложении и устройстве скопирована</string>
+    <string name="feedback_open_failed">Не удалось открыть GitHub. Ссылка на форму скопирована.</string>
+    <string name="feedback_privacy_note">Приложение не прикладывает автоматически логи, данные прокси, данные Telegram, IP-адреса, домены, секреты или другую диагностику. Проверьте всё, чем решите поделиться.</string>
+</resources>

--- a/app/src/main/res/values/feedback_strings.xml
+++ b/app/src/main/res/values/feedback_strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="feedback_title">Feedback</string>
+    <string name="feedback_subtitle">Report a problem or suggest an improvement on GitHub.</string>
+    <string name="feedback_report_bug">Report bug</string>
+    <string name="feedback_request_feature">Request feature</string>
+    <string name="feedback_safe_context_title">App and device info</string>
+    <string name="feedback_copy_context">Copy app/device info</string>
+    <string name="feedback_context_copied">App/device info copied</string>
+    <string name="feedback_open_failed">Could not open GitHub. The form link was copied.</string>
+    <string name="feedback_privacy_note">The app does not attach logs, proxy credentials, Telegram data, IP addresses, domains, secrets, or other diagnostics automatically. Review anything you choose to share.</string>
+</resources>

--- a/docs/versions/v1.10.13.md
+++ b/docs/versions/v1.10.13.md
@@ -15,7 +15,7 @@ This document describes the planned/in-progress scope for `v1.10.13`. It is not 
 | #2 | Proxy runtime stability + relevant Flowseal changes | **Completed** |
 | #3 | Public project structure/documentation alignment | **Completed** |
 | #4 | CI / Project sync / release automation | **Completed** |
-| #5 | In-app feedback + GitHub Issue Forms | Open |
+| #5 | In-app feedback + GitHub Issue Forms | **Implemented; manual acceptance pending** |
 | #6 | Update delivery through GitHub Releases | Open |
 | #7 | Final release/localization/compliance audit | Final gate |
 
@@ -75,6 +75,20 @@ The persistent `REGSTAR` self-hosted runner is no longer used for public PR vali
 Project Sync was rechecked from `main` after PR #12 was merged. Reopening Issue #4 triggered run `32839138269`; the GitHub-hosted `Add issue or PR to Development project` job completed successfully using the configured Project secret. This verifies the mainline Project Sync path without using the persistent owner runner.
 
 Release publication is intentionally not exercised during Issue #4 because doing so would create a real tagged GitHub Release. Release signing and a safe RC/test-tag run remain release-gate work; the release workflow itself is owner-gated and requires release-source CI plus validated `dist/` artifacts before publication.
+
+## Issue #5 — in-app feedback
+
+The feedback implementation adds a dedicated card to the Settings home screen with separate **Report bug** and **Request feature** actions. Both actions open this repository's GitHub Issue Forms in the browser; the Android application contains no GitHub PAT or other write credential.
+
+Feedback privacy is deliberately opt-in:
+
+- no runtime logs, proxy credentials, Telegram data, IP addresses, domains, route configuration, secrets or diagnostics are attached automatically;
+- the only helper context exposed by the feedback card is app version/version code, Android release/SDK, and manufacturer/model;
+- that helper context is copied only after an explicit user action, so the user can review it before pasting it into GitHub;
+- the bug and feature Issue Forms contain an explicit public-data warning and required privacy acknowledgement;
+- all new in-app strings are provided in both default English resources and Russian resources.
+
+The code and Issue Forms still require manual acceptance on an installed Android build: verify both links open the intended forms, RU/EN UI is correct, copied context contains only the documented fields, and the feedback flow does not stop or reconfigure the proxy.
 
 ## Versioning rule
 


### PR DESCRIPTION
## Summary

Implements the v1.10.13 feedback path for Issue #5 without embedding any GitHub write credential in the Android app.

### In-app feedback
- adds a Feedback card to Settings home
- separate **Report bug** and **Request feature** actions open this repository's GitHub Issue Forms in the browser
- no PAT/token or GitHub API write path is included in the app
- no logs, proxy credentials, Telegram data, IP addresses, domains, route configuration, secrets, or diagnostics are attached automatically
- optional **Copy app/device info** exposes only app version/versionCode, Android release/SDK, and manufacturer/model after explicit user action
- browser-open failure copies only the public form URL

### GitHub Issue Forms
- adds `.github/ISSUE_TEMPLATE/bug_report.yml`
- adds `.github/ISSUE_TEMPLATE/feature_request.yml`
- forms contain privacy guidance and a required privacy acknowledgement
- bug form requests reproducible steps and safe environment fields

### Localization
- all new in-app feedback strings are present in English and Russian resources

### Validation
- normal GitHub-hosted PR CI should build/test the integrated Android change
- manual Android acceptance remains required for browser links, clipboard contents, RU/EN rendering, and confirming the feedback flow does not affect the running proxy

Refs #5