### PR TITLE
docs: finalize v1.10.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-# Changelog
+﻿# Changelog
 
 All notable user-facing changes are listed here. Detailed notes for older releases: [docs/releases/](docs/releases/).
 
-## Unreleased — 1.10.13
-
+## 1.10.13 - 2026-08-26
 - MTProto WebSocket receive path now reassembles fragmented/continuation messages instead of dropping continuation frames.
 - Added 16 MiB protection for individual WebSocket frames and accumulated fragmented messages before payload allocation/delivery.
 - Failed/rejected MTProto WebSocket receive paths close the underlying connection.
@@ -149,3 +148,4 @@ All notable user-facing changes are listed here. Detailed notes for older releas
 - “Recommended” preset in route policy UI.
 
 Earlier versions: see [docs/releases/](docs/releases/).
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+﻿<div align="center">
 
 <img src="icon.png" width="128" alt="Иконка приложения TgWsProxy">
 
@@ -323,3 +323,4 @@ app\build\outputs\apk\debug\app-debug.apk
 ## Лицензия
 
 Проект распространяется по лицензии [GNU General Public License v3.0](LICENSE).
+

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,4 +1,4 @@
-<div align="center">
+﻿<div align="center">
 
 <img src="icon.png" width="128" alt="TgWsProxy application icon">
 
@@ -323,3 +323,4 @@ AI tools were used for selected parts of the code, tests, and documentation. The
 ## License
 
 The project is distributed under the [GNU General Public License v3.0](LICENSE).
+

--- a/docs/releases/RELEASE_NOTES_v1.10.13.md
+++ b/docs/releases/RELEASE_NOTES_v1.10.13.md
@@ -1,50 +1,146 @@
-# TgWsProxy Android v1.10.13
+﻿# TgWsProxy Android v1.10.13
+
+Релиз сосредоточен на стабильности proxy runtime, синхронизации актуальных методов работы с Flowseal и подготовке Android-приложения к более безопасным последующим обновлениям.
+
+Основной сценарий остаётся прежним:
+
+`Telegram → MTProto Proxy 127.0.0.1:1443 → Cloudflare Proxy → Telegram DC`
 
 `versionName` **1.10.13** · `versionCode` **51** · ABI **arm64-v8a**
 
 ## Главное
 
-- Стабилизирован MTProto WebSocket receive path: continuation/fragmented frames теперь собираются корректно, а размер отдельных и накопленных сообщений ограничен 16 MiB.
-- Worker failover и session-pool поведение усилены тестами; miss больше не запускает дублирующий background refill при уже выполняющемся foreground dial.
-- Синхронизированы релевантные изменения Flowseal с сохранением Android-специфичной маршрутизации, Fake TLS, watchdog и диагностики.
-- Добавлен отдельный экран **Обратная связь** с GitHub Issue Forms без встроенного GitHub PAT.
-- Добавлен отдельный экран **Обновления**: асинхронная проверка официальных GitHub Releases, SemVer stable/prerelease policy, release notes и переход только на официальный release URL.
-- Экран обновлений не скачивает и не устанавливает APK автоматически и не запрашивает дополнительные install/background permissions.
-- Публичная CI переведена на GitHub-hosted Windows; persistent self-hosted runner оставлен только для owner-controlled release/signing path.
-- Добавлены Project Sync, release automation, release signing verification и SHA-256 artifact generation.
-- Публичная структура и документация приведены к актуальным правилам проекта; private governance/AI/tool state исключены из Git.
+- Исправлена обработка fragmented WebSocket-сообщений в MTProto runtime.
+- Continuation frames теперь корректно собираются в единое сообщение.
+- Добавлено ограничение **16 MiB** для отдельных WebSocket frames и собранных fragmented messages.
+- При ошибках и отклонённых WS-сообщениях underlying connection корректно закрывается.
+- Улучшены Worker failover и session pool.
+- Worker failover гарантированно останавливается после первого успешного endpoint.
+- Исправлен лишний background refill Worker pool при уже выполняющемся foreground connection.
+- При одинаковом времени создания Worker порядок остаётся стабильным вместо случайного UUID-порядка.
 
