### PR TITLE
feat: move feedback into a dedicated settings screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,11 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name="com.amurcanov.tgwsproxy.FeedbackActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme.NoTitleBar" />
+
         <service
             android:name="com.amurcanov.tgwsproxy.ProxyService"
             android:exported="false"

--- a/app/src/main/java/com/amurcanov/tgwsproxy/FeedbackActivity.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/FeedbackActivity.kt
@@ -1,0 +1,95 @@
+package com.amurcanov.tgwsproxy
+
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
+class FeedbackActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            FeedbackActivityContent(onBack = { finish() })
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun FeedbackActivityContent(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences("ProxyPrefs", Context.MODE_PRIVATE) }
+    val themeMode = prefs.getString("theme_mode", "System") ?: "System"
+    val systemDark = isSystemInDarkTheme()
+    val useDarkTheme = when (themeMode) {
+        "Light" -> false
+        "Dark" -> true
+        else -> systemDark
+    }
+    val colorScheme = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && useDarkTheme -> dynamicDarkColorScheme(context)
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> dynamicLightColorScheme(context)
+        useDarkTheme -> darkColorScheme()
+        else -> lightColorScheme()
+    }
+
+    MaterialTheme(colorScheme = colorScheme) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background,
+        ) {
+            Scaffold(
+                topBar = {
+                    TopAppBar(
+                        title = { Text(stringResource(R.string.feedback_title)) },
+                        navigationIcon = {
+                            IconButton(onClick = onBack) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                    contentDescription = stringResource(R.string.feedback_back),
+                                )
+                            }
+                        },
+                    )
+                },
+            ) { innerPadding ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                ) {
+                    FeedbackSettingsCard()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/amurcanov/tgwsproxy/SettingsHubUi.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/SettingsHubUi.kt
@@ -1,5 +1,6 @@
 package com.amurcanov.tgwsproxy
 
+import android.content.Intent
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -90,6 +92,7 @@ fun SettingsNavigationCard(
     onRoutesClick: () -> Unit,
     onCloudflareClick: () -> Unit,
     onDiagnosticsLogsClick: () -> Unit,
+    onFeedbackClick: () -> Unit,
     onAppClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -128,6 +131,11 @@ fun SettingsNavigationCard(
                 title = stringResource(R.string.settings_section_diagnostics_logs_title),
                 subtitle = stringResource(R.string.settings_section_diagnostics_logs_subtitle),
                 onClick = onDiagnosticsLogsClick,
+            )
+            SettingsNavigationRow(
+                title = stringResource(R.string.feedback_title),
+                subtitle = stringResource(R.string.feedback_subtitle),
+                onClick = onFeedbackClick,
             )
             SettingsNavigationRow(
                 title = stringResource(R.string.settings_section_app_title),
@@ -226,6 +234,8 @@ fun SettingsHomeScreen(
     onApplyRecommendedRoutes: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+
     Column(modifier = modifier.fillMaxWidth()) {
         SettingsSummaryCard(
             networkLabel = networkLabel,
@@ -237,9 +247,11 @@ fun SettingsHomeScreen(
             onRoutesClick = { onNavigate(SettingsPage.ROUTES) },
             onCloudflareClick = { onNavigate(SettingsPage.CLOUDFLARE) },
             onDiagnosticsLogsClick = { onNavigate(SettingsPage.DIAGNOSTICS_LOGS) },
+            onFeedbackClick = {
+                context.startActivity(Intent(context, FeedbackActivity::class.java))
+            },
             onAppClick = { onNavigate(SettingsPage.APP) },
         )
-        FeedbackSettingsCard()
         SettingsQuickActionsCard(
             onApplyRecommendedRoutes = onApplyRecommendedRoutes,
             onCheckRoutes = { onNavigate(SettingsPage.DIAGNOSTICS_LOGS) },

--- a/app/src/main/res/values-ru/feedback_strings.xml
+++ b/app/src/main/res/values-ru/feedback_strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="feedback_title">Обратная связь</string>
     <string name="feedback_subtitle">Сообщите о проблеме или предложите улучшение через GitHub.</string>
+    <string name="feedback_back">Назад к настройкам</string>
     <string name="feedback_report_bug">Сообщить об ошибке</string>
     <string name="feedback_request_feature">Предложить функцию</string>
     <string name="feedback_safe_context_title">Информация о приложении и устройстве</string>

--- a/app/src/main/res/values/feedback_strings.xml
+++ b/app/src/main/res/values/feedback_strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="feedback_title">Feedback</string>
     <string name="feedback_subtitle">Report a problem or suggest an improvement on GitHub.</string>
+    <string name="feedback_back">Back to settings</string>
     <string name="feedback_report_bug">Report bug</string>
     <string name="feedback_request_feature">Request feature</string>
     <string name="feedback_safe_context_title">App and device info</string>


### PR DESCRIPTION
Refines the Issue #5 UX after manual review.

Changes:
- removes the large Feedback card from Settings home;
- adds **Feedback / Обратная связь** to the Settings sections list;
- opens feedback in a dedicated non-exported `FeedbackActivity` with explicit back navigation;
- preserves the existing safe bug/feature links, optional app/device context copy, and privacy guidance;
- follows the saved light/dark theme choice and RU/EN resources;
- does not touch proxy runtime state or service behavior.

The dedicated Activity is intentionally `exported=false`; it is reachable only from inside the app.

Refs #5