### PR TITLE
fix: polish update screen release notes UX

### DIFF
--- a/app/src/main/java/com/amurcanov/tgwsproxy/ReleaseNotesTextFormatter.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/ReleaseNotesTextFormatter.kt
@@ -1,0 +1,81 @@
+package com.amurcanov.tgwsproxy
+
+data class ReleaseNotesPreview(
+    val text: String,
+    val truncated: Boolean,
+)
+
+object ReleaseNotesTextFormatter {
+    private val headingPrefix = Regex("^\\s{0,3}#{1,6}\\s+")
+    private val quotePrefix = Regex("^\\s*>\\s?")
+    private val bulletPrefix = Regex("^\\s*[-*+]\\s+")
+    private val markdownLink = Regex("\\[([^\\]]+)]\\((https?://[^)]+)\\)")
+    private val inlineCode = Regex("`+([^`]+)`+")
+    private val excessiveBlankLines = Regex("\\n{3,}")
+
+    fun toPlainText(markdown: String): String {
+        if (markdown.isBlank()) return ""
+
+        var insideFence = false
+        val cleaned = buildList {
+            markdown
+                .replace("\r\n", "\n")
+                .replace('\r', '\n')
+                .lineSequence()
+                .forEach { rawLine ->
+                    val trimmedStart = rawLine.trimStart()
+                    if (trimmedStart.startsWith("```")) {
+                        insideFence = !insideFence
+                        return@forEach
+                    }
+
+                    var line = rawLine.trimEnd()
+                    if (!insideFence) {
+                        line = line.replace(headingPrefix, "")
+                        line = line.replace(quotePrefix, "")
+                        line = line.replace(bulletPrefix, "• ")
+                        line = line.replace(markdownLink, "$1")
+                        line = line.replace(inlineCode, "$1")
+                        line = line
+                            .replace("**", "")
+                            .replace("__", "")
+                            .replace("~~", "")
+                    }
+                    add(line)
+                }
+        }.joinToString("\n")
+
+        return cleaned
+            .replace(excessiveBlankLines, "\n\n")
+            .trim()
+    }
+
+    fun preview(
+        markdown: String,
+        maxLines: Int = 5,
+        maxChars: Int = 420,
+    ): ReleaseNotesPreview {
+        val plain = toPlainText(markdown)
+        if (plain.isEmpty()) return ReleaseNotesPreview("", false)
+
+        val allLines = plain.lines()
+        var truncated = allLines.size > maxLines
+        var text = allLines.take(maxLines).joinToString("\n").trimEnd()
+
+        if (text.length > maxChars) {
+            truncated = true
+            val candidate = text.take(maxChars).trimEnd()
+            val lastWhitespace = candidate.indexOfLast { it.isWhitespace() }
+            text = if (lastWhitespace >= maxChars / 2) {
+                candidate.take(lastWhitespace).trimEnd()
+            } else {
+                candidate
+            }
+        }
+
+        if (truncated) {
+            text = text.trimEnd().trimEnd('…') + "…"
+        }
+        return ReleaseNotesPreview(text, truncated)
+    }
+}

