### PR TITLE
release: complete v1.10.13 final audit and metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,17 @@ jobs:
 
           $arguments = @('release', 'create', $env:RELEASE_TAG)
           $arguments += $files
-          $arguments += @('--title', $env:RELEASE_TAG, '--generate-notes')
+          $arguments += @('--title', $env:RELEASE_TAG)
+
+          $notesPath = "./docs/releases/RELEASE_NOTES_$($env:RELEASE_TAG).md"
+          if (Test-Path $notesPath) {
+              Write-Host "Using curated release notes: $notesPath"
+              $arguments += @('--notes-file', $notesPath)
+          }
+          else {
+              Write-Host 'Curated release notes not found; falling back to generated notes.'
+              $arguments += '--generate-notes'
+          }
 
           if ($env:RELEASE_TAG -match '-(alpha|beta|rc)(\.|$)') {
               $arguments += '--prerelease'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ All notable user-facing changes are listed here. Detailed notes for older releas
 - Worker failover is regression-tested to stop after the first successful candidate.
 - Worker ordering for equal creation timestamps preserves stable persistence/insertion order instead of using random UUID order.
 - Reviewed relevant Flowseal runtime changes through `b2a8074`; Android-specific route keys, cooldown/watchdog/fake-TLS/diagnostics behavior are retained and disabled upstream 429 logic is not ported.
-- Added `docs/research/flowseal-upstream-2026-08-24.md` with port/no-port decisions. Automated Go/Android/debug-build validation passed on the implementation branch; the project owner also reported a successful manual proxy smoke test.
+- Added a dedicated **Feedback** settings section backed by GitHub Issue Forms, with optional safe app/device context and no embedded GitHub write credential.
+- Added a dedicated **Updates** section that checks only the official GitHub Releases feed asynchronously, applies SemVer stable/prerelease policy, shows bounded/cleaned release notes, and opens only the validated official release page.
+- Update checks do not silently download/install APKs, add install permissions, or touch proxy runtime state.
+- Public PR CI now runs on GitHub-hosted Windows; Project Sync uses GitHub-hosted Ubuntu; the persistent self-hosted runner is reserved for owner-controlled release/signing.
+- Added signed release packaging verification and SHA-256 artifact generation through `scripts/release.ps1`.
+- Added release-readiness auditing for version metadata, RU/EN resource parity, obsolete repository links, tracked private/local files, signing material, logs, environment files, and common credential signatures.
+- Public README/docs now describe source `1.10.13` accurately and use the canonical `Regstar2/tg-ws-proxy-android` repository URL.
+- Added `docs/research/flowseal-upstream-2026-08-24.md` with port/no-port decisions and `docs/releases/RELEASE_NOTES_v1.10.13.md` for the final release body.
 
 ## 1.10.12
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@
 
 **Русский** · [English](README_EN.md)
 
-[![Version](https://img.shields.io/badge/version-1.10.12-0969DA?style=for-the-badge)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/source-1.10.13-0969DA?style=for-the-badge)](CHANGELOG.md)
 [![Android](https://img.shields.io/badge/Android-8.0%2B-3DDC84?style=for-the-badge&logo=android&logoColor=white)](app/build.gradle.kts)
 [![ABI](https://img.shields.io/badge/ABI-arm64--v8a-7B61FF?style=for-the-badge)](app/build.gradle.kts)
 [![Documentation](https://img.shields.io/badge/docs-open-4C8BF5?style=for-the-badge&logo=readthedocs&logoColor=white)](#документация)
-[![License](https://img.shields.io/github/license/Regstar2/TgWsProxy_Android?style=for-the-badge&label=license)](LICENSE)
+[![License](https://img.shields.io/github/license/Regstar2/tg-ws-proxy-android?style=for-the-badge&label=license)](LICENSE)
 
 [Быстрый старт](#быстрый-старт) ·
 [Документация](#документация) ·
-[Релизы](https://github.com/Regstar2/TgWsProxy_Android/releases) ·
-[Сообщить об ошибке](https://github.com/Regstar2/TgWsProxy_Android/issues)
+[Релизы](https://github.com/Regstar2/tg-ws-proxy-android/releases) ·
+[Сообщить об ошибке](https://github.com/Regstar2/tg-ws-proxy-android/issues)
 
 </div>
 
@@ -27,20 +27,22 @@
 
 TgWsProxy запускает локальный прокси на Android-устройстве. Telegram подключается к нему через MTProto Proxy или совместимый SOCKS5-режим, после чего нативный runtime выбирает разрешённый маршрут к инфраструктуре Telegram.
 
-Основной сценарий версии `1.10.12` — **MTProto Proxy → Cloudflare Proxy** на локальном адресе `127.0.0.1:1443`. Приложение не создаёт системный VPN-туннель и не перенаправляет весь трафик устройства.
+Основной сценарий версии `1.10.13` — **MTProto Proxy → Cloudflare Proxy** на локальном адресе `127.0.0.1:1443`. Приложение не создаёт системный VPN-туннель и не перенаправляет весь трафик устройства.
 
 ## Статус проекта
 
-**Версия:** `1.10.12` (`versionCode 50`)  
-**Стадия:** активная разработка
+**Версия исходников:** `1.10.13` (`versionCode 51`)  
+**Стадия:** release candidate; тег и GitHub Release публикуются только после финального аудита #7
 
 | Область | Статус |
 |---|---|
-| MTProto Proxy через `cf_proxy_ws` | Основной сценарий; по release notes вручную проверен на мобильной сети и Wi-Fi |
+| MTProto Proxy через `cf_proxy_ws` | Основной сценарий; ранее вручную проверен на мобильной сети и Wi-Fi |
 | SOCKS5 / WebSocket frontend | Реализован как режим совместимости |
 | `direct_ws` и `tcp_fallback` | Реализованы; доступность зависит от сети |
 | Cloudflare Worker | Реализован как необязательный маршрут |
-| Worker Pool | Реализован, но в версии `1.10.12` остаётся медленным и не рекомендуется как основной маршрут |
+| Worker Pool | Реализован, но остаётся медленным и не рекомендуется как основной маршрут |
+| Feedback | Отдельный экран; GitHub Issue Forms без встроенного PAT |
+| Updates | Проверка официальных GitHub Releases с SemVer и открытием официальной страницы релиза |
 
 ## Возможности
 
@@ -52,6 +54,7 @@ TgWsProxy запускает локальный прокси на Android-уст
 - необязательный passthrough probe-соединений на указанный masking domain;
 - foreground service, уведомление о состоянии и watchdog локального listener;
 - диагностика маршрутов, runtime status, экспорт отчёта и настраиваемое логирование;
+- отдельные экраны обратной связи и проверки обновлений;
 - русский и английский интерфейс.
 
 ## Скриншоты
@@ -69,7 +72,7 @@ TgWsProxy запускает локальный прокси на Android-уст
 
 ## Быстрый старт
 
-1. Установите ARM64 APK из [GitHub Releases](https://github.com/Regstar2/TgWsProxy_Android/releases), если нужная версия опубликована, либо [соберите debug APK](#сборка).
+1. Установите ARM64 APK из [GitHub Releases](https://github.com/Regstar2/tg-ws-proxy-android/releases), если нужная версия опубликована, либо [соберите debug APK](#сборка).
 2. Откройте TgWsProxy.
 3. Оставьте frontend **MTProto Proxy** и порт `1443`, если он не занят другим локальным сервисом.
 4. Нажмите **Включить прокси**.
@@ -99,13 +102,13 @@ TgWsProxy запускает локальный прокси на Android-уст
 
 ## Установка
 
-Проверьте [GitHub Releases](https://github.com/Regstar2/TgWsProxy_Android/releases) на наличие APK нужной версии. Локально собранный debug APK устанавливается через ADB:
+Проверьте [GitHub Releases](https://github.com/Regstar2/tg-ws-proxy-android/releases) на наличие APK нужной версии. Локально собранный debug APK устанавливается через ADB:
 
 ```powershell
 adb install -r app\build\outputs\apk\debug\app-debug.apk
 ```
 
-При переходе между debug- и release-подписями Android может потребовать удалить ранее установленное приложение.
+При переходе между debug- и release-подписями Android может потребовать удалить ранее установленное приложение. Перед удалением приложения учитывайте, что его локальные настройки могут быть потеряны.
 
 ## Использование
 
@@ -153,7 +156,7 @@ WebSocket — транспорт. Фактический путь в интер�
 
 ## Конфигурация
 
-Значения по умолчанию для версии `1.10.12`:
+Значения по умолчанию для версии `1.10.13`:
 
 | Параметр | Значение |
 |---|---|
@@ -200,6 +203,8 @@ Android-часть написана на Kotlin и Jetpack Compose. Нативн
 - MTProto secret, query-параметры и чувствительные адреса маскируются в интерфейсе, диагностических отчётах и логах там, где это предусмотрено реализацией.
 - URL Cloudflare Worker, proxy secrets, keystore и переменные подписи нельзя публиковать в issue, логах или коммитах.
 - Release signing использует локальные переменные окружения; keystore исключён из Git.
+- Feedback не прикладывает runtime-логи, proxy credentials, Telegram data, IP-адреса или секреты автоматически.
+- Проверка обновлений использует официальный GitHub Releases API; установка APK приложением не выполняется.
 - Masking domain меняет форму Fake TLS handshake, но не превращает приложение в VPN.
 
 Перед публикацией диагностического отчёта проверьте его вручную.
@@ -254,6 +259,14 @@ app\build\outputs\apk\debug\app-debug.apk
 .\scripts\build-apk.ps1 -Configuration Debug
 ```
 
+Финальная signed release-сборка выполняется только при локально настроенном keystore:
+
+```powershell
+.\scripts\release.ps1 -Version v1.10.13
+```
+
+Скрипт проверяет соответствие тега `versionName`, подпись APK и формирует APK + SHA-256 в `dist/`.
+
 Отдельная сборка Go runtime:
 
 ```powershell
@@ -262,19 +275,15 @@ app\build\outputs\apk\debug\app-debug.apk
 
 ## Тестирование
 
-Команды, определённые в проекте:
+Единая проектная проверка:
 
 ```powershell
-.\gradlew.bat testDebugUnitTest
-.\gradlew.bat assembleDebug
-
-cd native\tgwsproxy
-go test ./...
+.\scripts\ci.ps1
 ```
 
-В рамках подготовки этого README команды не запускались. Release notes версии `1.10.12` сообщают о выполнении unit-тестов, debug-сборки, Go-тестов и ручной проверке MTProto через Cloudflare Proxy на мобильной сети и Wi-Fi.
+Она включает Go module verification, native Go tests, Android unit tests, debug APK build и packaged-resource audit. Финальный release audit дополнительно запускается из CI для release-candidate source.
 
-Ручная проверка должна включать запуск и остановку proxy service, подключение Telegram, загрузку сообщений и медиа, смену сетевой политики, диагностику маршрутов и просмотр экспортируемого отчёта на наличие секретов.
+Ручная проверка перед тегом должна включать запуск и остановку proxy service, подключение Telegram, сообщения и медиа, Wi-Fi ↔ mobile, reconnect, Feedback/Updates и просмотр экспортируемого отчёта на наличие секретов.
 
 Актуальный чек-лист: [docs/testing/README.md](docs/testing/README.md).
 
@@ -288,23 +297,24 @@ go test ./...
 | Структура репозитория | [docs/development/repository-structure.md](docs/development/repository-structure.md) |
 | Ручное тестирование | [docs/testing/README.md](docs/testing/README.md) |
 | Подготовка релиза | [docs/releases/release.md](docs/releases/release.md) |
-| Изменения версии `1.10.12` | [docs/releases/RELEASE_NOTES_v1.10.12.md](docs/releases/RELEASE_NOTES_v1.10.12.md) |
+| Release notes `1.10.13` | [docs/releases/RELEASE_NOTES_v1.10.13.md](docs/releases/RELEASE_NOTES_v1.10.13.md) |
+| Финальный аудит `1.10.13` | [docs/releases/v1.10.13-final-audit.md](docs/releases/v1.10.13-final-audit.md) |
 | История изменений | [CHANGELOG.md](CHANGELOG.md) |
 
 ## Происхождение и благодарности
 
 - [Flowseal/tg-ws-proxy](https://github.com/Flowseal/tg-ws-proxy) — upstream runtime и основная идея WebSocket-маршрутизации;
 - [amurcanov/tg-ws-proxy-android](https://github.com/amurcanov/tg-ws-proxy-android) — Android-обёртка, от которой началась эта ветка;
-- [Regstar2/TgWsProxy_Android](https://github.com/Regstar2/TgWsProxy_Android) — текущая Android-реализация и дальнейшая разработка.
+- [Regstar2/tg-ws-proxy-android](https://github.com/Regstar2/tg-ws-proxy-android) — текущая Android-реализация и дальнейшая разработка.
 
-При разработке отдельных участков кода, тестов и документации использовались AI-инструменты. Итоговые изменения проверялись вручную.
+При разработке отдельных участков кода, тестов и документации использовались AI-инструменты. Итоговые изменения проверяются тестами и release-аудитом; ручная device acceptance остаётся обязательным финальным шагом.
 
 ## Ограничения
 
 - поддерживается только ABI `arm64-v8a`;
 - приложение является прокси для Telegram, а не системным VPN;
 - доступность маршрутов зависит от сети и внешней инфраструктуры;
-- Worker Pool в версии `1.10.12` остаётся медленным и не предназначен для основного сценария;
+- Worker Pool остаётся медленным и не предназначен для основного сценария;
 - порт `1443` нужно изменить, если его уже использует другой локальный сервис;
 - native build script ориентирован на Windows; поддержка Linux и macOS не подтверждена;
 - masking-domain passthrough создаёт соединения с указанным доменом;

--- a/README_EN.md
+++ b/README_EN.md
@@ -8,16 +8,16 @@ A local Telegram proxy for Android with MTProto and SOCKS5 frontends and routing
 
 [Русский](README.md) · **English**
 
-[![Version](https://img.shields.io/badge/version-1.10.12-0969DA?style=for-the-badge)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/source-1.10.13-0969DA?style=for-the-badge)](CHANGELOG.md)
 [![Android](https://img.shields.io/badge/Android-8.0%2B-3DDC84?style=for-the-badge&logo=android&logoColor=white)](app/build.gradle.kts)
 [![ABI](https://img.shields.io/badge/ABI-arm64--v8a-7B61FF?style=for-the-badge)](app/build.gradle.kts)
 [![Documentation](https://img.shields.io/badge/docs-open-4C8BF5?style=for-the-badge&logo=readthedocs&logoColor=white)](#documentation)
-[![License](https://img.shields.io/github/license/Regstar2/TgWsProxy_Android?style=for-the-badge&label=license)](LICENSE)
+[![License](https://img.shields.io/github/license/Regstar2/tg-ws-proxy-android?style=for-the-badge&label=license)](LICENSE)
 
 [Quick start](#quick-start) ·
 [Documentation](#documentation) ·
-[Releases](https://github.com/Regstar2/TgWsProxy_Android/releases) ·
-[Report an issue](https://github.com/Regstar2/TgWsProxy_Android/issues)
+[Releases](https://github.com/Regstar2/tg-ws-proxy-android/releases) ·
+[Report an issue](https://github.com/Regstar2/tg-ws-proxy-android/issues)
 
 </div>
 
@@ -27,20 +27,22 @@ A local Telegram proxy for Android with MTProto and SOCKS5 frontends and routing
 
 TgWsProxy runs a local proxy on an Android device. Telegram connects through the MTProto Proxy frontend or the compatible SOCKS5 mode, and the native runtime selects an allowed route to Telegram infrastructure.
 
-The primary use case in version `1.10.12` is **MTProto Proxy → Cloudflare Proxy** on `127.0.0.1:1443`. The application does not create a system VPN tunnel or route all device traffic.
+The primary use case in version `1.10.13` is **MTProto Proxy → Cloudflare Proxy** on `127.0.0.1:1443`. The application does not create a system VPN tunnel or route all device traffic.
 
 ## Project status
 
-**Version:** `1.10.12` (`versionCode 50`)  
-**Stage:** active development
+**Source version:** `1.10.13` (`versionCode 51`)  
+**Stage:** release candidate; the tag and GitHub Release are published only after final Issue #7 acceptance
 
 | Area | Status |
 |---|---|
-| MTProto Proxy over `cf_proxy_ws` | Primary use case; the release notes report manual verification on mobile data and Wi-Fi |
+| MTProto Proxy over `cf_proxy_ws` | Primary use case; previously manually verified on mobile data and Wi-Fi |
 | SOCKS5 / WebSocket frontend | Implemented as a compatibility mode |
 | `direct_ws` and `tcp_fallback` | Implemented; availability depends on the network |
 | Cloudflare Worker | Implemented as an optional route |
-| Worker Pool | Implemented, but remains slow in version `1.10.12` and is not recommended as the primary route |
+| Worker Pool | Implemented but still slow and not recommended as the primary route |
+| Feedback | Dedicated screen; GitHub Issue Forms without an embedded PAT |
+| Updates | Official GitHub Releases check with SemVer and official release-page navigation |
 
 ## Features
 
@@ -52,6 +54,7 @@ The primary use case in version `1.10.12` is **MTProto Proxy → Cloudflare Prox
 - optional probe passthrough to a configured masking domain;
 - foreground service, status notification, and a local listener watchdog;
 - route diagnostics, runtime status, report export, and configurable logging;
+- dedicated Feedback and Updates screens;
 - English and Russian UI.
 
 ## Screenshots
@@ -69,7 +72,7 @@ The primary use case in version `1.10.12` is **MTProto Proxy → Cloudflare Prox
 
 ## Quick start
 
-1. Install an ARM64 APK from [GitHub Releases](https://github.com/Regstar2/TgWsProxy_Android/releases) when the required version is available, or [build a debug APK](#build).
+1. Install an ARM64 APK from [GitHub Releases](https://github.com/Regstar2/tg-ws-proxy-android/releases) when the required version is available, or [build a debug APK](#build).
 2. Open TgWsProxy.
 3. Keep **MTProto Proxy** as the frontend and port `1443` unless another local service already uses it.
 4. Tap **Start proxy**.
@@ -99,13 +102,13 @@ The current native build script uses a Windows NDK toolchain path. The repositor
 
 ## Installation
 
-Check [GitHub Releases](https://github.com/Regstar2/TgWsProxy_Android/releases) for an APK of the required version. Install a locally built debug APK through ADB:
+Check [GitHub Releases](https://github.com/Regstar2/tg-ws-proxy-android/releases) for an APK of the required version. Install a locally built debug APK through ADB:
 
 ```powershell
 adb install -r app\build\outputs\apk\debug\app-debug.apk
 ```
 
-Android may require uninstalling the existing application when switching between debug and release signatures.
+Android may require uninstalling the existing application when switching between debug and release signatures. Note that uninstalling may remove local application settings.
 
 ## Usage
 
@@ -153,7 +156,7 @@ WebSocket is a transport. The interface and diagnostics identify the actual path
 
 ## Configuration
 
-Defaults for version `1.10.12`:
+Defaults for version `1.10.13`:
 
 | Setting | Value |
 |---|---|
@@ -200,6 +203,8 @@ Detailed design: [docs/architecture/architecture.md](docs/architecture/architect
 - MTProto secrets, query parameters, and sensitive addresses are masked in the interface, diagnostic reports, and logs where the implementation supports it.
 - Cloudflare Worker URLs, proxy secrets, keystores, and signing variables must not be published in issues, logs, or commits.
 - Release signing uses local environment variables; the keystore is excluded from Git.
+- Feedback does not automatically attach runtime logs, proxy credentials, Telegram data, IP addresses, or secrets.
+- Update checks use the official GitHub Releases API; the application does not install APKs itself.
 - A masking domain changes the Fake TLS handshake shape but does not turn the application into a VPN.
 
 Review every diagnostic report manually before publishing it.
@@ -254,6 +259,14 @@ Build and copy the APK to the local `artifacts/` directory:
 .\scripts\build-apk.ps1 -Configuration Debug
 ```
 
+Build the final signed release only when the local keystore is configured:
+
+```powershell
+.\scripts\release.ps1 -Version v1.10.13
+```
+
+The script verifies that the tag matches `versionName`, verifies the APK signature, and produces the APK plus SHA-256 in `dist/`.
+
 Build the Go runtime separately:
 
 ```powershell
@@ -262,19 +275,15 @@ Build the Go runtime separately:
 
 ## Testing
 
-Commands defined by the project:
+Single project CI entry point:
 
 ```powershell
-.\gradlew.bat testDebugUnitTest
-.\gradlew.bat assembleDebug
-
-cd native\tgwsproxy
-go test ./...
+.\scripts\ci.ps1
 ```
 
-These commands were not run while preparing this README. The `1.10.12` release notes report unit tests, a debug build, Go tests, and manual verification of MTProto through Cloudflare Proxy on mobile data and Wi-Fi.
+It covers Go module verification, native Go tests, Android unit tests, debug APK assembly, and packaged-resource auditing. The release-candidate source also runs the final release audit from CI.
 
-Manual validation should cover starting and stopping the proxy service, connecting Telegram, loading messages and media, switching network policies, running route diagnostics, and reviewing exported reports for secrets.
+Manual pre-tag validation must cover proxy start/stop, Telegram connectivity, messages and media, Wi-Fi ↔ mobile switching, reconnect, Feedback/Updates, and review of exported diagnostics for secrets.
 
 Current checklist: [docs/testing/README.md](docs/testing/README.md).
 
@@ -288,23 +297,24 @@ Current checklist: [docs/testing/README.md](docs/testing/README.md).
 | Repository structure | [docs/development/repository-structure.md](docs/development/repository-structure.md) |
 | Manual testing | [docs/testing/README.md](docs/testing/README.md) |
 | Release preparation | [docs/releases/release.md](docs/releases/release.md) |
-| Version `1.10.12` changes | [docs/releases/RELEASE_NOTES_v1.10.12.md](docs/releases/RELEASE_NOTES_v1.10.12.md) |
+| `1.10.13` release notes | [docs/releases/RELEASE_NOTES_v1.10.13.md](docs/releases/RELEASE_NOTES_v1.10.13.md) |
+| `1.10.13` final audit | [docs/releases/v1.10.13-final-audit.md](docs/releases/v1.10.13-final-audit.md) |
 | Change history | [CHANGELOG.md](CHANGELOG.md) |
 
 ## Credits
 
 - [Flowseal/tg-ws-proxy](https://github.com/Flowseal/tg-ws-proxy) — upstream runtime and the main WebSocket routing concept;
 - [amurcanov/tg-ws-proxy-android](https://github.com/amurcanov/tg-ws-proxy-android) — the Android wrapper this branch started from;
-- [Regstar2/TgWsProxy_Android](https://github.com/Regstar2/TgWsProxy_Android) — the current Android implementation and ongoing development.
+- [Regstar2/tg-ws-proxy-android](https://github.com/Regstar2/tg-ws-proxy-android) — the current Android implementation and ongoing development.
 
-AI tools were used for selected parts of the code, tests, and documentation. The resulting changes were reviewed manually.
+AI tools were used for selected parts of the code, tests, and documentation. The resulting changes are checked by tests and the release audit; manual device acceptance remains a required final step.
 
 ## Limitations
 
 - only the `arm64-v8a` ABI is supported;
 - the application is a Telegram proxy, not a system-wide VPN;
 - route availability depends on the network and external infrastructure;
-- Worker Pool remains slow in version `1.10.12` and is not intended for the primary use case;
+- Worker Pool remains slow and is not intended for the primary use case;
 - port `1443` must be changed when another local service already uses it;
 - the native build script targets Windows; Linux and macOS support is not confirmed;
 - masking-domain passthrough creates connections to the configured domain;

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
-val releaseVersionCode = 50
-val releaseVersionName = "1.10.12"
+val releaseVersionCode = 51
+val releaseVersionName = "1.10.13"
 
 val buildNativeAndroid by tasks.registering(org.gradle.api.tasks.Exec::class) {
     val script = rootProject.file("scripts/build-native-android.ps1")
@@ -123,6 +123,8 @@ android {
 androidComponents {
     onVariants(selector().withBuildType("debug")) { variant ->
         variant.outputs.forEach { output ->
+            // Debug builds intentionally stay one code above the release code so they can be
+            // installed over the most recent release during pre-release Android acceptance.
             output.versionCode.set(releaseVersionCode + 1)
         }
     }

--- a/docs/releases/RELEASE_CHECKLIST.md
+++ b/docs/releases/RELEASE_CHECKLIST.md
@@ -2,93 +2,113 @@
 
 > Short workflow: [release.md](release.md). This file is the detailed checklist.
 
-## Build
+## Metadata / repository audit
 
-- [ ] `cd native/tgwsproxy && go test ./tgwsroute/...` (or `go test ./...` on Linux/CI)
-- [ ] `./gradlew.bat testDebugUnitTest`
-- [ ] `./gradlew.bat assembleDebug`
-- [ ] `./gradlew.bat lint`
-- [ ] `./gradlew.bat assembleRelease` (if signing configured)
-- [ ] `.\scripts\build-apk.ps1 -Configuration Release` (signed copy to `artifacts/apk/release/`)
+- [ ] `releaseVersionName = 1.10.13` and `releaseVersionCode = 51`.
+- [ ] `.\scripts\audit-release.ps1 -ExpectedVersion 1.10.13 -ExpectedVersionCode 51` passes.
+- [ ] RU/default-English resource keys have parity.
+- [ ] README RU/EN, CHANGELOG, version docs and `RELEASE_NOTES_v1.10.13.md` agree with the source metadata.
+- [ ] No obsolete `Regstar2/TgWsProxy_Android` repository URLs remain in README RU/EN.
+- [ ] No private governance/tool state, local logs, environment files, signing material or keystores are tracked.
+- [ ] Final branch diff contains no unrelated changes.
 
-## Runtime
+## Automated build
 
-- [ ] Start / stop / reconnect proxy
-- [ ] Telegram connects via SOCKS5 `127.0.0.1:1081`
-- [ ] Worker test OK
-- [ ] CF test OK or clear error
-- [ ] Auto / Worker only / CF only modes
-- [ ] Worker route works with pool enabled
-- [ ] Worker route still works when pool size is 0
-- [ ] Worker pool does not warm up when Worker route is disabled by policy
-- [ ] Worker pool resets on Stop
-- [ ] Worker pool resets or reconfigures on ACTION_RECONFIGURE
-- [ ] CF route still works after Worker pool changes
-- [ ] Direct route still works when selected by policy
-- [ ] TCP fallback still works when selected by policy
-- [ ] Active routes test respects Wi-Fi policy
-- [ ] Active routes test respects Mobile policy
-- [ ] Disabled route is shown as disabled, not failed
-- [ ] Empty Worker domain is shown as not configured
-- [ ] CF failures show useful hint
-- [ ] Route probe report can be copied
-- [ ] Route probe report is included in runtime log export after running probe
-- [ ] Existing Direct/Worker/CF/TCP test buttons still work
-- [ ] Worker pool hits/misses appear in runtime status
-- [ ] CF pool hits/misses appear in runtime status
-- [ ] Pool metrics appear in runtime log export
-- [ ] Pool metrics export does not include domains or runtime tokens
-- [ ] Active route diagnostics still shows disabled/not configured routes correctly
-- [ ] Effective route policy card shows current network type
-- [ ] Effective route policy card shows saved vs global source
-- [ ] Network switch updates last reconfigure status
-- [ ] Last reconfigure status does not spam Toasts
+- [ ] `.\scripts\ci.ps1` passes.
+- [ ] `go mod verify` passes in `native/tgwsproxy`.
+- [ ] `go test ./...` passes in `native/tgwsproxy`.
+- [ ] `testDebugUnitTest` passes.
+- [ ] `assembleDebug` passes.
+- [ ] packaged APK icon/resource audit passes.
+- [ ] debug APK reports `versionName 1.10.13-debug` / `versionCode 52`.
 
-## Notification
+## Signed release artifact
 
-- [ ] Foreground notification visible while running
-- [ ] Application icon resource: `ic_launcher_tgwsproxy_v2` (manifest)
-- [ ] Round icon: `ic_launcher_tgwsproxy_round_v2`
-- [ ] Notification small: `ic_notification_small_v2` (vector)
-- [ ] Notification large: `notification_app_icon_v2` (not PackageManager)
-- [ ] Channel: `tgwsproxy_service_status_v3`
-- [ ] `scripts/audit-apk-icons.ps1` reports no legacy filenames in APK
-- [ ] `adb dumpsys package` shows expected `versionCode` after install
-- [ ] MIUI: uninstall + reinstall (+ reboot if icon still cached)
-- [ ] Tap notification opens app
-- [ ] Stop / Start / Reconnect / Open actions work
-- [ ] Speed and latency when metrics enabled
-- [ ] Minimal mode hides metrics
-- [ ] Open Android notification settings
+- [ ] Local release signing variables/keystore are configured outside Git.
+- [ ] `.\scripts\release.ps1 -Version v1.10.13` succeeds.
+- [ ] `apksigner verify --verbose --print-certs` succeeds inside the release script.
+- [ ] `dist\TgWsProxy-Android-v1.10.13-arm64-v8a.apk` exists.
+- [ ] matching `.sha256` exists and contains the artifact SHA-256.
+- [ ] signed release APK reports `versionName 1.10.13` / `versionCode 51`.
 
-## Lifecycle
+## Core runtime
 
-- [ ] Screen rotation
-- [ ] App background / resume
-- [ ] Network switch Wi-Fi ↔ mobile
-- [ ] Start proxy on Wi-Fi, switch to Mobile, proxy reconfigures without manual restart
-- [ ] Start proxy on Mobile, switch to Wi-Fi, proxy reconfigures without manual restart
-- [ ] Reconfigure keeps foreground notification visible
-- [ ] Reconfigure does not show repeated Toast spam
-- [ ] Manual Reconnect still uses last runtime config
-- [ ] Stop proxy disables network monitor
+- [ ] Start proxy.
+- [ ] Stop proxy.
+- [ ] Reconnect proxy.
+- [ ] MTProto frontend starts on the configured local port (default `127.0.0.1:1443`).
+- [ ] **Apply in Telegram** opens the MTProto proxy configuration.
+- [ ] Telegram connects and receives text messages.
+- [ ] Telegram sends text messages.
+- [ ] Telegram loads images/media.
+- [ ] Telegram sends media where practical.
+- [ ] Main `cf_proxy_ws` route works.
+- [ ] Disabled routes are not selected.
+- [ ] Direct/TCP fallback behavior remains consistent with the saved route policy.
+- [ ] Worker route remains optional and does not become the default unexpectedly.
 
-## Privacy
+## Network / lifecycle
 
-- [ ] Log export masks domains when configured
-- [ ] No raw SSID in diagnostics
-- [ ] Copy policy diagnostics masks sensitive data
-- [ ] Runtime log export includes effective route policy section
-- [ ] Export does not include raw SSID, SIM operator, or full domains
-- [ ] Route probe report masks domains and sensitive network data
+- [ ] Proxy works on Wi-Fi.
+- [ ] Proxy works on mobile data.
+- [ ] Start on Wi-Fi → switch to mobile → runtime reconfigures without manual restart.
+- [ ] Start on mobile → switch to Wi-Fi → runtime reconfigures without manual restart.
+- [ ] Foreground notification remains visible during reconfigure.
+- [ ] Background/resume does not stop the proxy unexpectedly.
+- [ ] Screen rotation does not break settings/runtime state.
 
-## UI
+## Diagnostics / privacy
 
-- [ ] Onboarding on first launch
-- [ ] Help / About links open repository
-- [ ] Worker domain URL normalized to hostname
+- [ ] Route diagnostics opens and completes expected checks.
+- [ ] Diagnostic report can be copied/shared.
+- [ ] Exported diagnostics do not expose raw proxy secrets/tokens.
+- [ ] Exported diagnostics do not expose raw SSID or SIM operator.
+- [ ] Exported diagnostics do not expose full sensitive domains when masking is expected.
+- [ ] Runtime/persistent logging remains disabled by default.
 
-## Docs
+## Feedback
 
-- [ ] Cloudflare Worker guide contains current Worker code
-- [ ] Copy Worker code action works, if implemented
+- [ ] **Settings → Feedback / Обратная связь** opens a dedicated screen.
+- [ ] Report bug opens this repository's bug Issue Form.
+- [ ] Request feature opens this repository's feature Issue Form.
+- [ ] Copied helper context contains only app version/code, Android release/SDK and manufacturer/model.
+- [ ] No logs, proxy credentials, Telegram data, IPs or secrets are auto-attached.
+- [ ] Opening Feedback/browser while proxy is running does not stop/reconfigure it.
+
+## Updates
+
+- [ ] **Settings → Updates / Обновления** opens a dedicated screen.
+- [ ] Installed version/code are shown.
+- [ ] Automatic check starts only after the Updates screen opens.
+- [ ] Manual **Check for updates** works.
+- [ ] Release notes render as cleaned compact text; full notes can be expanded/collapsed.
+- [ ] Available update action opens only `Regstar2/tg-ws-proxy-android` official GitHub Release page.
+- [ ] Offline/timeout/API failures remain local UI errors and do not affect proxy connectivity.
+- [ ] No APK is silently downloaded or installed.
+
+## Localization / UI
+
+- [ ] Main UI reviewed in Russian.
+- [ ] Main UI reviewed in English/default fallback.
+- [ ] Feedback reviewed in RU/EN.
+- [ ] Updates reviewed in RU/EN.
+- [ ] No obvious unintended hardcoded user-facing strings are visible.
+- [ ] Back navigation from Feedback and Updates works.
+
+## Notification / packaged resources
+
+- [ ] Foreground notification visible while running.
+- [ ] Application icon resource: `ic_launcher_tgwsproxy_v2`.
+- [ ] Round icon: `ic_launcher_tgwsproxy_round_v2`.
+- [ ] Notification small icon: `ic_notification_small_v2`.
+- [ ] Notification large icon: `notification_app_icon_v2`.
+- [ ] `scripts/audit-apk-icons.ps1` reports no legacy filenames in APK.
+- [ ] Tap notification opens app.
+- [ ] Stop / Start / Reconnect / Open notification actions work.
+
+## Publication gate
+
+- [ ] Issue #6 manual acceptance is complete/closed or explicitly resolved as part of this final acceptance.
+- [ ] Issue #7 manual proxy acceptance is recorded.
+- [ ] Signed release artifact is verified.
+- [ ] Only then create/push tag `v1.10.13` and allow the owner-controlled release workflow to publish.

--- a/docs/releases/RELEASE_NOTES_v1.10.13.md
+++ b/docs/releases/RELEASE_NOTES_v1.10.13.md
@@ -1,0 +1,50 @@
+# TgWsProxy Android v1.10.13
+
+`versionName` **1.10.13** · `versionCode` **51** · ABI **arm64-v8a**
+
+## Главное
+
+- Стабилизирован MTProto WebSocket receive path: continuation/fragmented frames теперь собираются корректно, а размер отдельных и накопленных сообщений ограничен 16 MiB.
+- Worker failover и session-pool поведение усилены тестами; miss больше не запускает дублирующий background refill при уже выполняющемся foreground dial.
+- Синхронизированы релевантные изменения Flowseal с сохранением Android-специфичной маршрутизации, Fake TLS, watchdog и диагностики.
+- Добавлен отдельный экран **Обратная связь** с GitHub Issue Forms без встроенного GitHub PAT.
+- Добавлен отдельный экран **Обновления**: асинхронная проверка официальных GitHub Releases, SemVer stable/prerelease policy, release notes и переход только на официальный release URL.
+- Экран обновлений не скачивает и не устанавливает APK автоматически и не запрашивает дополнительные install/background permissions.
+- Публичная CI переведена на GitHub-hosted Windows; persistent self-hosted runner оставлен только для owner-controlled release/signing path.
+- Добавлены Project Sync, release automation, release signing verification и SHA-256 artifact generation.
+- Публичная структура и документация приведены к актуальным правилам проекта; private governance/AI/tool state исключены из Git.
+
+## Update delivery
+
+В **Настройки → Обновления** отображается установленная версия и выполняется безопасная проверка `Regstar2/tg-ws-proxy-android` Releases.
+
+При наличии более новой подходящей версии приложение показывает краткое описание релиза и предлагает открыть официальную страницу GitHub Release. Сетевые, timeout, API и malformed-metadata ошибки остаются локальным состоянием экрана и не должны останавливать или перенастраивать proxy runtime.
+
+## Feedback
+
+В **Настройки → Обратная связь** доступны отдельные действия **Сообщить об ошибке** и **Предложить функцию**. Приложение автоматически не прикладывает runtime logs, proxy credentials, Telegram data, IP-адреса или secrets. Копирование app/device context выполняется только по явному действию пользователя.
+
+## Runtime
+
+Основной сценарий остаётся **MTProto Proxy → Cloudflare Proxy** через локальный endpoint `127.0.0.1:1443`.
+
+Worker Pool остаётся необязательным и более медленным development/diagnostics path. `direct_ws` и `tcp_fallback` сохраняются как разрешаемые политикой альтернативы.
+
+## Безопасность релиза
+
+- Release signing material не хранится в Git.
+- `scripts/release.ps1 -Version v1.10.13` требует локально настроенные signing variables/keystore, проверяет подпись APK и формирует APK + SHA-256 в `dist/`.
+- GitHub Release должен публиковаться только после финального manual acceptance Issue #7.
+
+## Перед публикацией
+
+Обязательная ручная проверка финальной сборки:
+
+- MTProto proxy start/stop/reconnect;
+- Telegram messages и media;
+- Wi-Fi и mobile data;
+- Wi-Fi ↔ mobile reconfigure;
+- Feedback и Updates;
+- RU/EN;
+- diagnostic export на отсутствие чувствительных данных;
+- signed release artifact и SHA-256.

--- a/docs/releases/release.md
+++ b/docs/releases/release.md
@@ -1,70 +1,82 @@
-# Release checklist
+# Release workflow
 
 Short release workflow for TGWSProxyAndroid. Detailed checklist: [RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md).
 
 ## Before release
 
-- [ ] Bump `versionCode` and `versionName` in `app/build.gradle.kts`
-- [ ] Run [docs/testing/README.md](../testing/README.md) on a real device (mobile + Wi‑Fi)
-- [ ] Update [CHANGELOG.md](../../CHANGELOG.md)
-- [ ] Update [README.md](../../README.md) if UI or behavior changed
-- [ ] Update screenshots in `docs/assets/screenshots/` if UI changed
-- [ ] Add `docs/releases/RELEASE_NOTES_vX.Y.Z.md` if the release is feature-heavy
-- [ ] Confirm no keystores, passwords, or `local.properties` are committed
+- [ ] Confirm `releaseVersionName` / `releaseVersionCode` in `app/build.gradle.kts`.
+- [ ] Run `.\scripts\ci.ps1` and require the embedded `audit-release.ps1` to pass.
+- [ ] Run [docs/testing/README.md](../testing/README.md) on a real device on mobile data and Wi-Fi.
+- [ ] Verify Telegram messages/media, reconnect and Wi-Fi ↔ mobile reconfigure.
+- [ ] Verify Feedback and Updates in RU/EN.
+- [ ] Update [CHANGELOG.md](../../CHANGELOG.md), README RU/EN and per-version release notes.
+- [ ] Confirm no keystores, passwords, `local.properties`, private governance files, local logs, or environment files are tracked.
+- [ ] Review the release branch diff for unrelated changes.
 
-## Build debug APK
+For `v1.10.13`, the expected release metadata is `versionName 1.10.13` / `versionCode 51`.
+
+## Build debug APK for device acceptance
 
 ```powershell
-.\gradlew.bat assembleDebug
+.\scripts\ci.ps1
 ```
 
-Output: `app\build\outputs\apk\debug\app-debug.apk`
+The final CI stage builds:
 
-Optional copy:
-
-```powershell
-.\scripts\build-apk.ps1 -Configuration Debug
+```text
+app\build\outputs\apk\debug\app-debug.apk
 ```
 
-→ `artifacts\apk\debug\tgwsproxy-debug.apk`
+For `v1.10.13` source, the debug variant intentionally uses `versionName 1.10.13-debug` and `versionCode 52`, one code above release, so it can be installed over the latest release during pre-release testing.
 
-## Build release APK
+## Build final signed release artifacts
 
-Release signing uses **local** keystore and environment variables (not in git):
+Release signing stays local and outside Git. Configure the keystore through `release-signing.env` or process environment variables:
 
 ```powershell
-$env:KEYSTORE_FILE = "C:\path\to\tgwsproxy-release.jks"   # or repo-root file
+$env:KEYSTORE_FILE = "C:\path\to\tgwsproxy-release.jks"
 $env:KEYSTORE_PASSWORD = "..."
 $env:KEY_PASSWORD = "..."
 $env:KEY_ALIAS = "tgwsproxy"
 
-.\scripts\build-apk.ps1 -Configuration Release
+.\scripts\release.ps1 -Version v1.10.13
 ```
 
-Gradle output: `app\build\outputs\apk\release\app-release.apk`  
-Script copy: `artifacts\apk\release\tgwsproxy-release.apk`
+The canonical release script:
+
+1. validates the SemVer-like tag;
+2. requires the tag to match `releaseVersionName`;
+3. requires local signing variables and keystore;
+4. builds the release APK through `scripts/build-apk.ps1`;
+5. verifies the APK signature with `apksigner`;
+6. writes exactly two files to `dist/`:
+   - `TgWsProxy-Android-v1.10.13-arm64-v8a.apk`;
+   - `TgWsProxy-Android-v1.10.13-arm64-v8a.apk.sha256`.
+
+Do not publish if signature verification or any preceding check fails.
 
 ## Native library
 
-Release/debug builds run `scripts/build-native-android.ps1` via Gradle `preBuild` (ARM64 `libtgwsproxy.so`).
-
-## Artifacts (gitignored)
-
-| Path | Content |
-|------|---------|
-| `app/build/` | Gradle intermediates and APKs |
-| `artifacts/apk/` | Copied APKs from `build-apk.ps1` |
-| `artifacts/native/` | Built `.so` |
-| `app/src/main/jniLibs/` | Copied `.so` for packaging |
+Release/debug builds run `scripts/build-native-android.ps1` via Gradle `preBuild` and package the ARM64 `libtgwsproxy.so`.
 
 ## Install on device
 
+Debug acceptance build:
+
 ```powershell
-adb install -r artifacts\apk\release\tgwsproxy-release.apk
+adb install -r app\build\outputs\apk\debug\app-debug.apk
 ```
 
-Use `adb install -r` after uninstall if signatures differ (debug vs release).
+Signed release acceptance build:
 
-## Historical release notes
+```powershell
+adb install -r dist\TgWsProxy-Android-v1.10.13-arm64-v8a.apk
+```
+
+Switching between debug and release signatures can be rejected by Android. Do not uninstall an existing app blindly: uninstalling may remove local settings. Confirm signature/data implications first.
+
+## Publication
+
+The owner-controlled release workflow is triggered only after final Issue #7 acceptance. It checks out the exact `v*` tag on the trusted self-hosted Windows/X64 runner, reruns project CI, calls the release script, and publishes the verified APK and SHA-256 only when an existing release with that tag is absent.
 
 Per-version notes: `RELEASE_NOTES_vX.Y.Z.md` in this directory.

--- a/docs/releases/v1.10.13-final-audit.md
+++ b/docs/releases/v1.10.13-final-audit.md
@@ -1,23 +1,88 @@
 # v1.10.13 final release audit
 
-Status: **In progress**.
+Status: **automated audit implemented; manual device/signing acceptance pending**.
 
-Tracks the final release-readiness work from Issue #7 before tagging or publishing `v1.10.13`.
+Tracks Issue #7 before tagging or publishing `v1.10.13`.
 
-## Audit checklist
+## Final source metadata
 
-- [ ] RU/EN localization parity and fallback behavior audited.
-- [ ] Unintended hardcoded user-facing strings removed or documented.
-- [ ] README, CHANGELOG, version docs and release notes match the integrated implementation.
-- [ ] `versionName`, `versionCode`, tag and release artifact naming are consistent for `v1.10.13`.
-- [ ] Private/local governance files remain excluded from Git.
-- [ ] Repository checked for secrets, proxy credentials, signing material, sensitive logs and local environment files.
-- [ ] Project CI passes on the final integrated source.
-- [ ] Documented release build path produces the expected signed APK/artifacts.
-- [ ] Feedback and update-delivery UI/links are rechecked.
-- [ ] Final proxy acceptance passes on Wi-Fi and mobile data, including reconnect/network switching and Telegram messages/media.
-- [ ] Final diff reviewed for unrelated changes.
+- release `versionName`: `1.10.13`
+- release `versionCode`: `51`
+- debug acceptance build: `1.10.13-debug` / `versionCode 52`
+- target tag: `v1.10.13`
+- expected release artifact: `TgWsProxy-Android-v1.10.13-arm64-v8a.apk`
+- expected checksum: `TgWsProxy-Android-v1.10.13-arm64-v8a.apk.sha256`
 
-Do not tag or publish `v1.10.13` until all release-blocking items above are complete or explicitly documented as blockers.
+## Automated audit
+
+`scripts/audit-release.ps1` is executed by `scripts/ci.ps1` and checks:
+
+- release version name/code consistency;
+- README RU/EN source version and canonical repository URLs;
+- CHANGELOG and release-notes version presence;
+- default English ↔ Russian Android string/string-array/plurals resource-key parity;
+- forbidden tracked private governance and local tool-state paths;
+- tracked keystores/private-key/signing extensions, local logs and environment files;
+- common GitHub token/private-key signatures in tracked text;
+- required `.gitignore` protections;
+- heuristic warnings for obvious directly hardcoded Compose/Toast user-facing strings.
+
+Normal project CI continues with Go module verification, native Go tests, Android unit tests, debug APK assembly, and packaged APK resource/icon audit.
+
+## Documentation alignment completed on branch
+
+- README RU/EN now describe source `1.10.13 (51)` as a release candidate instead of claiming it is already published.
+- Old `Regstar2/TgWsProxy_Android` URLs in README RU/EN were replaced with canonical `Regstar2/tg-ws-proxy-android` URLs.
+- Feedback and Updates are documented in both README files.
+- `CHANGELOG.md` includes the full v1.10.13 user-facing scope.
+- `docs/releases/RELEASE_NOTES_v1.10.13.md` is prepared.
+- `docs/releases/release.md` defines `scripts/release.ps1 -Version v1.10.13` as the canonical signed release path.
+- `docs/releases/RELEASE_CHECKLIST.md` was updated for the current MTProto default, port `1443`, Feedback, Updates, RU/EN and final network/runtime acceptance.
+
+## Signed release path
+
+The signed artifact cannot be truthfully validated on public PR CI because release signing material intentionally remains outside GitHub-hosted contributor builds.
+
+The owner must run locally with the configured release keystore:
+
+```powershell
+.\scripts\release.ps1 -Version v1.10.13
+```
+
+The script must:
+
+1. require tag/version equality;
+2. build the signed release APK;
+3. verify the signature with `apksigner`;
+4. produce exactly APK + SHA-256 in `dist/`.
+
+A successful local signed build is still a release blocker until recorded.
+
+## Manual Android acceptance still required
+
+- [ ] Install the final debug acceptance build (`1.10.13-debug`, code `52`) or verified signed release build.
+- [ ] Start / stop / reconnect proxy.
+- [ ] Telegram connects using MTProto frontend on the configured port (default `1443`).
+- [ ] Text messages send/receive.
+- [ ] Images/media load and send where practical.
+- [ ] Proxy works on Wi-Fi.
+- [ ] Proxy works on mobile data.
+- [ ] Wi-Fi → mobile and mobile → Wi-Fi reconfigure without unexpected proxy stop.
+- [ ] Feedback screen/actions work and do not affect running proxy.
+- [ ] Updates screen/manual check/release link/error behavior work and do not affect running proxy.
+- [ ] RU and EN UI are visually reviewed.
+- [ ] Diagnostic/exported data is reviewed for sensitive values.
+- [ ] Issue #6 final acceptance is resolved.
+
+## Publication gate
+
+Do **not** create/push `v1.10.13` or publish the GitHub Release until:
+
+- final PR CI is green;
+- the signed release path succeeds locally;
+- the manual Android checklist above passes;
+- Issue #6 is resolved;
+- Issue #7 acceptance is recorded;
+- final branch diff is reviewed for unrelated changes.
 
 Refs #7

--- a/docs/releases/v1.10.13-final-audit.md
+++ b/docs/releases/v1.10.13-final-audit.md
@@ -1,0 +1,23 @@
+# v1.10.13 final release audit
+
+Status: **In progress**.
+
+Tracks the final release-readiness work from Issue #7 before tagging or publishing `v1.10.13`.
+
+## Audit checklist
+
+- [ ] RU/EN localization parity and fallback behavior audited.
+- [ ] Unintended hardcoded user-facing strings removed or documented.
+- [ ] README, CHANGELOG, version docs and release notes match the integrated implementation.
+- [ ] `versionName`, `versionCode`, tag and release artifact naming are consistent for `v1.10.13`.
+- [ ] Private/local governance files remain excluded from Git.
+- [ ] Repository checked for secrets, proxy credentials, signing material, sensitive logs and local environment files.
+- [ ] Project CI passes on the final integrated source.
+- [ ] Documented release build path produces the expected signed APK/artifacts.
+- [ ] Feedback and update-delivery UI/links are rechecked.
+- [ ] Final proxy acceptance passes on Wi-Fi and mobile data, including reconnect/network switching and Telegram messages/media.
+- [ ] Final diff reviewed for unrelated changes.
+
+Do not tag or publish `v1.10.13` until all release-blocking items above are complete or explicitly documented as blockers.
+
+Refs #7

--- a/docs/versions/v1.10.13.md
+++ b/docs/versions/v1.10.13.md
@@ -1,14 +1,18 @@
 # v1.10.13
 
-Status: **in development**.
+Status: **release candidate / final audit**.
 
-Published baseline: `1.10.12` (`versionCode 50`).
+Source metadata on the Issue #7 branch:
 
-This document describes the planned/in-progress scope for `v1.10.13`. It is not release notes and must not be used as evidence that the full version has shipped.
+- `releaseVersionName = 1.10.13`
+- `releaseVersionCode = 51`
+- debug acceptance variant: `1.10.13-debug` / `versionCode 52`
+- target tag: `v1.10.13`
+- release artifact: `TgWsProxy-Android-v1.10.13-arm64-v8a.apk`
 
-## Goals
+The tag/GitHub Release must not be published until Issue #7 manual acceptance and signed artifact verification are complete.
 
-`v1.10.13` is a single stabilization/release-preparation iteration composed of several independent GitHub Issues:
+## Issue status
 
 | Issue | Area | Status |
 |---|---|---|
@@ -16,113 +20,84 @@ This document describes the planned/in-progress scope for `v1.10.13`. It is not 
 | #3 | Public project structure/documentation alignment | **Completed** |
 | #4 | CI / Project sync / release automation | **Completed** |
 | #5 | In-app feedback + GitHub Issue Forms | **Completed** |
-| #6 | Update delivery through GitHub Releases | **Implemented; manual acceptance pending** |
-| #7 | Final release/localization/compliance audit | Final gate |
+| #6 | Update delivery through GitHub Releases | **Implemented; final manual acceptance pending** |
+| #7 | Final release/localization/compliance audit | **In progress / final gate** |
 
-## Issue #2 — runtime stability / Flowseal parity
+## Runtime stability / Flowseal parity
 
-The runtime task selectively ports relevant upstream behavior while preserving Android-specific routing and diagnostics:
+The release includes:
 
-- bounded MTProto WebSocket fragmentation/continuation reassembly;
+- bounded MTProto WebSocket fragmented/continuation-message reassembly;
 - 16 MiB frame and accumulated-message guards;
 - close-on-rejected/failed MTProto receive paths;
-- Worker session pool misses no longer start duplicate background preconnect refills;
-- Worker preconnect remains disabled by default;
-- regression coverage that Worker failover stops after the first successful candidate;
-- stable Worker ordering no longer uses random UUID ordering for equal creation timestamps;
-- Android-specific route keys, cooldown, watchdog, fake TLS and diagnostics remain intact;
-- disabled/dead upstream 429 Worker reporting is not ported.
+- no duplicate background Worker refill on a session pool miss while foreground dial is already in progress;
+- Worker failover regression coverage that stops after the first successful candidate;
+- stable Worker ordering for equal creation timestamps;
+- reviewed Flowseal changes through `b2a8074` while retaining Android-specific route keys, cooldown, watchdog, Fake TLS and diagnostics behavior.
 
 Detailed comparison: `docs/research/flowseal-upstream-2026-08-24.md`.
 
-Automated validation for the implementation branch completed successfully for native Go tests, Android unit tests and debug APK build. The project owner also reported a successful manual smoke test of the updated proxy build. This closes the scoped upstream/stability task; any future domain/network-specific instability should be opened as a new reproducible issue with diagnostics.
+## Public project / automation
 
-## Issue #3 — public project structure
+The repository includes:
 
-The documentation-alignment task added or refreshed:
+- public product/architecture/testing/release documentation;
+- private governance/AI/tool-state exclusions in `.gitignore`;
+- GitHub-hosted Windows PR CI through `scripts/ci.ps1`;
+- GitHub-hosted Project Sync;
+- owner-controlled self-hosted release/signing workflow;
+- `scripts/release.ps1 -Version vX.Y.Z` with tag/version validation, APK signature verification and SHA-256 artifact output.
 
-- `docs/product/idea.md`;
-- `docs/product/mvp-scope.md`;
-- `docs/product/roadmap.md`;
-- `docs/architecture/tech-stack.md`;
-- repository-structure/testing documentation;
-- `.gitignore` rules for private governance/AI/tool state.
+## Feedback
 
-Private/local files are intentionally not part of the repository:
+**Settings → Feedback / Обратная связь** is a dedicated non-exported screen.
 
-- `AGENTS.md`;
-- `.project-rules/`;
-- `docs/ai-prompts/`;
-- `docs/private/`;
-- `.codex/`, `.cursor/`, `.claude/`, `.ai/`.
+- Report bug and Request feature open this repository's GitHub Issue Forms.
+- No GitHub PAT/write credential is embedded in the Android app.
+- No runtime logs, proxy credentials, Telegram data, IP addresses, domains, routes or secrets are auto-attached.
+- Optional copied context is limited to app version/code, Android release/SDK and manufacturer/model and requires explicit user action.
+- RU/EN resources are provided.
 
-## Issue #4 — GitHub automation
+Issue #5 received manual Android acceptance and is complete.
 
-The automation implementation provides:
+## Update delivery
 
-- `scripts/ci.ps1` as the single project-specific CI entry point;
-- explicit Python build requirements for deterministic icon generation in clean CI environments;
-- public PR CI on GitHub-hosted `windows-latest`, with Java 17 and the Go version from `native/tgwsproxy/go.mod` configured before running `scripts/ci.ps1`;
-- `project-sync.yml` on GitHub-hosted `ubuntu-latest` for repository Issues and Pull Requests, using `ADD_TO_PROJECT_PAT` without executing contributor code;
-- `scripts/release.ps1 -Version vX.Y.Z` for signed APK packaging, APK signature verification and SHA-256 output in `dist/`;
-- owner-gated `release.yml` on the trusted self-hosted Windows/X64 runner, which checks out the exact release tag, reruns CI, builds `dist/` and refuses to overwrite an existing GitHub Release;
-- public automation and smoke-test documentation.
+**Settings → Updates / Обновления** is a dedicated non-exported screen.
 
-Public CI was exercised on PR #12 using a GitHub-hosted Windows Server 2025 image. The successful run completed Go module verification, native Go tests, Android unit tests, debug APK assembly, native library generation, icon generation and packaged-resource audit. The first clean-environment attempt exposed the previously implicit Pillow dependency; it was then declared in the project CI requirements and subsequent runs completed successfully. The latest PR-head validation run was `32838762313` and completed successfully.
+- Installed `versionName` / `versionCode` are displayed.
+- A check starts asynchronously only after opening the Updates screen; a manual check action is also available.
+- Metadata is fetched from the fixed official `Regstar2/tg-ws-proxy-android` GitHub Releases API endpoint with timeouts and a bounded response size.
+- Stable/prerelease comparison follows SemVer precedence; draft/malformed releases are ignored.
+- Release notes are bounded, cleaned from raw Markdown for compact display, and can be expanded/collapsed.
+- The update action constructs only an official repository release URL from a validated SemVer tag.
+- The app does not silently download/install APKs and requests no extra package-install/background-update permission.
+- Update errors remain local UI state and do not stop/reconfigure proxy runtime.
 
-The persistent `REGSTAR` self-hosted runner is no longer used for public PR validation or Project Sync. It remains reserved for the owner-controlled release path while signing material is kept outside the repository checkout.
+Automated unit/build validation is complete; final device acceptance remains part of the Issue #7 gate.
 
-Project Sync was rechecked from `main` after PR #12 was merged. Reopening Issue #4 triggered run `32839138269`; the GitHub-hosted `Add issue or PR to Development project` job completed successfully using the configured Project secret. This verifies the mainline Project Sync path without using the persistent owner runner.
+## Final release audit
 
-Release publication is intentionally not exercised during Issue #4 because doing so would create a real tagged GitHub Release. Release signing and a safe RC/test-tag run remain release-gate work; the release workflow itself is owner-gated and requires release-source CI plus validated `dist/` artifacts before publication.
+Issue #7 adds/updates:
 
-## Issue #5 — in-app feedback
-
-The feedback implementation adds **Feedback / Обратная связь** to the Settings sections list. It opens a dedicated, non-exported in-app screen with separate **Report bug** and **Request feature** actions, explicit back navigation, and optional copying of safe app/device context. Both actions open this repository's GitHub Issue Forms in the browser; the Android application contains no GitHub PAT or other write credential.
-
-Feedback privacy is deliberately opt-in:
-
-- no runtime logs, proxy credentials, Telegram data, IP addresses, domains, route configuration, secrets or diagnostics are attached automatically;
-- the only helper context exposed by the feedback screen is app version/version code, Android release/SDK, and manufacturer/model;
-- that helper context is copied only after an explicit user action, so the user can review it before pasting it into GitHub;
-- the bug and feature Issue Forms contain an explicit public-data warning and required privacy acknowledgement;
-- all new in-app strings are provided in both default English resources and Russian resources.
-
-The dedicated-screen refinement passed the GitHub-hosted project CI on PR #16. The project owner then manually reviewed the installed feedback UX and accepted it as suitable. Issue #5 is therefore complete; further feedback UX changes should be tracked separately.
-
-## Issue #6 — update delivery through GitHub Releases
-
-The update-delivery baseline adds a dedicated **Updates / Обновления** item to the Settings sections list and a non-exported update screen. The screen always shows the installed `versionName` and `versionCode`, checks the official repository's GitHub Releases metadata automatically when opened, and provides an explicit **Check for updates** action.
-
-The implementation is deliberately separated from the proxy startup/runtime path:
-
-- release metadata is fetched only from `api.github.com/repos/Regstar2/tg-ws-proxy-android/releases`;
-- network work runs on `Dispatchers.IO` with explicit connect/read timeouts and a bounded response size;
-- malformed metadata, timeout, DNS/network failures and GitHub API errors become update-screen status only and do not stop or reconfigure the proxy;
-- stable installations ignore prerelease releases, while prerelease/debug installations may advance through prerelease or stable SemVer versions;
-- draft releases and malformed/non-SemVer tags are ignored;
-- SemVer comparison includes prerelease precedence and ignores build metadata for ordering;
-- release notes are displayed in-app with a bounded length;
-- the update action never trusts a download URL from release metadata and constructs only this repository's official `github.com/.../releases/tag/<validated-semver-tag>` page;
-- v1.10.13 does not silently download/install APKs and adds no package-install or background-update permission;
-- all update UI strings are present in default English and Russian resources.
-
-Unit coverage is included for SemVer ordering, stable/prerelease policy, no-update behavior, malformed tags, draft releases and official release URL validation. Manual acceptance on Android still needs to verify the update screen, live GitHub Releases check, offline/error behavior, RU/EN rendering, browser navigation to the official release page, and that a running proxy remains unaffected.
-
-## Versioning rule
-
-Do not treat the integrated release as published until the remaining `v1.10.13` issues and final release gate are complete. README version badges, final release notes/tag and release publication belong to the final integration/release step.
+- source metadata bump to `1.10.13` / `51`;
+- RU/EN README alignment and canonical repository URLs;
+- `docs/releases/RELEASE_NOTES_v1.10.13.md`;
+- canonical signed release procedure through `scripts/release.ps1`;
+- `scripts/audit-release.ps1` for version consistency, localization resource parity, forbidden tracked private/local files, signing material/log/env checks, obsolete repository URLs and common credential signatures;
+- release audit execution from the normal project CI path;
+- updated detailed release checklist for runtime/network/Feedback/Updates/RU-EN/manual acceptance.
 
 ## Release gate
 
-The version can be tagged/published only after:
+Before `v1.10.13` is tagged/published:
 
-- required automated checks pass;
-- a release APK is built through the documented process;
-- proxy behavior is manually verified on Wi-Fi and mobile data;
-- reconnect/network switching and Telegram messages/media are checked;
-- RU/EN localization is audited;
-- release metadata and documentation match the actual integrated code;
-- no private governance files, secrets, signing material or sensitive logs are tracked.
+1. `scripts/ci.ps1` must pass on the final source.
+2. The signed release path `scripts/release.ps1 -Version v1.10.13` must produce and verify the APK + SHA-256 using local signing material.
+3. Final Android acceptance must pass on Wi-Fi and mobile data.
+4. Start/stop/reconnect, Wi-Fi ↔ mobile reconfigure, Telegram messages/media, Feedback and Updates must be checked.
+5. RU/EN must be visually reviewed.
+6. Diagnostic/exported data must be reviewed for sensitive information.
+7. Issue #6 acceptance and Issue #7 final acceptance must be resolved.
+8. The final branch diff must contain no unrelated changes.
 
-See `docs/testing/README.md`, `docs/releases/release.md` and `docs/releases/RELEASE_CHECKLIST.md` for the supporting checklists.
+See `docs/releases/v1.10.13-final-audit.md`, `docs/releases/RELEASE_CHECKLIST.md`, `docs/releases/release.md`, and `docs/testing/README.md`.

--- a/scripts/audit-release.ps1
+++ b/scripts/audit-release.ps1
@@ -1,0 +1,195 @@
+[CmdletBinding()]
+param(
+    [string]$ExpectedVersion = '1.10.13',
+    [int]$ExpectedVersionCode = 51
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location $root
+
+$failures = New-Object System.Collections.Generic.List[string]
+$warnings = New-Object System.Collections.Generic.List[string]
+
+function Add-Failure([string]$Message) {
+    $script:failures.Add($Message)
+}
+
+function Assert-Match {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Pattern,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        Add-Failure "$Description: missing file $Path"
+        return
+    }
+    $text = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+    if ($text -notmatch $Pattern) {
+        Add-Failure "$Description: expected pattern was not found in $Path"
+    }
+}
+
+Write-Host '==> Release metadata consistency'
+$gradlePath = Join-Path $root 'app\build.gradle.kts'
+$gradleText = Get-Content -LiteralPath $gradlePath -Raw -Encoding UTF8
+$versionNameMatch = [regex]::Match($gradleText, 'val\s+releaseVersionName\s*=\s*"([^"]+)"')
+$versionCodeMatch = [regex]::Match($gradleText, 'val\s+releaseVersionCode\s*=\s*(\d+)')
+
+if (-not $versionNameMatch.Success) {
+    Add-Failure 'Could not read releaseVersionName from app/build.gradle.kts.'
+} elseif ($versionNameMatch.Groups[1].Value -ne $ExpectedVersion) {
+    Add-Failure "releaseVersionName is '$($versionNameMatch.Groups[1].Value)', expected '$ExpectedVersion'."
+}
+
+if (-not $versionCodeMatch.Success) {
+    Add-Failure 'Could not read releaseVersionCode from app/build.gradle.kts.'
+} elseif ([int]$versionCodeMatch.Groups[1].Value -ne $ExpectedVersionCode) {
+    Add-Failure "releaseVersionCode is '$($versionCodeMatch.Groups[1].Value)', expected '$ExpectedVersionCode'."
+}
+
+$escapedVersion = [regex]::Escape($ExpectedVersion)
+Assert-Match -Path (Join-Path $root 'README.md') -Pattern "Версия исходников:\*\*\s+`?$escapedVersion`?\s+\(`?versionCode $ExpectedVersionCode`?\)" -Description 'Russian README source version'
+Assert-Match -Path (Join-Path $root 'README_EN.md') -Pattern "Source version:\*\*\s+`?$escapedVersion`?\s+\(`?versionCode $ExpectedVersionCode`?\)" -Description 'English README source version'
+Assert-Match -Path (Join-Path $root 'CHANGELOG.md') -Pattern "(?m)^##\s+(Unreleased\s+—\s+)?$escapedVersion\b" -Description 'CHANGELOG version section'
+Assert-Match -Path (Join-Path $root 'docs\releases\RELEASE_NOTES_v1.10.13.md') -Pattern "versionName`?\*\*?\s*$escapedVersion|versionName.*$escapedVersion" -Description 'Release notes versionName'
+
+foreach ($readme in @('README.md', 'README_EN.md')) {
+    $text = Get-Content -LiteralPath (Join-Path $root $readme) -Raw -Encoding UTF8
+    if ($text -match 'Regstar2/TgWsProxy_Android') {
+        Add-Failure "$readme still contains the obsolete Regstar2/TgWsProxy_Android repository URL."
+    }
+}
+
+Write-Host '==> RU/EN Android resource parity'
+function Get-ResourceNames([string]$Directory) {
+    $set = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+    if (-not (Test-Path -LiteralPath $Directory)) {
+        return $set
+    }
+    Get-ChildItem -LiteralPath $Directory -Filter '*.xml' -File | ForEach-Object {
+        $text = Get-Content -LiteralPath $_.FullName -Raw -Encoding UTF8
+        [regex]::Matches($text, '<(?:string|string-array|plurals)\b[^>]*\bname="([^"]+)"') | ForEach-Object {
+            [void]$set.Add($_.Groups[1].Value)
+        }
+    }
+    return $set
+}
+
+$defaultResources = Get-ResourceNames (Join-Path $root 'app\src\main\res\values')
+$russianResources = Get-ResourceNames (Join-Path $root 'app\src\main\res\values-ru')
+
+$missingRu = @($defaultResources | Where-Object { -not $russianResources.Contains($_) } | Sort-Object)
+$extraRu = @($russianResources | Where-Object { -not $defaultResources.Contains($_) } | Sort-Object)
+if ($missingRu.Count -gt 0) {
+    Add-Failure ('Missing RU resources: ' + ($missingRu -join ', '))
+}
+if ($extraRu.Count -gt 0) {
+    Add-Failure ('RU-only resources without default English fallback: ' + ($extraRu -join ', '))
+}
+Write-Host "Default resources: $($defaultResources.Count); RU resources: $($russianResources.Count)"
+
+Write-Host '==> Tracked private/local/sensitive files'
+$tracked = @(& git ls-files)
+if ($LASTEXITCODE -ne 0) {
+    throw 'git ls-files failed.'
+}
+
+$forbiddenExact = @(
+    'AGENTS.md',
+    'release-signing.env',
+    'debug.keystore',
+    'local.properties'
+)
+$forbiddenPrefixes = @(
+    '.project-rules/',
+    'docs/ai-prompts/',
+    'docs/private/',
+    '.cursor/',
+    '.codex/',
+    '.claude/',
+    '.ai/',
+    'secrets/',
+    'runtime-logs/'
+)
+$sensitiveExtensions = @('.jks', '.keystore', '.p12', '.pfx', '.pem', '.key', '.log')
+
+foreach ($path in $tracked) {
+    $normalized = $path.Replace('\', '/')
+    if ($forbiddenExact -contains $normalized) {
+        Add-Failure "Forbidden tracked local/private file: $normalized"
+    }
+    foreach ($prefix in $forbiddenPrefixes) {
+        if ($normalized.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Add-Failure "Forbidden tracked local/private path: $normalized"
+        }
+    }
+    $extension = [System.IO.Path]::GetExtension($normalized).ToLowerInvariant()
+    if ($sensitiveExtensions -contains $extension) {
+        Add-Failure "Sensitive file extension is tracked: $normalized"
+    }
+    if ($normalized -match '(^|/)\.env($|\.)' -and $normalized -notmatch '\.env\.example$') {
+        Add-Failure "Environment file is tracked: $normalized"
+    }
+    if ($normalized -match '(^|/)installed-v.*\.apk$') {
+        Add-Failure "Locally installed APK copy is tracked: $normalized"
+    }
+}
+
+Write-Host '==> Secret signature scan'
+$tokenPatterns = @(
+    ('g' + 'hp_[A-Za-z0-9]{20,}'),
+    ('github_' + 'pat_[A-Za-z0-9_]{20,}'),
+    ('-----BEGIN ' + '(RSA |EC |OPENSSH )?PRIVATE KEY-----')
+)
+foreach ($pattern in $tokenPatterns) {
+    $matches = @(& git grep -I -n -E -- $pattern 2>$null)
+    if ($LASTEXITCODE -eq 0 -and $matches.Count -gt 0) {
+        Add-Failure ('Potential credential/private-key material found: ' + ($matches -join '; '))
+    }
+}
+
+Write-Host '==> Hardcoded user-facing string heuristic'
+$uiPatterns = @(
+    'Text[[:space:]]*\([[:space:]]*"[^"\n]+"',
+    'contentDescription[[:space:]]*=[[:space:]]*"[^"\n]+"',
+    'Toast\.makeText\([^,]+,[[:space:]]*"[^"\n]+"'
+)
+foreach ($pattern in $uiPatterns) {
+    $matches = @(& git grep -I -n -E -- $pattern -- ':(glob)app/src/main/java/**/*.kt' 2>$null)
+    if ($LASTEXITCODE -eq 0 -and $matches.Count -gt 0) {
+        foreach ($match in $matches) {
+            $warnings.Add("Review possible hardcoded UI string: $match")
+        }
+    }
+}
+
+Write-Host '==> Required .gitignore protections'
+$gitignore = Get-Content -LiteralPath (Join-Path $root '.gitignore') -Raw -Encoding UTF8
+$requiredIgnoreEntries = @(
+    '/AGENTS.md', '/.project-rules/', '/docs/ai-prompts/', '/docs/private/',
+    '/.cursor/', '/.codex/', '/.claude/', '/.ai/', '*.jks', '*.keystore',
+    'release-signing.env', '.env', '*.log', 'dist/'
+)
+foreach ($entry in $requiredIgnoreEntries) {
+    if (-not $gitignore.Contains($entry)) {
+        Add-Failure ".gitignore is missing required protection: $entry"
+    }
+}
+
+if ($warnings.Count -gt 0) {
+    Write-Host "`nRelease audit warnings:"
+    $warnings | Sort-Object -Unique | ForEach-Object { Write-Warning $_ }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "`nRelease audit FAILED:" -ForegroundColor Red
+    $failures | Sort-Object -Unique | ForEach-Object { Write-Host " - $_" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host "`nRelease audit passed for v$ExpectedVersion (versionCode $ExpectedVersionCode)." -ForegroundColor Green

--- a/scripts/audit-release.ps1
+++ b/scripts/audit-release.ps1
@@ -28,6 +28,7 @@ function Assert-Match {
         Add-Failure "${Description}: missing file $Path"
         return
     }
+
     $text = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
     if ($text -notmatch $Pattern) {
         Add-Failure "${Description}: expected pattern was not found in $Path"
@@ -53,9 +54,9 @@ if (-not $versionCodeMatch.Success) {
 }
 
 $escapedVersion = [regex]::Escape($ExpectedVersion)
-Assert-Match -Path (Join-Path $root 'README.md') -Pattern "Версия исходников:.*$escapedVersion.*versionCode\s+$ExpectedVersionCode" -Description 'Russian README source version'
-Assert-Match -Path (Join-Path $root 'README_EN.md') -Pattern "Source version:.*$escapedVersion.*versionCode\s+$ExpectedVersionCode" -Description 'English README source version'
-Assert-Match -Path (Join-Path $root 'CHANGELOG.md') -Pattern "(?m)^##\s+(Unreleased\s+—\s+)?$escapedVersion\b" -Description 'CHANGELOG version section'
+Assert-Match -Path (Join-Path $root 'README.md') -Pattern "`?$escapedVersion`?\s+\(`?versionCode\s+$ExpectedVersionCode`?\)" -Description 'Russian README source version'
+Assert-Match -Path (Join-Path $root 'README_EN.md') -Pattern "`?$escapedVersion`?\s+\(`?versionCode\s+$ExpectedVersionCode`?\)" -Description 'English README source version'
+Assert-Match -Path (Join-Path $root 'CHANGELOG.md') -Pattern "(?m)^##[^\r\n]*$escapedVersion\b" -Description 'CHANGELOG version section'
 Assert-Match -Path (Join-Path $root 'docs\releases\RELEASE_NOTES_v1.10.13.md') -Pattern "versionName.*$escapedVersion" -Description 'Release notes versionName'
 
 foreach ($readme in @('README.md', 'README_EN.md')) {
@@ -71,12 +72,14 @@ function Get-ResourceNames([string]$Directory) {
     if (-not (Test-Path -LiteralPath $Directory)) {
         return $set
     }
+
     Get-ChildItem -LiteralPath $Directory -Filter '*.xml' -File | ForEach-Object {
         $text = Get-Content -LiteralPath $_.FullName -Raw -Encoding UTF8
         [regex]::Matches($text, '<(?:string|string-array|plurals)\b[^>]*\bname="([^"]+)"') | ForEach-Object {
             [void]$set.Add($_.Groups[1].Value)
         }
     }
+
     return $set
 }
 
@@ -85,12 +88,14 @@ $russianResources = Get-ResourceNames (Join-Path $root 'app\src\main\res\values-
 
 $missingRu = @($defaultResources | Where-Object { -not $russianResources.Contains($_) } | Sort-Object)
 $extraRu = @($russianResources | Where-Object { -not $defaultResources.Contains($_) } | Sort-Object)
+
 if ($missingRu.Count -gt 0) {
     Add-Failure ('Missing RU resources: ' + ($missingRu -join ', '))
 }
 if ($extraRu.Count -gt 0) {
     Add-Failure ('RU-only resources without default English fallback: ' + ($extraRu -join ', '))
 }
+
 Write-Host "Default resources: $($defaultResources.Count); RU resources: $($russianResources.Count)"
 
 Write-Host '==> Tracked private/local/sensitive files'
@@ -120,14 +125,17 @@ $sensitiveExtensions = @('.jks', '.keystore', '.p12', '.pfx', '.pem', '.key', '.
 
 foreach ($path in $tracked) {
     $normalized = $path.Replace('\', '/')
+
     if ($forbiddenExact -contains $normalized) {
         Add-Failure "Forbidden tracked local/private file: $normalized"
     }
+
     foreach ($prefix in $forbiddenPrefixes) {
         if ($normalized.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
             Add-Failure "Forbidden tracked local/private path: $normalized"
         }
     }
+
     $extension = [System.IO.Path]::GetExtension($normalized).ToLowerInvariant()
     if ($sensitiveExtensions -contains $extension) {
         Add-Failure "Sensitive file extension is tracked: $normalized"
@@ -146,6 +154,7 @@ $tokenPatterns = @(
     ('github_' + 'pat_[A-Za-z0-9_]{20,}'),
     ('-----BEGIN ' + '(RSA |EC |OPENSSH )?PRIVATE KEY-----')
 )
+
 foreach ($pattern in $tokenPatterns) {
     $matches = @(& git grep -I -n -E -- $pattern 2>$null)
     if ($LASTEXITCODE -eq 0 -and $matches.Count -gt 0) {
@@ -159,6 +168,7 @@ $uiPatterns = @(
     'contentDescription[[:space:]]*=[[:space:]]*"[^"\n]+"',
     'Toast\.makeText\([^,]+,[[:space:]]*"[^"\n]+"'
 )
+
 foreach ($pattern in $uiPatterns) {
     $matches = @(& git grep -I -n -E -- $pattern -- ':(glob)app/src/main/java/**/*.kt' 2>$null)
     if ($LASTEXITCODE -eq 0 -and $matches.Count -gt 0) {
@@ -171,10 +181,22 @@ foreach ($pattern in $uiPatterns) {
 Write-Host '==> Required .gitignore protections'
 $gitignore = Get-Content -LiteralPath (Join-Path $root '.gitignore') -Raw -Encoding UTF8
 $requiredIgnoreEntries = @(
-    '/AGENTS.md', '/.project-rules/', '/docs/ai-prompts/', '/docs/private/',
-    '/.cursor/', '/.codex/', '/.claude/', '/.ai/', '*.jks', '*.keystore',
-    'release-signing.env', '.env', '*.log', 'dist/'
+    '/AGENTS.md',
+    '/.project-rules/',
+    '/docs/ai-prompts/',
+    '/docs/private/',
+    '/.cursor/',
+    '/.codex/',
+    '/.claude/',
+    '/.ai/',
+    '*.jks',
+    '*.keystore',
+    'release-signing.env',
+    '.env',
+    '*.log',
+    'dist/'
 )
+
 foreach ($entry in $requiredIgnoreEntries) {
     if (-not $gitignore.Contains($entry)) {
         Add-Failure ".gitignore is missing required protection: $entry"
@@ -188,7 +210,9 @@ if ($warnings.Count -gt 0) {
 
 if ($failures.Count -gt 0) {
     Write-Host "`nRelease audit FAILED:" -ForegroundColor Red
-    $failures | Sort-Object -Unique | ForEach-Object { Write-Host " - $_" -ForegroundColor Red }
+    $failures | Sort-Object -Unique | ForEach-Object {
+        Write-Host " - $_" -ForegroundColor Red
+    }
     exit 1
 }
 

--- a/scripts/audit-release.ps1
+++ b/scripts/audit-release.ps1
@@ -45,7 +45,8 @@ function Get-NormalizedMarkdownText {
     }
 
     $text = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
-    return $text.Replace([char]96, '').Replace('*', '')
+    $backtick = ([char]96).ToString()
+    return $text.Replace($backtick, '').Replace('*', '')
 }
 
 function Assert-NormalizedContains {

--- a/scripts/audit-release.ps1
+++ b/scripts/audit-release.ps1
@@ -155,7 +155,7 @@ foreach ($pattern in $tokenPatterns) {
 
 Write-Host '==> Hardcoded user-facing string heuristic'
 $uiPatterns = @(
-    'Text[[:space:]]*\([[:space:]]*"[^"\n]+"',
+    '(^|[^[:alnum:]_])Text[[:space:]]*\([[:space:]]*"[^"\n]+"',
     'contentDescription[[:space:]]*=[[:space:]]*"[^"\n]+"',
     'Toast\.makeText\([^,]+,[[:space:]]*"[^"\n]+"'
 )
@@ -193,3 +193,4 @@ if ($failures.Count -gt 0) {
 }
 
 Write-Host "`nRelease audit passed for v$ExpectedVersion (versionCode $ExpectedVersionCode)." -ForegroundColor Green
+exit 0

--- a/scripts/audit-release.ps1
+++ b/scripts/audit-release.ps1
@@ -25,12 +25,12 @@ function Assert-Match {
     )
 
     if (-not (Test-Path -LiteralPath $Path)) {
-        Add-Failure "$Description: missing file $Path"
+        Add-Failure "${Description}: missing file $Path"
         return
     }
     $text = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
     if ($text -notmatch $Pattern) {
-        Add-Failure "$Description: expected pattern was not found in $Path"
+        Add-Failure "${Description}: expected pattern was not found in $Path"
     }
 }
 
@@ -53,10 +53,10 @@ if (-not $versionCodeMatch.Success) {
 }
 
 $escapedVersion = [regex]::Escape($ExpectedVersion)
-Assert-Match -Path (Join-Path $root 'README.md') -Pattern "Версия исходников:\*\*\s+`?$escapedVersion`?\s+\(`?versionCode $ExpectedVersionCode`?\)" -Description 'Russian README source version'
-Assert-Match -Path (Join-Path $root 'README_EN.md') -Pattern "Source version:\*\*\s+`?$escapedVersion`?\s+\(`?versionCode $ExpectedVersionCode`?\)" -Description 'English README source version'
+Assert-Match -Path (Join-Path $root 'README.md') -Pattern "Версия исходников:.*$escapedVersion.*versionCode\s+$ExpectedVersionCode" -Description 'Russian README source version'
+Assert-Match -Path (Join-Path $root 'README_EN.md') -Pattern "Source version:.*$escapedVersion.*versionCode\s+$ExpectedVersionCode" -Description 'English README source version'
 Assert-Match -Path (Join-Path $root 'CHANGELOG.md') -Pattern "(?m)^##\s+(Unreleased\s+—\s+)?$escapedVersion\b" -Description 'CHANGELOG version section'
-Assert-Match -Path (Join-Path $root 'docs\releases\RELEASE_NOTES_v1.10.13.md') -Pattern "versionName`?\*\*?\s*$escapedVersion|versionName.*$escapedVersion" -Description 'Release notes versionName'
+Assert-Match -Path (Join-Path $root 'docs\releases\RELEASE_NOTES_v1.10.13.md') -Pattern "versionName.*$escapedVersion" -Description 'Release notes versionName'
 
 foreach ($readme in @('README.md', 'README_EN.md')) {
     $text = Get-Content -LiteralPath (Join-Path $root $readme) -Raw -Encoding UTF8

--- a/scripts/audit-release.ps1
+++ b/scripts/audit-release.ps1
@@ -35,6 +35,37 @@ function Assert-Match {
     }
 }
 
+function Get-NormalizedMarkdownText {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $null
+    }
+
+    $text = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+    return $text.Replace([char]96, '').Replace('*', '')
+}
+
+function Assert-NormalizedContains {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$ExpectedText,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+
+    $text = Get-NormalizedMarkdownText -Path $Path
+    if ($null -eq $text) {
+        Add-Failure "${Description}: missing file $Path"
+        return
+    }
+
+    if (-not $text.Contains($ExpectedText)) {
+        Add-Failure "${Description}: expected text '$ExpectedText' was not found in $Path"
+    }
+}
+
 Write-Host '==> Release metadata consistency'
 $gradlePath = Join-Path $root 'app\build.gradle.kts'
 $gradleText = Get-Content -LiteralPath $gradlePath -Raw -Encoding UTF8
@@ -53,11 +84,16 @@ if (-not $versionCodeMatch.Success) {
     Add-Failure "releaseVersionCode is '$($versionCodeMatch.Groups[1].Value)', expected '$ExpectedVersionCode'."
 }
 
+$versionSummary = "$ExpectedVersion (versionCode $ExpectedVersionCode)"
+Assert-NormalizedContains -Path (Join-Path $root 'README.md') -ExpectedText $versionSummary -Description 'Russian README source version'
+Assert-NormalizedContains -Path (Join-Path $root 'README_EN.md') -ExpectedText $versionSummary -Description 'English README source version'
+
 $escapedVersion = [regex]::Escape($ExpectedVersion)
-Assert-Match -Path (Join-Path $root 'README.md') -Pattern "`?$escapedVersion`?\s+\(`?versionCode\s+$ExpectedVersionCode`?\)" -Description 'Russian README source version'
-Assert-Match -Path (Join-Path $root 'README_EN.md') -Pattern "`?$escapedVersion`?\s+\(`?versionCode\s+$ExpectedVersionCode`?\)" -Description 'English README source version'
 Assert-Match -Path (Join-Path $root 'CHANGELOG.md') -Pattern "(?m)^##[^\r\n]*$escapedVersion\b" -Description 'CHANGELOG version section'
-Assert-Match -Path (Join-Path $root 'docs\releases\RELEASE_NOTES_v1.10.13.md') -Pattern "versionName.*$escapedVersion" -Description 'Release notes versionName'
+
+$releaseNotesPath = Join-Path $root 'docs\releases\RELEASE_NOTES_v1.10.13.md'
+Assert-NormalizedContains -Path $releaseNotesPath -ExpectedText "versionName $ExpectedVersion" -Description 'Release notes versionName'
+Assert-NormalizedContains -Path $releaseNotesPath -ExpectedText "versionCode $ExpectedVersionCode" -Description 'Release notes versionCode'
 
 foreach ($readme in @('README.md', 'README_EN.md')) {
     $text = Get-Content -LiteralPath (Join-Path $root $readme) -Raw -Encoding UTF8

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -51,6 +51,17 @@ if (-not (Test-Path $pythonRequirements)) {
     throw "Python CI requirements not found: $pythonRequirements"
 }
 
+$releaseAudit = Join-Path $PSScriptRoot 'audit-release.ps1'
+if (-not (Test-Path $releaseAudit)) {
+    throw "Release audit script not found: $releaseAudit"
+}
+
+Write-Host "`n==> Audit release metadata, localization and tracked private files"
+& $releaseAudit -ExpectedVersion '1.10.13' -ExpectedVersionCode 51
+if ($LASTEXITCODE -ne 0) {
+    throw "Release audit failed with exit code $LASTEXITCODE."
+}
+
 Invoke-CheckedCommand -Label 'Install Python build dependencies' -FilePath $pythonLauncher.Source -Arguments @('-3', '-m', 'pip', 'install', '--disable-pip-version-check', '--requirement', $pythonRequirements)
 Invoke-CheckedCommand -Label 'Verify Go module' -FilePath $go.Source -Arguments @('mod', 'verify') -WorkingDirectory $nativeDir
 Invoke-CheckedCommand -Label 'Run native Go tests' -FilePath $go.Source -Arguments @('test', './...') -WorkingDirectory $nativeDir

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -36,6 +36,7 @@ function Invoke-CheckedCommand {
 
 $go = Get-Command go -ErrorAction Stop
 $pythonLauncher = Get-Command py -ErrorAction Stop
+$windowsPowerShell = Get-Command powershell.exe -ErrorAction Stop
 $gradle = Join-Path $root 'gradlew.bat'
 if (-not (Test-Path $gradle)) {
     throw "Gradle wrapper not found: $gradle"
@@ -66,6 +67,17 @@ Write-Host "`n==> Audit release metadata, localization and tracked private files
 if ($LASTEXITCODE -ne 0) {
     throw "Release audit failed with exit code $LASTEXITCODE."
 }
+
+Invoke-CheckedCommand `
+    -Label 'Validate release audit under Windows PowerShell 5.1' `
+    -FilePath $windowsPowerShell.Source `
+    -Arguments @(
+        '-NoProfile',
+        '-ExecutionPolicy', 'Bypass',
+        '-File', $releaseAudit,
+        '-ExpectedVersion', '1.10.13',
+        '-ExpectedVersionCode', '51'
+    )
 
 Write-Host "`n==> Validate release-script metadata preflight"
 & $releaseScript -Version 'v1.10.13' -PreflightOnly

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -56,10 +56,21 @@ if (-not (Test-Path $releaseAudit)) {
     throw "Release audit script not found: $releaseAudit"
 }
 
+$releaseScript = Join-Path $PSScriptRoot 'release.ps1'
+if (-not (Test-Path $releaseScript)) {
+    throw "Release script not found: $releaseScript"
+}
+
 Write-Host "`n==> Audit release metadata, localization and tracked private files"
 & $releaseAudit -ExpectedVersion '1.10.13' -ExpectedVersionCode 51
 if ($LASTEXITCODE -ne 0) {
     throw "Release audit failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "`n==> Validate release-script metadata preflight"
+& $releaseScript -Version 'v1.10.13' -PreflightOnly
+if ($LASTEXITCODE -ne 0) {
+    throw "Release-script preflight failed with exit code $LASTEXITCODE."
 }
 
 Invoke-CheckedCommand -Label 'Install Python build dependencies' -FilePath $pythonLauncher.Source -Arguments @('-3', '-m', 'pip', 'install', '--disable-pip-version-check', '--requirement', $pythonRequirements)

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -35,7 +35,7 @@ $expectedVersionCode = [int]$versionCodeMatch.Groups[1].Value
 
 $releaseNotes = Join-Path $root ("docs\releases\RELEASE_NOTES_$Version.md")
 if (-not (Test-Path $releaseNotes)) {
-    throw "Release notes were not found for $Version: $releaseNotes"
+    throw "Release notes were not found for ${Version}: $releaseNotes"
 }
 
 $artifactName = "TgWsProxy-Android-$Version-arm64-v8a.apk"

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -2,7 +2,9 @@
 param(
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
-    [string]$Version
+    [string]$Version,
+
+    [switch]$PreflightOnly
 )
 
 Set-StrictMode -Version Latest
@@ -30,6 +32,19 @@ if ($versionMatch.Groups[1].Value -ne $versionName) {
     throw "Release tag $Version does not match app releaseVersionName '$($versionMatch.Groups[1].Value)'."
 }
 $expectedVersionCode = [int]$versionCodeMatch.Groups[1].Value
+
+$releaseNotes = Join-Path $root ("docs\releases\RELEASE_NOTES_$Version.md")
+if (-not (Test-Path $releaseNotes)) {
+    throw "Release notes were not found for $Version: $releaseNotes"
+}
+
+$artifactName = "TgWsProxy-Android-$Version-arm64-v8a.apk"
+Write-Host "Release metadata preflight: tag=$Version versionName=$versionName versionCode=$expectedVersionCode artifact=$artifactName"
+
+if ($PreflightOnly) {
+    Write-Host 'Release metadata preflight passed.'
+    exit 0
+}
 
 $signingLoader = Join-Path $PSScriptRoot 'load-release-signing.ps1'
 if (Test-Path $signingLoader) {
@@ -123,7 +138,6 @@ if ($LASTEXITCODE -ne 0) {
     throw "APK signature verification failed with exit code $LASTEXITCODE."
 }
 
-$artifactName = "TgWsProxy-Android-$Version-arm64-v8a.apk"
 $artifactPath = Join-Path $dist $artifactName
 Copy-Item -Force $sourceApk $artifactPath
 

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -18,13 +18,18 @@ if ($Version -notmatch '^v\d+\.\d+\.\d+([-.][0-9A-Za-z.-]+)?$') {
 $versionName = $Version.Substring(1)
 $gradleFile = Join-Path $root 'app\build.gradle.kts'
 $gradleText = Get-Content $gradleFile -Raw -Encoding UTF8
-$versionMatch = [regex]::Match($gradleText, 'versionName\s*=\s*"([^"]+)"')
+$versionMatch = [regex]::Match($gradleText, 'val\s+releaseVersionName\s*=\s*"([^"]+)"')
+$versionCodeMatch = [regex]::Match($gradleText, 'val\s+releaseVersionCode\s*=\s*(\d+)')
 if (-not $versionMatch.Success) {
-    throw 'Could not read versionName from app/build.gradle.kts.'
+    throw 'Could not read releaseVersionName from app/build.gradle.kts.'
+}
+if (-not $versionCodeMatch.Success) {
+    throw 'Could not read releaseVersionCode from app/build.gradle.kts.'
 }
 if ($versionMatch.Groups[1].Value -ne $versionName) {
-    throw "Release tag $Version does not match app versionName '$($versionMatch.Groups[1].Value)'."
+    throw "Release tag $Version does not match app releaseVersionName '$($versionMatch.Groups[1].Value)'."
 }
+$expectedVersionCode = [int]$versionCodeMatch.Groups[1].Value
 
 $signingLoader = Join-Path $PSScriptRoot 'load-release-signing.ps1'
 if (Test-Path $signingLoader) {
@@ -81,7 +86,7 @@ if ([string]::IsNullOrWhiteSpace($sdkRoot) -and (Test-Path 'C:\Android\SDK')) {
     $sdkRoot = 'C:\Android\SDK'
 }
 if ([string]::IsNullOrWhiteSpace($sdkRoot) -or -not (Test-Path $sdkRoot)) {
-    throw 'Android SDK root is not configured; apksigner is required for release verification.'
+    throw 'Android SDK root is not configured; aapt/apksigner are required for release verification.'
 }
 
 $buildToolsRoot = Join-Path $sdkRoot 'build-tools'
@@ -91,6 +96,26 @@ $apksigner = Get-ChildItem $buildToolsRoot -Recurse -Filter 'apksigner.bat' -Fil
 if (-not $apksigner) {
     throw "apksigner.bat was not found under $buildToolsRoot."
 }
+
+$aapt = Get-ChildItem $buildToolsRoot -Recurse -Filter 'aapt.exe' -File -ErrorAction SilentlyContinue |
+    Sort-Object FullName -Descending |
+    Select-Object -First 1
+if (-not $aapt) {
+    throw "aapt.exe was not found under $buildToolsRoot."
+}
+
+Write-Host '==> Verify APK package/version metadata'
+$badgingLines = @(& $aapt.FullName dump badging $sourceApk)
+if ($LASTEXITCODE -ne 0) {
+    throw "aapt dump badging failed with exit code $LASTEXITCODE."
+}
+$badging = $badgingLines -join "`n"
+$escapedVersionName = [regex]::Escape($versionName)
+$escapedVersionCode = [regex]::Escape($expectedVersionCode.ToString())
+if ($badging -notmatch "package:\s+name='com\.amurcanov\.tgwsproxy'.*versionCode='$escapedVersionCode'.*versionName='$escapedVersionName'") {
+    throw "Release APK metadata mismatch. Expected com.amurcanov.tgwsproxy versionName=$versionName versionCode=$expectedVersionCode."
+}
+Write-Host "Verified package metadata: versionName=$versionName versionCode=$expectedVersionCode"
 
 Write-Host '==> Verify APK signature'
 & $apksigner.FullName verify --verbose --print-certs $sourceApk


### PR DESCRIPTION
Implements the automatable part of Issue #7 and prepares the final v1.10.13 release candidate.

Changes:
- bumps release source metadata to `1.10.13` / `versionCode 51` (debug acceptance becomes `1.10.13-debug` / code `52`);
- aligns README RU/EN with the release candidate and canonical `Regstar2/tg-ws-proxy-android` URLs;
- documents Feedback and GitHub Releases update delivery in public docs;
- completes the v1.10.13 CHANGELOG scope;
- adds `docs/releases/RELEASE_NOTES_v1.10.13.md`;
- makes `scripts/release.ps1 -Version v1.10.13` the documented canonical signed release path;
- updates the detailed release checklist for current MTProto/1443, Wi-Fi/mobile, Feedback, Updates, RU/EN and privacy checks;
- adds `scripts/audit-release.ps1` for version consistency, RU/EN resource parity, obsolete repo URLs, tracked private/local files, signing/log/env material, common credential signatures and hardcoded-UI heuristics;
- runs the release audit from the normal `scripts/ci.ps1` path.

This PR must not publish/tag v1.10.13. Public CI cannot validate the private signing keystore by design. After green CI, manual device acceptance and a local signed `scripts/release.ps1 -Version v1.10.13` run remain release blockers.

Refs #7