### PR TITLE
docs: mark Issue #5 feedback acceptance complete

### DIFF
--- a/docs/versions/v1.10.13.md
+++ b/docs/versions/v1.10.13.md
@@ -15,7 +15,7 @@ This document describes the planned/in-progress scope for `v1.10.13`. It is not 
 | #2 | Proxy runtime stability + relevant Flowseal changes | **Completed** |
 | #3 | Public project structure/documentation alignment | **Completed** |
 | #4 | CI / Project sync / release automation | **Completed** |
-| #5 | In-app feedback + GitHub Issue Forms | **Implemented; manual acceptance pending** |
+| #5 | In-app feedback + GitHub Issue Forms | **Completed** |
 | #6 | Update delivery through GitHub Releases | Open |
 | #7 | Final release/localization/compliance audit | Final gate |
 
@@ -78,17 +78,17 @@ Release publication is intentionally not exercised during Issue #4 because doing
 
 ## Issue #5 — in-app feedback
 
-The feedback implementation adds a dedicated card to the Settings home screen with separate **Report bug** and **Request feature** actions. Both actions open this repository's GitHub Issue Forms in the browser; the Android application contains no GitHub PAT or other write credential.
+The feedback implementation adds **Feedback / Обратная связь** to the Settings sections list. It opens a dedicated, non-exported in-app screen with separate **Report bug** and **Request feature** actions, explicit back navigation, and optional copying of safe app/device context. Both actions open this repository's GitHub Issue Forms in the browser; the Android application contains no GitHub PAT or other write credential.
 
 Feedback privacy is deliberately opt-in:
 
 - no runtime logs, proxy credentials, Telegram data, IP addresses, domains, route configuration, secrets or diagnostics are attached automatically;
-- the only helper context exposed by the feedback card is app version/version code, Android release/SDK, and manufacturer/model;
+- the only helper context exposed by the feedback screen is app version/version code, Android release/SDK, and manufacturer/model;
 - that helper context is copied only after an explicit user action, so the user can review it before pasting it into GitHub;
 - the bug and feature Issue Forms contain an explicit public-data warning and required privacy acknowledgement;
 - all new in-app strings are provided in both default English resources and Russian resources.
 
-The code and Issue Forms still require manual acceptance on an installed Android build: verify both links open the intended forms, RU/EN UI is correct, copied context contains only the documented fields, and the feedback flow does not stop or reconfigure the proxy.
+The dedicated-screen refinement passed the GitHub-hosted project CI on PR #16. The project owner then manually reviewed the installed feedback UX and accepted it as suitable. Issue #5 is therefore complete; further feedback UX changes should be tracked separately.
 
 ## Versioning rule
 


### PR DESCRIPTION
Records the project owner's manual acceptance of the dedicated Feedback screen added for Issue #5 and updates `docs/versions/v1.10.13.md` to mark the task completed.

Refs #5