--- a/app/src/main/java/com/amurcanov/tgwsproxy/UpdateActivity.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/UpdateActivity.kt
@@ -10,10 +10,8 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -31,6 +29,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -170,7 +169,7 @@ private fun UpdateScreen(modifier: Modifier = Modifier) {
                 containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
             ),
         ) {
-            Column(modifier = Modifier.padding(16.dp)) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp)) {
                 Text(
                     text = stringResource(R.string.update_current_version_title),
                     style = MaterialTheme.typography.titleMedium,
@@ -183,13 +182,7 @@ private fun UpdateScreen(modifier: Modifier = Modifier) {
                         installed.code,
                     ),
                     style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(top = 6.dp),
-                )
-                Text(
-                    text = stringResource(R.string.update_source_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 8.dp),
+                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
         }
@@ -201,7 +194,7 @@ private fun UpdateScreen(modifier: Modifier = Modifier) {
                 containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
             ),
         ) {
-            Column(modifier = Modifier.padding(16.dp)) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp)) {
                 when (val current = state) {
                     UpdateScreenState.Idle -> {
                         Text(stringResource(R.string.update_status_idle))
@@ -238,6 +231,14 @@ private fun UpdateScreen(modifier: Modifier = Modifier) {
                     }
                     is UpdateScreenState.Available -> {
                         val release = current.release
+                        val fullNotes = remember(release.notes) {
+                            ReleaseNotesTextFormatter.toPlainText(release.notes)
+                        }
+                        val preview = remember(release.notes) {
+                            ReleaseNotesTextFormatter.preview(release.notes)
+                        }
+                        var notesExpanded by remember(release.tagName) { mutableStateOf(false) }
+
                         Text(
                             text = stringResource(R.string.update_available_title, release.tagName),
                             style = MaterialTheme.typography.titleMedium,
@@ -251,26 +252,15 @@ private fun UpdateScreen(modifier: Modifier = Modifier) {
                                 modifier = Modifier.padding(top = 4.dp),
                             )
                         }
-                        Text(
-                            text = release.title,
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.padding(top = 8.dp),
-                        )
-                        Text(
-                            text = stringResource(R.string.update_release_notes_title),
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            modifier = Modifier.padding(top = 12.dp),
-                        )
-                        Text(
-                            text = release.notes.ifBlank {
-                                stringResource(R.string.update_release_notes_empty)
-                            },
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(top = 4.dp),
-                        )
-                        Spacer(modifier = Modifier.height(12.dp))
+                        if (release.title.isNotBlank() && release.title != release.tagName) {
+                            Text(
+                                text = release.title,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(top = 6.dp),
+                            )
+                        }
+
                         Button(
                             onClick = {
                                 val url = AppUpdateSelector.officialReleaseUrl(release.tagName)
@@ -294,30 +284,67 @@ private fun UpdateScreen(modifier: Modifier = Modifier) {
                                     }
                                 }
                             },
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 12.dp),
                         ) {
                             Text(stringResource(R.string.update_open_release))
                         }
-                    }
-                }
 
