### PR TITLE
fix: make APK icon audit robust on Cyrillic Windows profiles

### DIFF
--- a/scripts/audit-apk-icons.ps1
+++ b/scripts/audit-apk-icons.ps1
@@ -19,11 +19,18 @@ if ($aapt) {
     Write-Warning "aapt not found; skip badging"
 }
 
-$checkDir = Join-Path $env:TEMP "tgwsproxy_apk_check"
-if (Test-Path $checkDir) { Remove-Item $checkDir -Recurse -Force }
-New-Item -ItemType Directory -Path $checkDir | Out-Null
-Copy-Item $ApkPath (Join-Path $checkDir "app.zip")
-Expand-Archive (Join-Path $checkDir "app.zip") (Join-Path $checkDir "unzipped") -Force
+# Keep temporary extraction under the repository build tree instead of $env:TEMP.
+# Some Windows profiles with non-ASCII user names expose an invalid 8.3 TEMP path
+# (for example C:\Users\XXXX~1), which breaks Remove-Item in Windows PowerShell 5.1.
+$checkDir = [System.IO.Path]::GetFullPath(
+    (Join-Path $PSScriptRoot "..\app\build\tmp\tgwsproxy_apk_check")
+)
+if (Test-Path -LiteralPath $checkDir) {
+    Remove-Item -LiteralPath $checkDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $checkDir -Force | Out-Null
+Copy-Item -LiteralPath $ApkPath -Destination (Join-Path $checkDir "app.zip")
+Expand-Archive -LiteralPath (Join-Path $checkDir "app.zip") -DestinationPath (Join-Path $checkDir "unzipped") -Force
 
 Write-Host "`n=== Icon-like files in APK ===" -ForegroundColor Cyan
 $patterns = @(


### PR DESCRIPTION
Fixes the local Windows CI failure reproduced on a profile with a non-ASCII username, where `$env:TEMP` resolved through an unusable 8.3 path and `Remove-Item` failed before the APK icon audit.

Changes:
- keep the temporary APK extraction directory under `app/build/tmp` instead of the user TEMP directory;
- use `-LiteralPath` for cleanup/copy operations;
- no Android runtime, proxy behavior, version metadata, or release behavior changes.

This unblocks the local `scripts/ci.ps1` acceptance path for Issue #5.