-## Update delivery
+## Синхронизация с Flowseal
 
-В **Настройки → Обновления** отображается установленная версия и выполняется безопасная проверка `Regstar2/tg-ws-proxy-android` Releases.
+Проведён отдельный аудит актуального `Flowseal/tg-ws-proxy` вплоть до upstream commit `b2a8074`.
 
-При наличии более новой подходящей версии приложение показывает краткое описание релиза и предлагает открыть официальную страницу GitHub Release. Сетевые, timeout, API и malformed-metadata ошибки остаются локальным состоянием экрана и не должны останавливать или перенастраивать proxy runtime.
+В Android runtime перенесены применимые изменения:
 
-## Feedback
+- WebSocket fragmentation / continuation handling;
+- bounded WebSocket receive path;
+- 16 MiB frame/message guards;
+- Worker first-success behavior;
+- безопасная часть обновлённой Worker pool semantics.
 
-В **Настройки → Обратная связь** доступны отдельные действия **Сообщить об ошибке** и **Предложить функцию**. Приложение автоматически не прикладывает runtime logs, proxy credentials, Telegram data, IP-адреса или secrets. Копирование app/device context выполняется только по явному действию пользователя.
+Android-специфичная логика сохранена там, где прямой перенос Flowseal мог изменить поведение приложения:
 
-## Runtime
+- route policies для Wi-Fi и mobile data;
+- adaptive routing;
+- CF-domain health/cooldown;
+- Android Worker destination/media logic;
+- watchdog;
+- Fake TLS;
+- diagnostics.
 
-Основной сценарий остаётся **MTProto Proxy → Cloudflare Proxy** через локальный endpoint `127.0.0.1:1443`.
+Flowseal остаётся reference upstream для proxy runtime, а платформенный слой реализуется отдельно для Android.
 
-Worker Pool остаётся необязательным и более медленным development/diagnostics path. `direct_ws` и `tcp_fallback` сохраняются как разрешаемые политикой альтернативы.
+## Обратная связь
 
-## Безопасность релиза
+Добавлен отдельный экран:
 
-- Release signing material не хранится в Git.
-- `scripts/release.ps1 -Version v1.10.13` требует локально настроенные signing variables/keystore, проверяет подпись APK и формирует APK + SHA-256 в `dist/`.
-- GitHub Release должен публиковаться только после финального manual acceptance Issue #7.
+**Настройки → Обратная связь**
 
-## Перед публикацией
+Доступны:
 
-Обязательная ручная проверка финальной сборки:
+- **Сообщить об ошибке**
+- **Предложить функцию**
 
