### PR TITLE
[v1.10.14][Worker] Route MTProto Worker through WorkerDestinationPlan

### DIFF
--- a/native/tgwsproxy/mtproto_worker_route.go
+++ b/native/tgwsproxy/mtproto_worker_route.go
@@ -243,11 +243,43 @@ func (c *mtProtoWorkerConnector) Connect(
 		result.Err = fmt.Errorf("MTProto Worker backend is not configured")
 		return nil, result
 	}
-	target := fallbackTarget(request.DCID, "")
-	if target == "" {
+
+	destination := buildMtProtoWorkerDestinationPlan(
+		candidates[0].Domain,
+		request.DCID,
+		request.IsMedia,
+		settings,
+	)
+	target := strings.TrimSpace(destination.WorkerDst)
+	effectiveDC := destination.EffectiveDC
+	effectiveMedia := destination.EffectiveIsMedia
+	if !destination.OK || target == "" || effectiveDC <= 0 {
 		result.Reason = "dc_target_unavailable"
-		result.Err = fmt.Errorf("no Worker target for dc %d", request.DCID)
+		result.Err = fmt.Errorf(
+			"no Worker destination for dc %d: %s",
+			request.DCID,
+			mtProtoStatusField(destination.FailReason),
+		)
 		return nil, result
+	}
+
+	workerRelayInit := request.RelayInit
+	if effectiveDC != request.DCID || effectiveMedia != request.IsMedia {
+		signedDC := effectiveDC
+		if effectiveMedia {
+			signedDC = -effectiveDC
+		}
+		workerRelayInit = patchInitDC(request.RelayInit, signedDC)
+		patchedDC, patchedMedia, ok := dcFromInit(workerRelayInit)
+		if !ok || patchedDC != effectiveDC || patchedMedia != effectiveMedia {
+			result.Reason = "worker_relay_init_destination_mismatch"
+			result.Err = fmt.Errorf(
+				"Worker relay init destination mismatch: dc=%d media=%t",
+				effectiveDC,
+				effectiveMedia,
+			)
+			return nil, result
+		}
 	}
 
 	maxAttempts := settings.Worker.Failover.maxAttemptsFor(len(candidates))
@@ -262,7 +294,7 @@ func (c *mtProtoWorkerConnector) Connect(
 	var lastReason string
 	for i := 0; i < maxAttempts; i++ {
 		candidate := candidates[i]
-		path := buildWorkerWSPath(request.DCID, target, request.IsMedia, sessionID)
+		path := buildWorkerWSPath(effectiveDC, target, effectiveMedia, sessionID)
 		prefix := fmt.Sprintf(
 			"[MTProto] session_id=%s DC%d%s cfworker",
 			sessionID,
@@ -271,22 +303,26 @@ func (c *mtProtoWorkerConnector) Connect(
 		)
 		if logInfo != nil {
 			logInfo.Printf(
-				"MTProto route truth frontend=MTProto selected_backend=%s actual_backend=none fallback_used=false reason=connecting dc=%d media=%t transport=%s worker_host=%s worker_dst=%s attempt=%d",
+				"MTProto route truth frontend=MTProto selected_backend=%s actual_backend=none fallback_used=false reason=connecting dc=%d media=%t effective_dc=%d effective_media=%t transport=%s worker_host=%s worker_dst=%s destination_mode=%s effective_destination_mode=%s attempt=%d",
 				mtProtoWorkerBackend,
 				request.DCID,
 				request.IsMedia,
+				effectiveDC,
+				effectiveMedia,
 				request.Transport,
 				candidate.Domain,
 				target,
+				destination.ConfiguredDestinationMode,
+				destination.EffectiveDestinationMode,
 				i+1,
 			)
 		}
 
 		poolKey := WorkerPoolKey{
-			DC:           request.DCID,
+			DC:           effectiveDC,
 			WorkerDomain: candidate.Domain,
 			Dst:          target,
-			Media:        request.IsMedia,
+			Media:        effectiveMedia,
 		}
 		var ws mtProtoFrameSocket
 		var err error
@@ -295,8 +331,8 @@ func (c *mtProtoWorkerConnector) Connect(
 			if logInfo != nil {
 				logInfo.Printf(
 					"MTProto Worker WS preconnect hit dc=%d media=%t worker_host=%s worker_dst=%s attempt=%d",
-					request.DCID,
-					request.IsMedia,
+					effectiveDC,
+					effectiveMedia,
 					candidate.Domain,
 					target,
 					i+1,
@@ -306,8 +342,8 @@ func (c *mtProtoWorkerConnector) Connect(
 			if logInfo != nil && workerWsPreconnectActive() {
 				logInfo.Printf(
 					"MTProto Worker WS preconnect miss dc=%d media=%t worker_host=%s worker_dst=%s attempt=%d",
-					request.DCID,
-					request.IsMedia,
+					effectiveDC,
+					effectiveMedia,
 					candidate.Domain,
 					target,
 					i+1,
@@ -321,7 +357,7 @@ func (c *mtProtoWorkerConnector) Connect(
 			continue
 		}
 
-		stream, err := mtProtoWebSocketConn(ws, request.RelayInit, candidate.Domain)
+		stream, err := mtProtoWebSocketConn(ws, workerRelayInit, candidate.Domain)
 		if err != nil {
 			ws.Close()
 			lastErr = err

--- a/native/tgwsproxy/mtproto_worker_route_test.go
+++ b/native/tgwsproxy/mtproto_worker_route_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"tg-ws-proxy/mtproxyfrontend"
+	"tg-ws-proxy/tgwsroute"
 )
 
 func TestMtProtoWorkerConnectorUsesConfiguredWorkerWithoutFallback(t *testing.T) {
@@ -16,6 +17,7 @@ func TestMtProtoWorkerConnectorUsesConfiguredWorkerWithoutFallback(t *testing.T)
 		settings.Worker.Enabled = true
 		settings.Worker.Domain = "example.workers.dev"
 		settings.Worker.Failover = workerFailoverSettings{}
+		settings.Worker.DestinationMode = tgwsroute.WorkerDestinationPreserveOriginalDst
 		return settings
 	})
 
@@ -54,6 +56,92 @@ func TestMtProtoWorkerConnectorUsesConfiguredWorkerWithoutFallback(t *testing.T)
 	}
 	if len(socket.sent) != 1 || !bytes.Equal(socket.sent[0], relayInit) {
 		t.Fatal("relay init was not sent to Worker")
+	}
+}
+
+func TestMtProtoWorkerConnectorUsesFlowsealDCMapDestination(t *testing.T) {
+	withMtProtoWorkerDCMap(t, map[int]string{2: "149.154.167.220"})
+	withRuntimeSettings(t, func(settings runtimeSettings) runtimeSettings {
+		settings.Worker.Enabled = true
+		settings.Worker.Domain = "example.workers.dev"
+		settings.Worker.Failover = workerFailoverSettings{}
+		settings.Worker.DestinationMode = tgwsroute.WorkerDestinationFlowsealDCMap
+		return settings
+	})
+
+	socket := &fakeMtProtoFrameSocket{}
+	var dialPath string
+	connector := &mtProtoWorkerConnector{
+		dial: func(_, path, _ string) (mtProtoFrameSocket, error) {
+			dialPath = path
+			return socket, nil
+		},
+	}
+	relayInit := buildTestInitWithSignedDC(t, 2)
+	conn, result := connector.Connect(context.Background(), mtproxyfrontend.OutboundRequest{
+		DCID:      2,
+		Transport: mtproxyfrontend.TransportAbridged,
+		RelayInit: relayInit,
+	})
+	if result.Err != nil {
+		t.Fatalf("connect: %v", result.Err)
+	}
+	defer conn.Close()
+
+	if !containsAll(dialPath, "/apiws?", "dc=2", "dst=149.154.167.220", "media=0", "sid=") {
+		t.Fatalf("path=%s", dialPath)
+	}
+	if len(socket.sent) != 1 || !bytes.Equal(socket.sent[0], relayInit) {
+		t.Fatal("FLOWSEAL_DC_MAP must keep relay init metadata when effective dc/media are unchanged")
+	}
+}
+
+func TestMtProtoWorkerConnectorAlignsExperimentalMediaDestinationAndRelayInit(t *testing.T) {
+	withRuntimeSettings(t, func(settings runtimeSettings) runtimeSettings {
+		settings.Worker.Enabled = true
+		settings.Worker.Domain = "example.workers.dev"
+		settings.Worker.Failover = workerFailoverSettings{}
+		settings.Worker.DestinationMode = tgwsroute.WorkerDestinationExperimentalForceMediaDC4
+		settings.Worker.MediaFix = flowsealMediaFixConfig{
+			Enabled: true,
+			DC:      4,
+			IP:      "149.154.167.220",
+		}
+		return settings
+	})
+
+	socket := &fakeMtProtoFrameSocket{}
+	var dialPath string
+	connector := &mtProtoWorkerConnector{
+		dial: func(_, path, _ string) (mtProtoFrameSocket, error) {
+			dialPath = path
+			return socket, nil
+		},
+	}
+	relayInit := buildTestInitWithSignedDC(t, -2)
+	conn, result := connector.Connect(context.Background(), mtproxyfrontend.OutboundRequest{
+		DCID:      2,
+		IsMedia:   true,
+		Transport: mtproxyfrontend.TransportAbridged,
+		RelayInit: relayInit,
+	})
+	if result.Err != nil {
+		t.Fatalf("connect: %v", result.Err)
+	}
+	defer conn.Close()
+
+	if !containsAll(dialPath, "/apiws?", "dc=4", "dst=149.154.167.220", "media=1", "sid=") {
+		t.Fatalf("path=%s", dialPath)
+	}
+	if len(socket.sent) != 1 {
+		t.Fatalf("sent frames=%d", len(socket.sent))
+	}
+	if bytes.Equal(socket.sent[0], relayInit) {
+		t.Fatal("expected relay init route metadata to be patched for effective DC4 media destination")
+	}
+	dc, isMedia, ok := dcFromInit(socket.sent[0])
+	if !ok || dc != 4 || !isMedia {
+		t.Fatalf("relay init dc=%d media=%t ok=%t", dc, isMedia, ok)
 	}
 }
 
@@ -369,5 +457,18 @@ func withRuntimeSettings(t *testing.T, mutate func(runtimeSettings) runtimeSetti
 	setRuntimeSettings(mutate(previous))
 	t.Cleanup(func() {
 		setRuntimeSettings(previous)
+	})
+}
+
+func withMtProtoWorkerDCMap(t *testing.T, value map[int]string) {
+	t.Helper()
+	dcOptMu.Lock()
+	previous := dcOpt
+	dcOpt = value
+	dcOptMu.Unlock()
+	t.Cleanup(func() {
+		dcOptMu.Lock()
+		dcOpt = previous
+		dcOptMu.Unlock()
 	})
 }

--- a/native/tgwsproxy/routing.go
+++ b/native/tgwsproxy/routing.go
@@ -357,12 +357,19 @@ func snapshotDcOptMap() map[int]string {
 	return out
 }
 
-func buildCfWorkerDestinationPlanWithMedia(workerDomain string, session *initSession, parsedDstHost string, settings runtimeSettings, isMedia bool) tgwsroute.WorkerDestinationPlan {
+func resolveWorkerDestinationPlan(
+	workerDomain string,
+	dc int,
+	isMedia bool,
+	dcOK bool,
+	parsedDstHost string,
+	settings runtimeSettings,
+) tgwsroute.WorkerDestinationPlan {
 	return tgwsroute.ResolveCfWorkerDestination(tgwsroute.WorkerDestinationInput{
 		WorkerDomain:  workerDomain,
-		DCID:          session.dc,
+		DCID:          dc,
 		IsMedia:       isMedia,
-		DCOk:          session.dcOk,
+		DCOk:          dcOK,
 		ParsedDstHost: parsedDstHost,
 		Mode:          settings.Worker.DestinationMode,
 		DcIPMap:       snapshotDcOptMap(),
@@ -372,6 +379,22 @@ func buildCfWorkerDestinationPlanWithMedia(workerDomain string, session *initSes
 			IP:      settings.Worker.MediaFix.IP,
 		},
 	})
+}
+
+func buildCfWorkerDestinationPlanWithMedia(workerDomain string, session *initSession, parsedDstHost string, settings runtimeSettings, isMedia bool) tgwsroute.WorkerDestinationPlan {
+	return resolveWorkerDestinationPlan(
+		workerDomain,
+		session.dc,
+		isMedia,
+		session.dcOk,
+		parsedDstHost,
+		settings,
+	)
+}
+
+func buildMtProtoWorkerDestinationPlan(workerDomain string, dc int, isMedia bool, settings runtimeSettings) tgwsroute.WorkerDestinationPlan {
+	parsedDstHost, dcOK := tgwsroute.WorkerCanonicalIPv4ForDC(dc)
+	return resolveWorkerDestinationPlan(workerDomain, dc, isMedia, dcOK, parsedDstHost, settings)
 }
 
 func buildCfWorkerDestinationPlan(workerDomain string, session *initSession, parsedDstHost string, settings runtimeSettings) tgwsroute.WorkerDestinationPlan {


### PR DESCRIPTION
## Что изменено

- MTProto Worker больше не выбирает destination через отдельный `fallbackTarget()`.
- Добавлен общий internal resolver, который подготавливает `WorkerDestinationPlan` и для SOCKS/transparent Worker, и для MTProto Worker.
- MTProto Worker применяет `DestinationMode`, DC map и `MediaFix` из runtime settings.
- `dc`, `media`, `dst`, pool key и первый relay init синхронизированы с effective destination.
- При `EXPERIMENTAL_FORCE_MEDIA_DC4` media-сессия переводится на effective DC4 / `149.154.167.220`, а signed DC в relay init патчится существующим `patchInitDC()`.
- CF Proxy/direct route chain не изменён.

## Тесты

Добавлены регрессии для:
- `PRESERVE_ORIGINAL_DST`;
- `FLOWSEAL_DC_MAP`;
- `EXPERIMENTAL_FORCE_MEDIA_DC4` с проверкой Worker path и signed DC/media в отправленном relay init;
- существующий Worker failover остаётся покрыт прежними тестами.

Closes #30