### PR TITLE
feat: add update delivery via GitHub Releases

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,11 @@
             android:exported="false"
             android:theme="@android:style/Theme.NoTitleBar" />
 
+        <activity
+            android:name="com.amurcanov.tgwsproxy.UpdateActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme.NoTitleBar" />
+
         <service
             android:name="com.amurcanov.tgwsproxy.ProxyService"
             android:exported="false"

--- a/app/src/main/java/com/amurcanov/tgwsproxy/AppUpdateDelivery.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/AppUpdateDelivery.kt
@@ -1,0 +1,243 @@
+package com.amurcanov.tgwsproxy
+
+import org.json.JSONArray
+import org.json.JSONException
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
+import java.net.URL
+import java.net.UnknownHostException
+
+private const val UPDATE_API_URL =
+    "https://api.github.com/repos/Regstar2/tg-ws-proxy-android/releases?per_page=20"
+private const val RELEASE_PAGE_PREFIX =
+    "https://github.com/Regstar2/tg-ws-proxy-android/releases/tag/"
+private const val MAX_RELEASE_RESPONSE_BYTES = 1024 * 1024
+private const val MAX_RELEASE_NOTES_CHARS = 6000
+
+data class SemanticVersion(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+    val prerelease: List<String> = emptyList(),
+    val buildMetadata: List<String> = emptyList(),
+) : Comparable<SemanticVersion> {
+    val isPrerelease: Boolean
+        get() = prerelease.isNotEmpty()
+
+    override fun compareTo(other: SemanticVersion): Int {
+        compareValues(major, other.major).takeIf { it != 0 }?.let { return it }
+        compareValues(minor, other.minor).takeIf { it != 0 }?.let { return it }
+        compareValues(patch, other.patch).takeIf { it != 0 }?.let { return it }
+
+        if (prerelease.isEmpty() && other.prerelease.isEmpty()) return 0
+        if (prerelease.isEmpty()) return 1
+        if (other.prerelease.isEmpty()) return -1
+
+        val shared = minOf(prerelease.size, other.prerelease.size)
+        for (index in 0 until shared) {
+            val left = prerelease[index]
+            val right = other.prerelease[index]
+            if (left == right) continue
+
+            val leftNumber = left.toLongOrNull()
+            val rightNumber = right.toLongOrNull()
+            return when {
+                leftNumber != null && rightNumber != null -> leftNumber.compareTo(rightNumber)
+                leftNumber != null -> -1
+                rightNumber != null -> 1
+                else -> left.compareTo(right)
+            }
+        }
+        return prerelease.size.compareTo(other.prerelease.size)
+    }
+
+    companion object {
+        private val pattern = Regex(
+            "^[vV]?(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)" +
+                "(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?" +
+                "(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$",
+        )
+
+        fun parse(raw: String?): SemanticVersion? {
+            val value = raw?.trim().orEmpty()
+            val match = pattern.matchEntire(value) ?: return null
+            val prerelease = match.groupValues[4]
+                .takeIf { it.isNotEmpty() }
+                ?.split('.')
+                .orEmpty()
+            if (prerelease.any { identifier ->
+                    identifier.all(Char::isDigit) && identifier.length > 1 && identifier.startsWith('0')
+                }) {
+                return null
+            }
+            return SemanticVersion(
+                major = match.groupValues[1].toIntOrNull() ?: return null,
+                minor = match.groupValues[2].toIntOrNull() ?: return null,
+                patch = match.groupValues[3].toIntOrNull() ?: return null,
+                prerelease = prerelease,
+                buildMetadata = match.groupValues[5]
+                    .takeIf { it.isNotEmpty() }
+                    ?.split('.')
+                    .orEmpty(),
+            )
+        }
+    }
+}
+
+data class GitHubReleaseInfo(
+    val tagName: String,
+    val title: String,
+    val notes: String,
+    val draft: Boolean,
+    val prerelease: Boolean,
+)
+
+sealed interface UpdateDecision {
+    data class Available(
+        val release: GitHubReleaseInfo,
+        val version: SemanticVersion,
+    ) : UpdateDecision
+
+    data object UpToDate : UpdateDecision
+    data object UnsupportedCurrentVersion : UpdateDecision
+}
+
+object AppUpdateSelector {
+    fun select(currentVersionName: String, releases: List<GitHubReleaseInfo>): UpdateDecision {
+        val current = SemanticVersion.parse(currentVersionName)
+            ?: return UpdateDecision.UnsupportedCurrentVersion
+        val allowPrerelease = current.isPrerelease
+
+        val candidate = releases.asSequence()
+            .filterNot { it.draft }
+            .mapNotNull { release ->
+                val version = SemanticVersion.parse(release.tagName) ?: return@mapNotNull null
+                if (!allowPrerelease && (release.prerelease || version.isPrerelease)) {
+                    return@mapNotNull null
+                }
+                if (version <= current) return@mapNotNull null
+                release to version
+            }
+            .maxWithOrNull(compareBy<Pair<GitHubReleaseInfo, SemanticVersion>> { it.second })
+            ?: return UpdateDecision.UpToDate
+
+        return UpdateDecision.Available(candidate.first, candidate.second)
+    }
+
+    fun officialReleaseUrl(tagName: String): String? {
+        val version = SemanticVersion.parse(tagName) ?: return null
+        val canonicalTag = buildString {
+            append('v')
+            append(version.major)
+            append('.')
+            append(version.minor)
+            append('.')
+            append(version.patch)
+            if (version.prerelease.isNotEmpty()) {
+                append('-')
+                append(version.prerelease.joinToString("."))
+            }
+            if (version.buildMetadata.isNotEmpty()) {
+                append('+')
+                append(version.buildMetadata.joinToString("."))
+            }
+        }
+        return RELEASE_PAGE_PREFIX + canonicalTag
+    }
+}
+
+enum class UpdateFailureKind {
+    NETWORK,
+    TIMEOUT,
+    API,
+    MALFORMED,
+}
+
+class UpdateCheckException(
+    val kind: UpdateFailureKind,
+    message: String,
+    cause: Throwable? = null,
+) : IOException(message, cause)
+
+class GitHubReleasesClient(
+    private val endpoint: String = UPDATE_API_URL,
+) {
+    fun fetchReleases(): List<GitHubReleaseInfo> {
+        val connection = try {
+            URL(endpoint).openConnection() as HttpURLConnection
+        } catch (error: IOException) {
+            throw UpdateCheckException(UpdateFailureKind.NETWORK, "Unable to open releases endpoint", error)
+        }
+
+        return try {
+            connection.requestMethod = "GET"
+            connection.connectTimeout = 5_000
+            connection.readTimeout = 7_000
+            connection.instanceFollowRedirects = false
+            connection.setRequestProperty("Accept", "application/vnd.github+json")
+            connection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28")
+            connection.setRequestProperty("User-Agent", "tg-ws-proxy-android-update-check")
+
+            val code = connection.responseCode
+            if (code != HttpURLConnection.HTTP_OK) {
+                throw UpdateCheckException(UpdateFailureKind.API, "GitHub Releases returned HTTP $code")
+            }
+
+            val body = connection.inputStream.use(::readBoundedUtf8)
+            parseReleaseList(body)
+        } catch (error: SocketTimeoutException) {
+            throw UpdateCheckException(UpdateFailureKind.TIMEOUT, "GitHub Releases request timed out", error)
+        } catch (error: UnknownHostException) {
+            throw UpdateCheckException(UpdateFailureKind.NETWORK, "GitHub Releases host is unavailable", error)
+        } catch (error: UpdateCheckException) {
+            throw error
+        } catch (error: JSONException) {
+            throw UpdateCheckException(UpdateFailureKind.MALFORMED, "Malformed GitHub Releases metadata", error)
+        } catch (error: IOException) {
+            throw UpdateCheckException(UpdateFailureKind.NETWORK, "Unable to read GitHub Releases metadata", error)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun parseReleaseList(rawJson: String): List<GitHubReleaseInfo> {
+        val array = JSONArray(rawJson)
+        return buildList {
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                val tagName = item.optString("tag_name").trim()
+                if (tagName.isEmpty()) continue
+                add(
+                    GitHubReleaseInfo(
+                        tagName = tagName,
+                        title = item.optString("name").trim().ifBlank { tagName },
+                        notes = item.optString("body").trim().take(MAX_RELEASE_NOTES_CHARS),
+                        draft = item.optBoolean("draft", false),
+                        prerelease = item.optBoolean("prerelease", false),
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun readBoundedUtf8(input: java.io.InputStream): String {
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(8 * 1024)
+        var total = 0
+        while (true) {
+            val count = input.read(buffer)
+            if (count < 0) break
+            total += count
+            if (total > MAX_RELEASE_RESPONSE_BYTES) {
+                throw UpdateCheckException(
+                    UpdateFailureKind.MALFORMED,
+                    "GitHub Releases response exceeds size limit",
+                )
+            }
+            output.write(buffer, 0, count)
+        }
+        return output.toString(Charsets.UTF_8.name())
+    }
+}

--- a/app/src/main/java/com/amurcanov/tgwsproxy/AppUpdateDelivery.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/AppUpdateDelivery.kt
@@ -127,24 +127,9 @@ object AppUpdateSelector {
     }
 
     fun officialReleaseUrl(tagName: String): String? {
-        val version = SemanticVersion.parse(tagName) ?: return null
-        val canonicalTag = buildString {
-            append('v')
-            append(version.major)
-            append('.')
-            append(version.minor)
-            append('.')
-            append(version.patch)
-            if (version.prerelease.isNotEmpty()) {
-                append('-')
-                append(version.prerelease.joinToString("."))
-            }
-            if (version.buildMetadata.isNotEmpty()) {
-                append('+')
-                append(version.buildMetadata.joinToString("."))
-            }
-        }
-        return RELEASE_PAGE_PREFIX + canonicalTag
+        val validatedTag = tagName.trim()
+        SemanticVersion.parse(validatedTag) ?: return null
+        return RELEASE_PAGE_PREFIX + validatedTag
     }
 }
 

--- a/app/src/main/java/com/amurcanov/tgwsproxy/SettingsHubUi.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/SettingsHubUi.kt
@@ -92,6 +92,7 @@ fun SettingsNavigationCard(
     onRoutesClick: () -> Unit,
     onCloudflareClick: () -> Unit,
     onDiagnosticsLogsClick: () -> Unit,
+    onUpdatesClick: () -> Unit,
     onFeedbackClick: () -> Unit,
     onAppClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -131,6 +132,11 @@ fun SettingsNavigationCard(
                 title = stringResource(R.string.settings_section_diagnostics_logs_title),
                 subtitle = stringResource(R.string.settings_section_diagnostics_logs_subtitle),
                 onClick = onDiagnosticsLogsClick,
+            )
+            SettingsNavigationRow(
+                title = stringResource(R.string.update_title),
+                subtitle = stringResource(R.string.update_subtitle),
+                onClick = onUpdatesClick,
             )
             SettingsNavigationRow(
                 title = stringResource(R.string.feedback_title),
@@ -247,6 +253,9 @@ fun SettingsHomeScreen(
             onRoutesClick = { onNavigate(SettingsPage.ROUTES) },
             onCloudflareClick = { onNavigate(SettingsPage.CLOUDFLARE) },
             onDiagnosticsLogsClick = { onNavigate(SettingsPage.DIAGNOSTICS_LOGS) },
+            onUpdatesClick = {
+                context.startActivity(Intent(context, UpdateActivity::class.java))
+            },
             onFeedbackClick = {
                 context.startActivity(Intent(context, FeedbackActivity::class.java))
             },

--- a/app/src/main/java/com/amurcanov/tgwsproxy/UpdateActivity.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/UpdateActivity.kt
@@ -1,0 +1,349 @@
+package com.amurcanov.tgwsproxy
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private data class InstalledAppVersion(
+    val name: String,
+    val code: Long,
+)
+
+private sealed interface UpdateScreenState {
+    data object Idle : UpdateScreenState
+    data object Checking : UpdateScreenState
+    data object UpToDate : UpdateScreenState
+    data object UnsupportedVersion : UpdateScreenState
+    data class Available(val release: GitHubReleaseInfo) : UpdateScreenState
+    data class Failed(val kind: UpdateFailureKind) : UpdateScreenState
+}
+
+class UpdateActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            UpdateActivityContent(onBack = { finish() })
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun UpdateActivityContent(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences("ProxyPrefs", Context.MODE_PRIVATE) }
+    val themeMode = prefs.getString("theme_mode", "System") ?: "System"
+    val systemDark = isSystemInDarkTheme()
+    val useDarkTheme = when (themeMode) {
+        "Light" -> false
+        "Dark" -> true
+        else -> systemDark
+    }
+    val colorScheme = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && useDarkTheme -> dynamicDarkColorScheme(context)
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> dynamicLightColorScheme(context)
+        useDarkTheme -> darkColorScheme()
+        else -> lightColorScheme()
+    }
+
+    MaterialTheme(colorScheme = colorScheme) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background,
+        ) {
+            Scaffold(
+                topBar = {
+                    TopAppBar(
+                        title = { Text(stringResource(R.string.update_title)) },
+                        navigationIcon = {
+                            IconButton(onClick = onBack) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                    contentDescription = stringResource(R.string.update_back),
+                                )
+                            }
+                        },
+                    )
+                },
+            ) { innerPadding ->
+                UpdateScreen(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun UpdateScreen(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val appContext = context.applicationContext
+    val scope = rememberCoroutineScope()
+    val client = remember { GitHubReleasesClient() }
+    val installed = remember { readInstalledVersion(appContext) }
+    var state by remember { mutableStateOf<UpdateScreenState>(UpdateScreenState.Idle) }
+
+    suspend fun checkForUpdates() {
+        if (state == UpdateScreenState.Checking) return
+        state = UpdateScreenState.Checking
+        state = try {
+            val decision = withContext(Dispatchers.IO) {
+                AppUpdateSelector.select(installed.name, client.fetchReleases())
+            }
+            when (decision) {
+                is UpdateDecision.Available -> UpdateScreenState.Available(decision.release)
+                UpdateDecision.UpToDate -> UpdateScreenState.UpToDate
+                UpdateDecision.UnsupportedCurrentVersion -> UpdateScreenState.UnsupportedVersion
+            }
+        } catch (error: UpdateCheckException) {
+            UpdateScreenState.Failed(error.kind)
+        } catch (_: Exception) {
+            UpdateScreenState.Failed(UpdateFailureKind.NETWORK)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        // Automatic check happens only after this screen is opened and never blocks app/proxy startup.
+        checkForUpdates()
+    }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
+            ),
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = stringResource(R.string.update_current_version_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = stringResource(
+                        R.string.update_current_version_value,
+                        installed.name,
+                        installed.code,
+                    ),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(top = 6.dp),
+                )
+                Text(
+                    text = stringResource(R.string.update_source_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+        }
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
+            ),
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                when (val current = state) {
+                    UpdateScreenState.Idle -> {
+                        Text(stringResource(R.string.update_status_idle))
+                    }
+                    UpdateScreenState.Checking -> {
+                        Text(
+                            text = stringResource(R.string.update_status_checking),
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
+                    UpdateScreenState.UpToDate -> {
+                        Text(
+                            text = stringResource(R.string.update_status_up_to_date),
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
+                    UpdateScreenState.UnsupportedVersion -> {
+                        Text(
+                            text = stringResource(R.string.update_status_unsupported_version),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                    is UpdateScreenState.Failed -> {
+                        Text(
+                            text = stringResource(current.kind.messageResource()),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                        Text(
+                            text = stringResource(R.string.update_failure_safe_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 6.dp),
+                        )
+                    }
+                    is UpdateScreenState.Available -> {
+                        val release = current.release
+                        Text(
+                            text = stringResource(R.string.update_available_title, release.tagName),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        if (release.prerelease) {
+                            Text(
+                                text = stringResource(R.string.update_prerelease_label),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
+                        Text(
+                            text = release.title,
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(top = 8.dp),
+                        )
+                        Text(
+                            text = stringResource(R.string.update_release_notes_title),
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.padding(top = 12.dp),
+                        )
+                        Text(
+                            text = release.notes.ifBlank {
+                                stringResource(R.string.update_release_notes_empty)
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Button(
+                            onClick = {
+                                val url = AppUpdateSelector.officialReleaseUrl(release.tagName)
+                                if (url == null) {
+                                    Toast.makeText(
+                                        context,
+                                        context.getString(R.string.update_open_failed),
+                                        Toast.LENGTH_SHORT,
+                                    ).show()
+                                } else {
+                                    runCatching {
+                                        context.startActivity(
+                                            Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url)),
+                                        )
+                                    }.onFailure {
+                                        Toast.makeText(
+                                            context,
+                                            context.getString(R.string.update_open_failed),
+                                            Toast.LENGTH_SHORT,
+                                        ).show()
+                                    }
+                                }
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(stringResource(R.string.update_open_release))
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                FilledTonalButton(
+                    onClick = { scope.launch { checkForUpdates() } },
+                    enabled = state != UpdateScreenState.Checking,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        if (state == UpdateScreenState.Checking) {
+                            stringResource(R.string.update_status_checking)
+                        } else {
+                            stringResource(R.string.update_check_now)
+                        },
+                    )
+                }
+            }
+        }
+
+        Text(
+            text = stringResource(R.string.update_security_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun readInstalledVersion(context: Context): InstalledAppVersion {
+    return runCatching {
+        val info = context.packageManager.getPackageInfo(context.packageName, 0)
+        InstalledAppVersion(
+            name = info.versionName ?: "unknown",
+            code = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                info.longVersionCode
+            } else {
+                @Suppress("DEPRECATION")
+                info.versionCode.toLong()
+            },
+        )
+    }.getOrDefault(InstalledAppVersion("unknown", 0L))
+}
+
+private fun UpdateFailureKind.messageResource(): Int = when (this) {
+    UpdateFailureKind.NETWORK -> R.string.update_error_network
+    UpdateFailureKind.TIMEOUT -> R.string.update_error_timeout
+    UpdateFailureKind.API -> R.string.update_error_api
+    UpdateFailureKind.MALFORMED -> R.string.update_error_malformed
+}

--- a/app/src/main/res/values-ru/update_strings.xml
+++ b/app/src/main/res/values-ru/update_strings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="update_title">Обновления</string>
+    <string name="update_subtitle">Проверка новых версий через официальные GitHub Releases.</string>
+    <string name="update_back">Назад</string>
+    <string name="update_current_version_title">Установленная версия</string>
+    <string name="update_current_version_value">%1$s (код %2$d)</string>
+    <string name="update_source_hint">Метаданные обновлений читаются только из официальных GitHub Releases репозитория Regstar2/tg-ws-proxy-android.</string>
+    <string name="update_status_idle">Проверка обновлений ещё не выполнялась.</string>
+    <string name="update_status_checking">Проверка обновлений…</string>
+    <string name="update_status_up_to_date">Установлена самая новая подходящая версия.</string>
+    <string name="update_status_unsupported_version">Установленная версия не соответствует SemVer, поэтому безопасно сравнить её нельзя.</string>
+    <string name="update_available_title">Доступно обновление: %1$s</string>
+    <string name="update_prerelease_label">Предварительная версия</string>
+    <string name="update_release_notes_title">Описание релиза</string>
+    <string name="update_release_notes_empty">Описание релиза отсутствует.</string>
+    <string name="update_open_release">Открыть официальный релиз</string>
+    <string name="update_check_now">Проверить обновления</string>
+    <string name="update_open_failed">Не удалось открыть официальный GitHub Release.</string>
+    <string name="update_error_network">Не удалось подключиться к GitHub Releases. Проверьте сеть и повторите попытку.</string>
+    <string name="update_error_timeout">Истекло время ожидания GitHub Releases. Повторите попытку позже.</string>
+    <string name="update_error_api">GitHub Releases вернул ошибку API. Повторите попытку позже.</string>
+    <string name="update_error_malformed">GitHub Releases вернул метаданные, которые нельзя безопасно обработать.</string>
+    <string name="update_failure_safe_hint">Ошибка проверки обновлений не останавливает и не перенастраивает прокси.</string>
+    <string name="update_security_note">TgWsProxy не скачивает и не устанавливает APK скрытно. Кнопка обновления только открывает страницу официального релиза репозитория в браузере.</string>
+</resources>

--- a/app/src/main/res/values/update_strings.xml
+++ b/app/src/main/res/values/update_strings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="update_title">Updates</string>
+    <string name="update_subtitle">Check official GitHub Releases for a newer app version.</string>
+    <string name="update_back">Back</string>
+    <string name="update_current_version_title">Installed version</string>
+    <string name="update_current_version_value">%1$s (code %2$d)</string>
+    <string name="update_source_hint">Update metadata is read only from the official Regstar2/tg-ws-proxy-android GitHub Releases feed.</string>
+    <string name="update_status_idle">Update status has not been checked yet.</string>
+    <string name="update_status_checking">Checking for updates…</string>
+    <string name="update_status_up_to_date">You are using the newest applicable version.</string>
+    <string name="update_status_unsupported_version">The installed version is not valid SemVer, so it cannot be compared safely.</string>
+    <string name="update_available_title">Update available: %1$s</string>
+    <string name="update_prerelease_label">Prerelease</string>
+    <string name="update_release_notes_title">Release notes</string>
+    <string name="update_release_notes_empty">No release notes were provided.</string>
+    <string name="update_open_release">Open official release</string>
+    <string name="update_check_now">Check for updates</string>
+    <string name="update_open_failed">Could not open the official GitHub Release page.</string>
+    <string name="update_error_network">Could not reach GitHub Releases. Check the network connection and try again.</string>
+    <string name="update_error_timeout">The GitHub Releases request timed out. Try again later.</string>
+    <string name="update_error_api">GitHub Releases returned an API error. Try again later.</string>
+    <string name="update_error_malformed">GitHub Releases returned metadata that could not be processed safely.</string>
+    <string name="update_failure_safe_hint">Update-check failures do not stop or reconfigure the proxy.</string>
+    <string name="update_security_note">TgWsProxy does not silently download or install APKs. The update action only opens the official repository release page in your browser.</string>
+</resources>

--- a/app/src/test/java/com/amurcanov/tgwsproxy/AppUpdateDeliveryTest.kt
+++ b/app/src/test/java/com/amurcanov/tgwsproxy/AppUpdateDeliveryTest.kt
@@ -1,0 +1,141 @@
+package com.amurcanov.tgwsproxy
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppUpdateDeliveryTest {
+    @Test
+    fun `semver follows stable and prerelease precedence`() {
+        val alpha = SemanticVersion.parse("1.10.13-alpha.1")!!
+        val beta = SemanticVersion.parse("v1.10.13-beta.1")!!
+        val rc = SemanticVersion.parse("1.10.13-rc.1")!!
+        val stable = SemanticVersion.parse("1.10.13")!!
+
+        assertTrue(alpha < beta)
+        assertTrue(beta < rc)
+        assertTrue(rc < stable)
+    }
+
+    @Test
+    fun `semver compares numeric prerelease identifiers numerically`() {
+        val rc2 = SemanticVersion.parse("1.10.13-rc.2")!!
+        val rc10 = SemanticVersion.parse("1.10.13-rc.10")!!
+
+        assertTrue(rc2 < rc10)
+    }
+
+    @Test
+    fun `semver ignores build metadata for precedence`() {
+        val left = SemanticVersion.parse("1.10.13+build.1")!!
+        val right = SemanticVersion.parse("1.10.13+build.99")!!
+
+        assertEquals(0, left.compareTo(right))
+    }
+
+    @Test
+    fun `invalid semver is rejected`() {
+        assertNull(SemanticVersion.parse("1.10"))
+        assertNull(SemanticVersion.parse("1.10.13-rc.01"))
+        assertNull(SemanticVersion.parse("latest"))
+    }
+
+    @Test
+    fun `stable install ignores prerelease and selects newer stable`() {
+        val decision = AppUpdateSelector.select(
+            currentVersionName = "1.10.12",
+            releases = listOf(
+                release("v1.10.14-rc.1", prerelease = true),
+                release("v1.10.13"),
+            ),
+        )
+
+        assertTrue(decision is UpdateDecision.Available)
+        assertEquals("v1.10.13", (decision as UpdateDecision.Available).release.tagName)
+    }
+
+    @Test
+    fun `stable install reports up to date when only newer prerelease exists`() {
+        val decision = AppUpdateSelector.select(
+            currentVersionName = "1.10.12",
+            releases = listOf(release("v1.10.13-rc.1", prerelease = true)),
+        )
+
+        assertEquals(UpdateDecision.UpToDate, decision)
+    }
+
+    @Test
+    fun `prerelease install may advance to newer prerelease`() {
+        val decision = AppUpdateSelector.select(
+            currentVersionName = "1.10.13-beta.1",
+            releases = listOf(
+                release("v1.10.13-rc.1", prerelease = true),
+                release("v1.10.13-beta.2", prerelease = true),
+            ),
+        )
+
+        assertTrue(decision is UpdateDecision.Available)
+        assertEquals("v1.10.13-rc.1", (decision as UpdateDecision.Available).release.tagName)
+    }
+
+    @Test
+    fun `prerelease install prefers stable of same version`() {
+        val decision = AppUpdateSelector.select(
+            currentVersionName = "1.10.13-rc.1",
+            releases = listOf(
+                release("v1.10.13"),
+                release("v1.10.14-beta.1", prerelease = true),
+            ),
+        )
+
+        assertTrue(decision is UpdateDecision.Available)
+        assertEquals("v1.10.14-beta.1", (decision as UpdateDecision.Available).release.tagName)
+    }
+
+    @Test
+    fun `draft malformed and older releases are ignored`() {
+        val decision = AppUpdateSelector.select(
+            currentVersionName = "1.10.13",
+            releases = listOf(
+                release("v2.0.0", draft = true),
+                release("not-a-version"),
+                release("v1.10.12"),
+            ),
+        )
+
+        assertEquals(UpdateDecision.UpToDate, decision)
+    }
+
+    @Test
+    fun `unsupported installed version is explicit`() {
+        val decision = AppUpdateSelector.select(
+            currentVersionName = "dev-build",
+            releases = listOf(release("v1.10.13")),
+        )
+
+        assertEquals(UpdateDecision.UnsupportedCurrentVersion, decision)
+    }
+
+    @Test
+    fun `release URL accepts only semver tags and stays on official repository`() {
+        assertEquals(
+            "https://github.com/Regstar2/tg-ws-proxy-android/releases/tag/v1.10.13",
+            AppUpdateSelector.officialReleaseUrl("v1.10.13"),
+        )
+        assertNull(AppUpdateSelector.officialReleaseUrl("../../issues/1"))
+        assertNull(AppUpdateSelector.officialReleaseUrl("latest"))
+    }
+
+    private fun release(
+        tag: String,
+        draft: Boolean = false,
+        prerelease: Boolean = false,
+    ) = GitHubReleaseInfo(
+        tagName = tag,
+        title = tag,
+        notes = "notes",
+        draft = draft,
+        prerelease = prerelease,
+    )
+}

--- a/docs/versions/v1.10.13.md
+++ b/docs/versions/v1.10.13.md
@@ -16,7 +16,7 @@ This document describes the planned/in-progress scope for `v1.10.13`. It is not 
 | #3 | Public project structure/documentation alignment | **Completed** |
 | #4 | CI / Project sync / release automation | **Completed** |
 | #5 | In-app feedback + GitHub Issue Forms | **Completed** |
-| #6 | Update delivery through GitHub Releases | Open |
+| #6 | Update delivery through GitHub Releases | **In progress** |
 | #7 | Final release/localization/compliance audit | Final gate |
 
 ## Issue #2 — runtime stability / Flowseal parity

--- a/docs/versions/v1.10.13.md
+++ b/docs/versions/v1.10.13.md
@@ -16,7 +16,7 @@ This document describes the planned/in-progress scope for `v1.10.13`. It is not 
 | #3 | Public project structure/documentation alignment | **Completed** |
 | #4 | CI / Project sync / release automation | **Completed** |
 | #5 | In-app feedback + GitHub Issue Forms | **Completed** |
-| #6 | Update delivery through GitHub Releases | **In progress** |
+| #6 | Update delivery through GitHub Releases | **Implemented; manual acceptance pending** |
 | #7 | Final release/localization/compliance audit | Final gate |
 
 ## Issue #2 — runtime stability / Flowseal parity
@@ -89,6 +89,25 @@ Feedback privacy is deliberately opt-in:
 - all new in-app strings are provided in both default English resources and Russian resources.
 
 The dedicated-screen refinement passed the GitHub-hosted project CI on PR #16. The project owner then manually reviewed the installed feedback UX and accepted it as suitable. Issue #5 is therefore complete; further feedback UX changes should be tracked separately.
+
+## Issue #6 — update delivery through GitHub Releases
+
+The update-delivery baseline adds a dedicated **Updates / Обновления** item to the Settings sections list and a non-exported update screen. The screen always shows the installed `versionName` and `versionCode`, checks the official repository's GitHub Releases metadata automatically when opened, and provides an explicit **Check for updates** action.
+
+The implementation is deliberately separated from the proxy startup/runtime path:
+
+- release metadata is fetched only from `api.github.com/repos/Regstar2/tg-ws-proxy-android/releases`;
+- network work runs on `Dispatchers.IO` with explicit connect/read timeouts and a bounded response size;
+- malformed metadata, timeout, DNS/network failures and GitHub API errors become update-screen status only and do not stop or reconfigure the proxy;
+- stable installations ignore prerelease releases, while prerelease/debug installations may advance through prerelease or stable SemVer versions;
+- draft releases and malformed/non-SemVer tags are ignored;
+- SemVer comparison includes prerelease precedence and ignores build metadata for ordering;
+- release notes are displayed in-app with a bounded length;
+- the update action never trusts a download URL from release metadata and constructs only this repository's official `github.com/.../releases/tag/<validated-semver-tag>` page;
+- v1.10.13 does not silently download/install APKs and adds no package-install or background-update permission;
+- all update UI strings are present in default English and Russian resources.
+
+Unit coverage is included for SemVer ordering, stable/prerelease policy, no-update behavior, malformed tags, draft releases and official release URL validation. Manual acceptance on Android still needs to verify the update screen, live GitHub Releases check, offline/error behavior, RU/EN rendering, browser navigation to the official release page, and that a running proxy remains unaffected.
 
 ## Versioning rule
 


### PR DESCRIPTION
Implements Issue #6 for v1.10.13.

Implemented:
- dedicated **Updates / Обновления** item in the Settings sections list;
- non-exported update screen showing installed version name/code;
- automatic asynchronous check when the update screen opens plus manual **Check for updates** action;
- fixed official GitHub Releases API source for `Regstar2/tg-ws-proxy-android`;
- explicit connect/read timeouts and bounded metadata response size;
- SemVer-compatible ordering including prerelease precedence and build-metadata handling;
- stable builds ignore prereleases; prerelease/debug builds may advance through prerelease or stable releases;
- draft/malformed releases are ignored;
- release notes shown in-app;
- network/API/timeout/malformed metadata failures degrade to update UI status and do not touch proxy runtime;
- update action opens only a constructed official repository release page for a validated SemVer tag;
- no silent APK download/install and no new install/background permissions;
- RU/EN localization;
- unit tests for SemVer, stable/prerelease/no-update and URL safety.

Manual Android acceptance remains before closing #6.

Refs #6