-- MTProto proxy start/stop/reconnect;
-- Telegram messages и media;
-- Wi-Fi и mobile data;
-- Wi-Fi ↔ mobile reconfigure;
-- Feedback и Updates;
-- RU/EN;
-- diagnostic export на отсутствие чувствительных данных;
-- signed release artifact и SHA-256.
+Используются официальные GitHub Issue Forms.
+
+Приложение не содержит встроенного GitHub PAT и автоматически не отправляет:
+
+- runtime logs;
+- proxy credentials;
+- Telegram data;
+- IP-адреса;
+- secrets.
+
+Безопасный app/device context копируется только по явному действию пользователя.
+
+## Обновления
+
+Добавлен экран:
+
+**Настройки → Обновления**
+
+Приложение умеет:
+
+- асинхронно проверять официальный GitHub Releases feed;
+- сравнивать версии по SemVer;
+- корректно учитывать stable/prerelease;
+- показывать доступную версию и release notes;
+- открывать только официальную страницу релиза `Regstar2/tg-ws-proxy-android`.
+
+Release notes отображаются в компактном читаемом виде с возможностью раскрыть полное описание.
+
+Проверка обновлений:
+
+- не скачивает APK автоматически;
+- не устанавливает APK автоматически;
+- не требует дополнительных install permissions;
+- не влияет на запуск и работу proxy runtime.
+
+## CI и выпуск
+
+Инфраструктура проекта переработана:
+
+- публичные Pull Requests проверяются на GitHub-hosted Windows;
+- Project Sync выполняется на GitHub-hosted runner;
+- persistent self-hosted runner оставлен только для owner-controlled release/signing;
+- добавлена проверка release metadata;
+- добавлена проверка RU/EN localization parity;
+- проверяется отсутствие private/local файлов и signing material в Git;
+- добавлен поиск типовых credential/private-key signatures;
+- release APK проверяется перед публикацией;
+- для release artifact формируется SHA-256.
+
+Release signing material и keystore не хранятся в репозитории.
+
+## Текущие маршруты
+
+Поддерживаются:
+
+- `cf_proxy_ws` — основной рекомендуемый маршрут;
+- `direct_ws`;
+- `cf_worker_ws`;
+- `tcp_fallback`.
+
+MTProto Proxy остаётся основным local frontend.
+
+SOCKS5/WebSocket сохранён как compatibility mode.
+
+## Known issues
+
+**Worker Pool** всё ещё заметно медленнее основного Cloudflare Proxy path и остаётся дополнительным/диагностическим режимом.
+
+Доступность `direct_ws`, `cf_proxy_ws` и `tcp_fallback` зависит от конкретной сети и ограничений провайдера.
+
+Приложение не является системным VPN и проксирует только трафик, который Telegram направляет на локальный proxy frontend.
+
+## Проверено
+
+- native Go tests;
+- Android unit tests;
+- debug APK build;
+- release/compliance audit;
+- RU/EN resource parity;
+- Windows PowerShell 5.1 release audit;
+- GitHub-hosted Windows CI;
+- установка Android debug build;
+- MTProto proxy;
+- Telegram messages/media;
+- reconnect;
+- Feedback / Updates screens.
+
+---
+
+Следующий этап разработки — дальнейшее сближение Android proxy paths с актуальной реализацией Flowseal при сохранении Android-specific lifecycle и network policy.

--- a/docs/releases/v1.10.13-final-audit.md
+++ b/docs/releases/v1.10.13-final-audit.md
@@ -1,6 +1,6 @@
-# v1.10.13 final release audit
+﻿# v1.10.13 final release audit
 
-Status: **automated audit implemented; manual device/signing acceptance pending**.
+Status: **manual device acceptance complete; signed release path verified locally**.
 
 Tracks Issue #7 before tagging or publishing `v1.10.13`.
 
@@ -56,23 +56,23 @@ The script must:
 3. verify the signature with `apksigner`;
 4. produce exactly APK + SHA-256 in `dist/`.
 
-A successful local signed build is still a release blocker until recorded.
+The local signed release path completed successfully before publication.
 
-## Manual Android acceptance still required
+## Manual Android acceptance completed
 
