### PR TITLE
[v1.10.14][Worker] Stabilize MTProto Worker preconnect pool

### DIFF
--- a/app/src/main/java/com/amurcanov/tgwsproxy/MtProtoRuntimeAdapter.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/MtProtoRuntimeAdapter.kt
@@ -8,7 +8,7 @@ internal data class MtProtoRuntimeConfig(
     val fakeTlsDomain: String = "",
     val fakeTlsPassthrough: Boolean = false,
     val forceTestDc: Boolean = false,
-    val mtProtoWorkerPreconnect: Boolean = true,
+    val mtProtoWorkerPreconnect: Boolean = false,
     val verbose: Int = 1,
 ) {
     fun normalized(): MtProtoRuntimeConfig {

--- a/app/src/test/java/com/amurcanov/tgwsproxy/MtProtoRuntimeAdapterTest.kt
+++ b/app/src/test/java/com/amurcanov/tgwsproxy/MtProtoRuntimeAdapterTest.kt
@@ -48,7 +48,7 @@ class MtProtoRuntimeAdapterTest {
         assertEquals("1:149.154.175.50", runtimeConfig.dcIps)
         assertEquals("", runtimeConfig.fakeTlsDomain)
         assertFalse(runtimeConfig.fakeTlsPassthrough)
-        assertTrue(runtimeConfig.mtProtoWorkerPreconnect)
+        assertFalse(runtimeConfig.mtProtoWorkerPreconnect)
         assertEquals(1, runtimeConfig.verbose)
         assertNull(result.errorCode)
     }
@@ -77,6 +77,7 @@ class MtProtoRuntimeAdapterTest {
                 dcIps = "1:149.154.175.50",
                 fakeTlsDomain = "www.google.com",
                 fakeTlsPassthrough = true,
+                mtProtoWorkerPreconnect = true,
             ).normalized(),
         )
 
@@ -97,7 +98,7 @@ class MtProtoRuntimeAdapterTest {
         assertEquals(MtProtoSecretMasking.MASKED, fields["secret"])
         assertEquals("no", fields["fakeTls"])
         assertEquals("no", fields["fakeTlsPassthrough"])
-        assertEquals("yes", fields["mtProtoWorkerPreconnect"])
+        assertEquals("no", fields["mtProtoWorkerPreconnect"])
         assertFalse(fields.values.any { it.contains(fixedSecret) })
     }
 

--- a/native/tgwsproxy/mtproto_websocket_frames.go
+++ b/native/tgwsproxy/mtproto_websocket_frames.go
@@ -184,7 +184,7 @@ func (p *WorkerWsPool) GetForSession(key WorkerPoolKey) *RawWebSocket {
 		p.idle[key] = bucket
 
 		age := now - entry.created
-		if age > p.maxAge || entry.ws.closed.Load() {
+		if age > p.maxAge || !p.reusable(entry.ws) {
 			go entry.ws.Close()
 			continue
 		}

--- a/native/tgwsproxy/mtproto_worker_route.go
+++ b/native/tgwsproxy/mtproto_worker_route.go
@@ -339,13 +339,25 @@ func (c *mtProtoWorkerConnector) Connect(
 				)
 			}
 		} else {
-			if logInfo != nil && workerWsPreconnectActive() {
+			preconnectEnabled := workerWsPreconnectActive()
+			if logInfo != nil && preconnectEnabled {
 				logInfo.Printf(
 					"MTProto Worker WS preconnect miss dc=%d media=%t worker_host=%s worker_dst=%s attempt=%d",
 					effectiveDC,
 					effectiveMedia,
 					candidate.Domain,
 					target,
+					i+1,
+				)
+			}
+			if logInfo != nil {
+				logInfo.Printf(
+					"MTProto Worker WS fresh dial dc=%d media=%t worker_host=%s worker_dst=%s preconnect_enabled=%t attempt=%d",
+					effectiveDC,
+					effectiveMedia,
+					candidate.Domain,
+					target,
+					preconnectEnabled,
 					i+1,
 				)
 			}

--- a/native/tgwsproxy/mtproto_worker_route_test.go
+++ b/native/tgwsproxy/mtproto_worker_route_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"testing"
+	"time"
 
 	"tg-ws-proxy/mtproxyfrontend"
 	"tg-ws-proxy/tgwsroute"
@@ -192,6 +193,63 @@ func TestMtProtoWorkerConnectorUsesPreconnectedWorkerWhenMtProtoEnabled(t *testi
 	}
 	if stats.workerWsPreconnectHits.Load() == 0 {
 		t.Fatal("expected worker ws preconnect hit")
+	}
+}
+
+func TestMtProtoWorkerConnectorMediaPoolMissUsesFreshDial(t *testing.T) {
+	withPoolSize(t, 1)
+	stats.Reset()
+	withRuntimeSettings(t, func(settings runtimeSettings) runtimeSettings {
+		settings.Worker.Enabled = true
+		settings.Worker.Domain = "example.workers.dev"
+		settings.Worker.Failover = workerFailoverSettings{}
+		settings.Worker.DestinationMode = tgwsroute.WorkerDestinationPreserveOriginalDst
+		settings.MtProtoWorkerPreconnect = true
+		return settings
+	})
+
+	previousPool := workerPool
+	backgroundDialer := &fakeWorkerDialer{}
+	workerPool = newWorkerWsPool(backgroundDialer)
+	t.Cleanup(func() {
+		workerPool.CloseAll()
+		workerPool = previousPool
+	})
+
+	socket := &fakeMtProtoFrameSocket{}
+	foregroundDials := 0
+	var dialPath string
+	connector := &mtProtoWorkerConnector{
+		dial: func(_, path, _ string) (mtProtoFrameSocket, error) {
+			foregroundDials++
+			dialPath = path
+			return socket, nil
+		},
+	}
+
+	conn, result := connector.Connect(context.Background(), mtproxyfrontend.OutboundRequest{
+		DCID:      2,
+		IsMedia:   true,
+		Transport: mtproxyfrontend.TransportAbridged,
+		RelayInit: buildTestInitWithSignedDC(t, -2),
+	})
+	if result.Err != nil {
+		t.Fatalf("connect: %v", result.Err)
+	}
+	defer conn.Close()
+
+	if foregroundDials != 1 {
+		t.Fatalf("foreground dials=%d want=1", foregroundDials)
+	}
+	if !containsAll(dialPath, "/apiws?", "dc=2", "dst=149.154.167.51", "media=1", "sid=") {
+		t.Fatalf("path=%s", dialPath)
+	}
+	if got := stats.workerWsPreconnectMisses.Load(); got != 1 {
+		t.Fatalf("preconnect misses=%d want=1", got)
+	}
+	time.Sleep(30 * time.Millisecond)
+	if got := backgroundDialer.count.Load(); got != 0 {
+		t.Fatalf("session miss started %d duplicate background dial(s)", got)
 	}
 }
 

--- a/native/tgwsproxy/tg-ws-proxy.go
+++ b/native/tgwsproxy/tg-ws-proxy.go
@@ -1594,7 +1594,7 @@ var wsPool = newWsPool()
 
 var workerWsPreconnectEnabled = false
 
-const workerWsPreconnectMaxPerKey = 2
+const workerWsPreconnectMaxPerKey = 1
 
 func workerWsPreconnectActive() bool {
 	return workerWsPreconnectEnabled || getRuntimeSettings().MtProtoWorkerPreconnect
@@ -1621,11 +1621,6 @@ type WorkerPoolKey struct {
 	Media        bool
 }
 
-type workerWarmupTarget struct {
-	DC  int
-	Dst string
-}
-
 func workerWarmupDomains(settings runtimeSettings) []string {
 	candidates := settings.Worker.Failover.effectiveCandidates(settings.Worker.Domain)
 	if len(candidates) == 0 {
@@ -1647,32 +1642,37 @@ func workerWarmupDomains(settings runtimeSettings) []string {
 	return out
 }
 
-func workerWarmupTargets(dcOptMap map[int]string) []workerWarmupTarget {
-	seen := make(map[string]struct{})
-	out := make([]workerWarmupTarget, 0, 10)
-	add := func(dc int, dst string) {
-		dst = strings.TrimSpace(dst)
-		if dc <= 0 || dst == "" {
-			return
+// workerWarmupKeys derives preconnect keys through the same
+// WorkerDestinationPlan used by foreground MTProto Worker sessions.
+// Media is intentionally not warmed up: media/CDN sessions use a fresh dial
+// unless an exact media key was populated explicitly in the future.
+func workerWarmupKeys(settings runtimeSettings, workerDomains []string) []WorkerPoolKey {
+	seen := make(map[WorkerPoolKey]struct{})
+	out := make([]WorkerPoolKey, 0, len(workerDomains)*6)
+	for _, workerDomain := range workerDomains {
+		workerDomain = NormalizeWorkerDomain(workerDomain)
+		if workerDomain == "" {
+			continue
 		}
-		key := fmt.Sprintf("%d|%s", dc, dst)
-		if _, ok := seen[key]; ok {
-			return
+		for _, dc := range []int{1, 2, 3, 4, 5, 203} {
+			destination := buildMtProtoWorkerDestinationPlan(workerDomain, dc, false, settings)
+			target := strings.TrimSpace(destination.WorkerDst)
+			if !destination.OK || destination.EffectiveDC <= 0 || target == "" || destination.EffectiveIsMedia {
+				continue
+			}
+			key := WorkerPoolKey{
+				DC:           destination.EffectiveDC,
+				WorkerDomain: workerDomain,
+				Dst:          target,
+				Media:        false,
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, key)
 		}
-		seen[key] = struct{}{}
-		out = append(out, workerWarmupTarget{DC: dc, Dst: dst})
 	}
-
-	for _, dc := range []int{1, 2, 3, 4, 5, 203} {
-		add(dc, telegramDCTargetIP(dc, ""))
-		if dcOptMap != nil {
-			add(dc, dcOptMap[dc])
-		}
-	}
-	for _, candidate := range tgwsroute.DC2WorkerCandidates {
-		add(2, candidate)
-	}
-	add(tgwsroute.DefaultFlowsealMediaFixDC, tgwsroute.DefaultFlowsealMediaFixIP)
 	return out
 }
 
@@ -1703,11 +1703,36 @@ func (defaultWorkerPoolDialer) DialWorker(key WorkerPoolKey) (*RawWebSocket, err
 	return nil, lastErr
 }
 
+const workerWsReuseProbeTimeout = 2 * time.Millisecond
+
+// workerWebSocketReusable rejects preconnected sockets that are locally
+// closed, already have unexpected upstream data buffered, or whose peer has
+// already closed the connection. A read timeout means the idle socket is still
+// quiet and can be handed to a foreground MTProto session.
+func workerWebSocketReusable(ws *RawWebSocket) bool {
+	if ws == nil || ws.closed.Load() || ws.conn == nil || ws.bufReader == nil {
+		return false
+	}
+	if ws.bufReader.Buffered() > 0 {
+		return false
+	}
+
+	_ = ws.conn.SetReadDeadline(time.Now().Add(workerWsReuseProbeTimeout))
+	_, err := ws.bufReader.Peek(1)
+	_ = ws.conn.SetReadDeadline(time.Time{})
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
 type WorkerWsPool struct {
 	mu        sync.Mutex
 	idle      map[WorkerPoolKey][]poolEntry
 	refilling map[WorkerPoolKey]bool
 	dialer    workerPoolDialer
+	reusable  func(*RawWebSocket) bool
 	now       func() float64
 	maxAge    float64
 }
@@ -1720,6 +1745,7 @@ func newWorkerWsPool(dialer workerPoolDialer) *WorkerWsPool {
 		idle:      make(map[WorkerPoolKey][]poolEntry),
 		refilling: make(map[WorkerPoolKey]bool),
 		dialer:    dialer,
+		reusable:  workerWebSocketReusable,
 		now:       monoNow,
 		maxAge:    100.0,
 	}
@@ -1741,7 +1767,7 @@ func (p *WorkerWsPool) Get(key WorkerPoolKey) *RawWebSocket {
 		p.idle[key] = bucket
 
 		age := now - entry.created
-		if age > p.maxAge || entry.ws.closed.Load() {
+		if age > p.maxAge || !p.reusable(entry.ws) {
 			go entry.ws.Close()
 			continue
 		}
@@ -1790,35 +1816,22 @@ func (p *WorkerWsPool) refill(key WorkerPoolKey) {
 	}
 }
 
-func (p *WorkerWsPool) Warmup(dcOptMap map[int]string, workerDomains []string) {
+func (p *WorkerWsPool) Warmup(settings runtimeSettings, workerDomains []string) {
 	if !workerWsPreconnectActive() || workerWsPreconnectTargetSize() <= 0 || len(workerDomains) == 0 {
 		return
 	}
+	keys := workerWarmupKeys(settings, workerDomains)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	started := 0
-	for _, workerDomain := range workerDomains {
-		workerDomain = NormalizeWorkerDomain(workerDomain)
-		if workerDomain == "" {
-			continue
-		}
-		for _, target := range workerWarmupTargets(dcOptMap) {
-			key := WorkerPoolKey{
-				DC:           target.DC,
-				WorkerDomain: workerDomain,
-				Dst:          target.Dst,
-				Media:        false,
-			}
-			p.scheduleRefillLocked(key)
-			started++
-		}
+	for _, key := range keys {
+		p.scheduleRefillLocked(key)
 	}
-	if started > 0 {
-		logInfo.Printf("Worker pool warmup scheduled for %d target(s) across %d worker(s)", started, len(workerDomains))
+	if len(keys) > 0 && logInfo != nil {
+		logInfo.Printf("Worker pool warmup scheduled for %d effective non-media target(s) across %d worker(s)", len(keys), len(workerDomains))
 	}
 }
 
-func (p *WorkerWsPool) Maintain(ctx context.Context, dcOptMap map[int]string, workerDomains []string) {
+func (p *WorkerWsPool) Maintain(ctx context.Context, settings runtimeSettings, workerDomains []string) {
 	ticker := time.NewTicker(poolMaintainInterval * time.Second)
 	defer ticker.Stop()
 	for {
@@ -1826,18 +1839,18 @@ func (p *WorkerWsPool) Maintain(ctx context.Context, dcOptMap map[int]string, wo
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			p.maintainOnce(dcOptMap, workerDomains)
+			p.maintainOnce(settings, workerDomains)
 		}
 	}
 }
 
-func (p *WorkerWsPool) maintainOnce(dcOptMap map[int]string, workerDomains []string) {
+func (p *WorkerWsPool) maintainOnce(settings runtimeSettings, workerDomains []string) {
 	now := p.now()
 	p.mu.Lock()
 	for key, bucket := range p.idle {
 		var fresh []poolEntry
 		for _, entry := range bucket {
-			if now-entry.created > p.maxAge || entry.ws.closed.Load() {
+			if now-entry.created > p.maxAge || !p.reusable(entry.ws) {
 				go entry.ws.Close()
 				continue
 			}
@@ -1846,7 +1859,7 @@ func (p *WorkerWsPool) maintainOnce(dcOptMap map[int]string, workerDomains []str
 		p.idle[key] = fresh
 	}
 	p.mu.Unlock()
-	p.Warmup(dcOptMap, workerDomains)
+	p.Warmup(settings, workerDomains)
 }
 
 func (p *WorkerWsPool) IdleCount() int {
@@ -2894,8 +2907,8 @@ func runProxy(ctx context.Context, host string, port int, dcOptMap map[int]strin
 	workerDomains := workerWarmupDomains(settings)
 	workerPreconnectActive := workerWsPreconnectActiveForSettings(settings)
 	if settings.workerRouteAvailable() && workerPreconnectActive && len(workerDomains) > 0 {
-		workerPool.Warmup(dcOptMap, workerDomains)
-		go workerPool.Maintain(srvCtx, dcOptMap, workerDomains)
+		workerPool.Warmup(settings, workerDomains)
+		go workerPool.Maintain(srvCtx, settings, workerDomains)
 		logInfo.Printf("  Worker WS preconnect enabled domains=%d", len(workerDomains))
 	} else {
 		logInfo.Printf("  Worker WS preconnect skipped enabled=%t route_available=%t domains=%d",
@@ -3253,8 +3266,8 @@ func startMtProtoWorkerPreconnect(dcOptMap map[int]string, settings runtimeSetti
 	mtProtoWorkerPreconnectStop = cancel
 	mtProtoWorkerPreconnectMu.Unlock()
 
-	workerPool.Warmup(dcOptMap, workerDomains)
-	go workerPool.Maintain(ctx, dcOptMap, workerDomains)
+	workerPool.Warmup(settings, workerDomains)
+	go workerPool.Maintain(ctx, settings, workerDomains)
 	if logInfo != nil {
 		logInfo.Printf("MTProto Worker WS preconnect enabled domains=%d", len(workerDomains))
 	}

--- a/native/tgwsproxy/worker_pool_session_test.go
+++ b/native/tgwsproxy/worker_pool_session_test.go
@@ -48,3 +48,30 @@ func TestWorkerPoolSessionHitSchedulesReplacementRefill(t *testing.T) {
 	}
 	t.Fatalf("replacement refill was not scheduled after hit, dialed=%d idle=%d", dialer.count.Load(), pool.IdleCount())
 }
+
+
+func TestWorkerPoolSessionDoesNotCrossEffectiveMediaOrDestination(t *testing.T) {
+	withWorkerWsPreconnect(t, true)
+	withPoolSize(t, 1)
+	stats.Reset()
+	pool := newWorkerWsPool(&fakeWorkerDialer{})
+	normalKey := testWorkerKey()
+	pooled := newFakeWebSocket()
+	pool.idle[normalKey] = []poolEntry{{ws: pooled, created: pool.now()}}
+
+	mediaKey := normalKey
+	mediaKey.Media = true
+	if got := pool.GetForSession(mediaKey); got != nil {
+		t.Fatal("non-media pooled socket must not be reused for media")
+	}
+
+	otherDst := normalKey
+	otherDst.Dst = "149.154.167.220"
+	if got := pool.GetForSession(otherDst); got != nil {
+		t.Fatal("pooled socket must not be reused for another effective destination")
+	}
+
+	if got := pool.IdleCount(); got != 1 {
+		t.Fatalf("unrelated pooled entry was consumed, idle=%d", got)
+	}
+}

--- a/native/tgwsproxy/worker_pool_test.go
+++ b/native/tgwsproxy/worker_pool_test.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"tg-ws-proxy/tgwsroute"
 )
 
 type nopConn struct{}
@@ -24,6 +26,16 @@ type dummyAddr string
 func (a dummyAddr) Network() string { return string(a) }
 func (a dummyAddr) String() string  { return string(a) }
 
+type fakeIdleTimeoutError struct{}
+
+func (fakeIdleTimeoutError) Error() string   { return "idle timeout" }
+func (fakeIdleTimeoutError) Timeout() bool   { return true }
+func (fakeIdleTimeoutError) Temporary() bool { return true }
+
+type fakeIdleConn struct{ nopConn }
+
+func (fakeIdleConn) Read(_ []byte) (int, error) { return 0, fakeIdleTimeoutError{} }
+
 type fakeWorkerDialer struct {
 	count atomic.Int64
 	fail  bool
@@ -40,9 +52,10 @@ func (d *fakeWorkerDialer) DialWorker(_ WorkerPoolKey) (*RawWebSocket, error) {
 var errFakeDial = &net.DNSError{Err: "fake dial failed", Name: "worker.test"}
 
 func newFakeWebSocket() *RawWebSocket {
+	conn := fakeIdleConn{}
 	return &RawWebSocket{
-		conn:      nopConn{},
-		bufReader: bufio.NewReader(nopConn{}),
+		conn:      conn,
+		bufReader: bufio.NewReader(conn),
 	}
 }
 
@@ -195,5 +208,47 @@ func TestWorkerPoolDoesNotWarmupWhenWorkerRouteDisabled(t *testing.T) {
 
 	if settings.workerRouteAvailable() {
 		t.Fatal("worker route should be unavailable for strict CF-only mode")
+	}
+}
+
+
+func TestWorkerWebSocketReusableDetectsPeerClose(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	ws := &RawWebSocket{
+		conn:      client,
+		bufReader: bufio.NewReader(client),
+	}
+
+	if !workerWebSocketReusable(ws) {
+		t.Fatal("quiet connected Worker socket should be reusable")
+	}
+	_ = server.Close()
+	if workerWebSocketReusable(ws) {
+		t.Fatal("peer-closed Worker socket must not be reused")
+	}
+}
+
+func TestWorkerWarmupKeysUseEffectiveDestinationAndExcludeMedia(t *testing.T) {
+	withMtProtoWorkerDCMap(t, map[int]string{2: "149.154.167.220"})
+	settings := runtimeSettings{
+		Worker: workerConfig{
+			Enabled:         true,
+			Domain:          "worker.example",
+			DestinationMode: tgwsroute.WorkerDestinationFlowsealDCMap,
+		},
+	}
+	keys := workerWarmupKeys(settings, []string{"worker.example"})
+	foundDC2 := false
+	for _, key := range keys {
+		if key.Media {
+			t.Fatalf("media key must not be warmed up: %+v", key)
+		}
+		if key.DC == 2 && key.Dst == "149.154.167.220" {
+			foundDC2 = true
+		}
+	}
+	if !foundDC2 {
+		t.Fatalf("effective DC2 destination not warmed up: %+v", keys)
 	}
 }


### PR DESCRIPTION
## Зависимость

Этот PR построен поверх #35, который в свою очередь зависит от #34.

Стек:
- #34 — WorkerDestinationPlan;
- #35 — Flowseal-compatible Worker framing;
- этот PR — pool/preconnect stability.

## Что изменено

- MTProto Worker preconnect на Android теперь **выключен по умолчанию**. Обычный runtime использует fresh Worker dial, пока preconnect не включён явно.
- Максимальный idle pool уменьшен с 2 до 1 соединения на точный ключ, как у актуального Flowseal Worker pool.
- Warmup больше не строится из набора сырых DC/IP кандидатов. Ключи выводятся через тот же `WorkerDestinationPlan`, что и foreground MTProto route.
- Warmup намеренно создаёт только non-media entries. Media/CDN miss идёт через fresh dial.
- Pool key остаётся полным: `effective DC + WorkerDomain + dst + media`.
- Перед выдачей idle Worker WebSocket выполняется bounded liveness probe: закрытый peer, локально закрытый socket или неожиданные buffered upstream bytes не переиспользуются.
- Session miss по-прежнему не запускает дублирующий background refill.
- Добавлен явный лог `MTProto Worker WS fresh dial ... preconnect_enabled=...`.

## Regression tests

Добавлены/обновлены проверки:
- Android mapper больше не включает preconnect по умолчанию;
- явное включение preconnect по-прежнему формирует runtime token;
- per-key cap равен 1;
- peer-closed idle WebSocket не считается reusable;
- warmup использует effective destination и не создаёт media keys;
- pooled non-media socket не используется для media или другого `dst`;
- media pool miss делает ровно один foreground fresh dial и не запускает background duplicate refill.

Не изменяет Worker framing из #31 и destination routing из #30.

Closes #32