-                Spacer(modifier = Modifier.height(12.dp))
-                FilledTonalButton(
-                    onClick = { scope.launch { checkForUpdates() } },
-                    enabled = state != UpdateScreenState.Checking,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(
-                        if (state == UpdateScreenState.Checking) {
-                            stringResource(R.string.update_status_checking)
-                        } else {
-                            stringResource(R.string.update_check_now)
-                        },
-                    )
+                        Text(
+                            text = stringResource(R.string.update_release_notes_title),
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.padding(top = 14.dp),
+                        )
+                        Text(
+                            text = when {
+                                fullNotes.isBlank() -> stringResource(R.string.update_release_notes_empty)
+                                notesExpanded -> fullNotes
+                                else -> preview.text
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                        if (preview.truncated) {
+                            TextButton(
+                                onClick = { notesExpanded = !notesExpanded },
+                                modifier = Modifier.padding(top = 2.dp),
+                            ) {
+                                Text(
+                                    if (notesExpanded) {
+                                        stringResource(R.string.update_hide_release_notes)
+                                    } else {
+                                        stringResource(R.string.update_show_release_notes)
+                                    },
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }
 
+        FilledTonalButton(
+            onClick = { scope.launch { checkForUpdates() } },
+            enabled = state != UpdateScreenState.Checking,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                if (state == UpdateScreenState.Checking) {
+                    stringResource(R.string.update_status_checking)
+                } else {
+                    stringResource(R.string.update_check_now)
+                },
+            )
+        }
+
+        Text(
+            text = stringResource(R.string.update_source_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
         Text(
             text = stringResource(R.string.update_security_note),
             style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/res/values-ru/update_strings.xml
+++ b/app/src/main/res/values-ru/update_strings.xml
@@ -14,6 +14,8 @@
     <string name="update_prerelease_label">Предварительная версия</string>
     <string name="update_release_notes_title">Описание релиза</string>
     <string name="update_release_notes_empty">Описание релиза отсутствует.</string>
+    <string name="update_show_release_notes">Показать полное описание</string>
+    <string name="update_hide_release_notes">Скрыть полное описание</string>
     <string name="update_open_release">Открыть официальный релиз</string>
     <string name="update_check_now">Проверить обновления</string>
     <string name="update_open_failed">Не удалось открыть официальный GitHub Release.</string>

--- a/app/src/main/res/values/update_strings.xml
+++ b/app/src/main/res/values/update_strings.xml
@@ -14,6 +14,8 @@
     <string name="update_prerelease_label">Prerelease</string>
     <string name="update_release_notes_title">Release notes</string>
     <string name="update_release_notes_empty">No release notes were provided.</string>
+    <string name="update_show_release_notes">Show full release notes</string>
+    <string name="update_hide_release_notes">Hide full release notes</string>
     <string name="update_open_release">Open official release</string>
     <string name="update_check_now">Check for updates</string>
     <string name="update_open_failed">Could not open the official GitHub Release page.</string>

--- a/app/src/test/java/com/amurcanov/tgwsproxy/ReleaseNotesTextFormatterTest.kt
+++ b/app/src/test/java/com/amurcanov/tgwsproxy/ReleaseNotesTextFormatterTest.kt
@@ -1,0 +1,74 @@
+package com.amurcanov.tgwsproxy
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReleaseNotesTextFormatterTest {
+    @Test
+    fun `markdown is converted to readable plain text`() {
+        val markdown = """
+            # Release notes v1.10.12
+
+            **Main changes**
+            - MTProto uses `cf_proxy_ws`.
+            - See [documentation](https://example.com/docs).
+
+            ## Details
+            > Proxy runtime stays unchanged.
+        """.trimIndent()
+
+        val plain = ReleaseNotesTextFormatter.toPlainText(markdown)
+
+        assertEquals(
+            """
+                Release notes v1.10.12
+
+                Main changes
+                • MTProto uses cf_proxy_ws.
+                • See documentation.
+
+                Details
+                Proxy runtime stays unchanged.
+            """.trimIndent(),
+            plain,
+        )
+        assertFalse(plain.contains("**"))
+        assertFalse(plain.contains("`"))
+        assertFalse(plain.contains("#"))
+    }
+
+    @Test
+    fun `preview is short and reports truncation`() {
+        val markdown = (1..8).joinToString("\n") { "- Release note item $it with useful details" }
+
+        val preview = ReleaseNotesTextFormatter.preview(markdown, maxLines = 3, maxChars = 500)
+
+        assertTrue(preview.truncated)
+        assertTrue(preview.text.lines().size <= 3)
+        assertTrue(preview.text.endsWith("…"))
+        assertFalse(preview.text.contains("item 4"))
+    }
+
+    @Test
+    fun `short release notes are not marked as truncated`() {
+        val preview = ReleaseNotesTextFormatter.preview("**Fixed** update screen.")
+
+        assertFalse(preview.truncated)
+        assertEquals("Fixed update screen.", preview.text)
+    }
+
+    @Test
+    fun `fenced code keeps content but hides fence markers`() {
+        val plain = ReleaseNotesTextFormatter.toPlainText(
+            """
+                ```text
+                versionName=1.10.13
+                ```
+            """.trimIndent(),
+        )
+
+        assertEquals("versionName=1.10.13", plain)
+    }
+}


### PR DESCRIPTION
Polishes the Issue #6 update-delivery screen after manual Android review.

Changes:
- keeps the installed-version card compact;
- moves the official-source/security explanations to secondary text below the main controls;
- places **Open official release** immediately in the available-update card;
- converts GitHub Markdown release notes to readable plain text instead of showing raw `#`, `**`, backticks and Markdown links;
- shows only a short release-notes preview by default;
- adds **Show full release notes / Hide full release notes** controls;
- keeps **Check for updates** as a separate compact action;
- adds RU/EN strings for the new controls;
- adds unit tests for Markdown cleanup, fenced-code handling, preview truncation and short-note behavior.

No update-selection, release-source, permissions, proxy runtime, or networking behavior is changed.

Refs #6