-- [ ] Install the final debug acceptance build (`1.10.13-debug`, code `52`) or verified signed release build.
-- [ ] Start / stop / reconnect proxy.
-- [ ] Telegram connects using MTProto frontend on the configured port (default `1443`).
-- [ ] Text messages send/receive.
-- [ ] Images/media load and send where practical.
-- [ ] Proxy works on Wi-Fi.
-- [ ] Proxy works on mobile data.
-- [ ] Wi-Fi → mobile and mobile → Wi-Fi reconfigure without unexpected proxy stop.
-- [ ] Feedback screen/actions work and do not affect running proxy.
-- [ ] Updates screen/manual check/release link/error behavior work and do not affect running proxy.
-- [ ] RU and EN UI are visually reviewed.
-- [ ] Diagnostic/exported data is reviewed for sensitive values.
-- [ ] Issue #6 final acceptance is resolved.
+- [x] Install the final debug acceptance build (`1.10.13-debug`, code `52`) or verified signed release build.
+- [x] Start / stop / reconnect proxy.
+- [x] Telegram connects using MTProto frontend on the configured port (default `1443`).
+- [x] Text messages send/receive.
+- [x] Images/media load and send where practical.
+- [x] Proxy works on Wi-Fi.
+- [x] Proxy works on mobile data.
+- [x] Wi-Fi → mobile and mobile → Wi-Fi reconfigure without unexpected proxy stop.
+- [x] Feedback screen/actions work and do not affect running proxy.
+- [x] Updates screen/manual check/release link/error behavior work and do not affect running proxy.
+- [x] RU and EN UI are visually reviewed.
+- [x] Diagnostic/exported data is reviewed for sensitive values.
+- [x] Issue #6 final acceptance is resolved.
 
 ## Publication gate
 
@@ -86,3 +86,4 @@ Do **not** create/push `v1.10.13` or publish the GitHub Release until:
 - final branch diff is reviewed for unrelated changes.
 
 Refs #7
+

--- a/docs/versions/v1.10.13.md
+++ b/docs/versions/v1.10.13.md
@@ -1,8 +1,8 @@
-# v1.10.13
+﻿# v1.10.13
 
-Status: **release candidate / final audit**.
+Status: **stable release / final acceptance complete**.
 
-Source metadata on the Issue #7 branch:
+Release metadata:
 
 - `releaseVersionName = 1.10.13`
 - `releaseVersionCode = 51`
@@ -10,7 +10,7 @@ Source metadata on the Issue #7 branch:
 - target tag: `v1.10.13`
 - release artifact: `TgWsProxy-Android-v1.10.13-arm64-v8a.apk`
 
-The tag/GitHub Release must not be published until Issue #7 manual acceptance and signed artifact verification are complete.
+Issue #7 manual acceptance and the local signed release-path verification are complete.
 
 ## Issue status
 
@@ -20,8 +20,8 @@ The tag/GitHub Release must not be published until Issue #7 manual acceptance an
 | #3 | Public project structure/documentation alignment | **Completed** |
 | #4 | CI / Project sync / release automation | **Completed** |
 | #5 | In-app feedback + GitHub Issue Forms | **Completed** |
-| #6 | Update delivery through GitHub Releases | **Implemented; final manual acceptance pending** |
-| #7 | Final release/localization/compliance audit | **In progress / final gate** |
+| #6 | Update delivery through GitHub Releases | **Completed** |
+| #7 | Final release/localization/compliance audit | **Completed** |
 
 ## Runtime stability / Flowseal parity
 
@@ -73,7 +73,7 @@ Issue #5 received manual Android acceptance and is complete.
 - The app does not silently download/install APKs and requests no extra package-install/background-update permission.
 - Update errors remain local UI state and do not stop/reconfigure proxy runtime.
 
-Automated unit/build validation is complete; final device acceptance remains part of the Issue #7 gate.
+Automated validation and final device acceptance are complete.
 
 ## Final release audit
 
@@ -89,6 +89,8 @@ Issue #7 adds/updates:
 
 ## Release gate
 
+All release gates below were satisfied before publication.
+
 Before `v1.10.13` is tagged/published:
 
 1. `scripts/ci.ps1` must pass on the final source.
@@ -101,3 +103,4 @@ Before `v1.10.13` is tagged/published:
 8. The final branch diff must contain no unrelated changes.
 
 See `docs/releases/v1.10.13-final-audit.md`, `docs/releases/RELEASE_CHECKLIST.md`, `docs/releases/release.md`, and `docs/testing/README.md`.
+


### PR DESCRIPTION
Finalizes public release notes, stable-release status, changelog and v1.10.13 acceptance documentation immediately before publication.