### PR TITLE
fix: make debug APK installable over current test build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,9 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+val releaseVersionCode = 50
+val releaseVersionName = "1.10.12"
+
 val buildNativeAndroid by tasks.registering(org.gradle.api.tasks.Exec::class) {
     val script = rootProject.file("scripts/build-native-android.ps1")
     val nativeDir = rootProject.file("native/tgwsproxy")
@@ -46,8 +49,8 @@ android {
         applicationId = "com.amurcanov.tgwsproxy"
         minSdk = 26
         targetSdk = 35
-        versionCode = 50
-        versionName = "1.10.12"
+        versionCode = releaseVersionCode
+        versionName = releaseVersionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -76,6 +79,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            versionNameSuffix = "-debug"
+        }
         release {
             signingConfig = signingConfigs.findByName("release")
             isMinifyEnabled = true
@@ -110,6 +116,14 @@ android {
     sourceSets {
         getByName("main") {
             jniLibs.srcDir("src/main/jniLibs")
+        }
+    }
+}
+
+androidComponents {
+    onVariants(selector().withBuildType("debug")) { variant ->
+        variant.outputs.forEach { output ->
+            output.versionCode.set(releaseVersionCode + 1)
         }
     }
 }


### PR DESCRIPTION
The current repository release metadata intentionally remains 1.10.12 / versionCode 50 until the v1.10.13 release gate, but the test device already has a 1.10.13 / versionCode 51 build installed. Android therefore rejects the newly built debug APK as a downgrade, even with `adb install -r -d`.

This change keeps release metadata unchanged while making debug builds use `releaseVersionCode + 1` and adds a `-debug` versionName suffix. For the current baseline that produces debug `versionCode 51`, allowing replacement of the existing test build without uninstalling the app or losing data.

No proxy runtime behavior changes.