### PR TITLE
[v1.10.14][Worker] Add end-to-end regression gate for #29

### DIFF
--- a/docs/testing/v1.10.14-worker-acceptance.md
+++ b/docs/testing/v1.10.14-worker-acceptance.md
@@ -1,0 +1,84 @@
+# v1.10.14 Worker acceptance checklist
+
+This checklist is the manual Android gate for issue #33 / regression #29. Automated Go/JVM tests cover deterministic transport semantics; these checks must be run on a real Telegram client before v1.10.14 is released.
+
+## Build under test
+
+Record before testing:
+
+- branch / commit SHA;
+- app version and versionCode;
+- Android device and Android version;
+- Worker hostname used;
+- whether `EXPERIMENTAL_FORCE_MEDIA_DC4` is enabled.
+
+Do not paste MTProto secrets into the report.
+
+## Wi-Fi
+
+1. Start TgWsProxy with **Worker only** and Worker preconnect disabled.
+2. Connect Telegram to the local MTProto proxy.
+3. Confirm ordinary Telegram traffic remains usable for at least 2 minutes.
+4. Send several text messages.
+5. Upload a photo.
+6. Upload a video larger than 1 MiB.
+7. Download/open a photo.
+8. Download/open a video larger than 1 MiB.
+9. Repeat media tests with `EXPERIMENTAL_FORCE_MEDIA_DC4`.
+10. Export TgWsProxy logs.
+
+Expected route evidence for DC4 media:
+
+```text
+selected_backend=cf_worker_ws
+actual_backend=cf_worker_ws
+media=true
+effective_dc=4
+effective_media=true
+worker_dst=149.154.167.220
+fallback_used=false
+```
+
+## Mobile data
+
+Repeat the complete Wi-Fi sequence with Wi-Fi disabled and mobile data active.
+
+## Bridge diagnostics
+
+For every unexpectedly short Worker session, inspect:
+
+```text
+MTProto bridge closed ...
+first_terminator=...
+close_reason=...
+up_bytes=...
+down_bytes=...
+up_chunks=...
+down_chunks=...
+duration_ms=...
+error=...
+```
+
+Interpretation:
+
+- `first_terminator=client_to_upstream close_reason=eof`: the local Telegram side closed first;
+- `first_terminator=upstream_to_client close_reason=eof`: Worker / Telegram upstream closed first;
+- `write_error`: forwarding failed while writing to the opposite side;
+- `read_error`: forwarding failed while reading;
+- `cancelled`: secondary direction was closed because the other direction already ended.
+
+A successful HTTP 101 / `MTProto route connected` is **not** sufficient acceptance. The session must transfer payload in both directions and media upload/download must complete.
+
+## Release gate
+
+Do not mark #29 resolved or release v1.10.14 until:
+
+- [ ] automated CI for #33 is green;
+- [ ] Wi-Fi text traffic passes;
+- [ ] Wi-Fi media upload passes;
+- [ ] Wi-Fi media download passes;
+- [ ] mobile text traffic passes;
+- [ ] mobile media upload passes;
+- [ ] mobile media download passes;
+- [ ] DC4 media fix produces the expected effective destination;
+- [ ] exported logs contain no unexplained rapid Worker reconnect loop.

--- a/docs/testing/v1.10.14-worker-acceptance.md
+++ b/docs/testing/v1.10.14-worker-acceptance.md
@@ -24,16 +24,18 @@ Do not paste MTProto secrets into the report.
 6. Upload a video larger than 1 MiB.
 7. Download/open a photo.
 8. Download/open a video larger than 1 MiB.
-9. Repeat media tests with `EXPERIMENTAL_FORCE_MEDIA_DC4`.
+9. Repeat media tests with `EXPERIMENTAL_FORCE_MEDIA_DC4`; despite the legacy name, verify that only `worker_dst` changes and the original logical DC remains unchanged.
 10. Export TgWsProxy logs.
 
-Expected route evidence for DC4 media:
+Expected route evidence for a DC2 media session with the legacy `EXPERIMENTAL_FORCE_MEDIA_DC4` destination override:
 
 ```text
 selected_backend=cf_worker_ws
 actual_backend=cf_worker_ws
+signed_dc=-2
+dc=2
 media=true
-effective_dc=4
+effective_dc=2
 effective_media=true
 worker_dst=149.154.167.220
 fallback_used=false
@@ -80,5 +82,5 @@ Do not mark #29 resolved or release v1.10.14 until:
 - [ ] mobile text traffic passes;
 - [ ] mobile media upload passes;
 - [ ] mobile media download passes;
-- [ ] DC4 media fix produces the expected effective destination;
+- [ ] media destination override preserves the logical signed DC while routing to `149.154.167.220`;
 - [ ] exported logs contain no unexplained rapid Worker reconnect loop.

--- a/native/tgwsproxy/mtproto_route_diagnostics_test.go
+++ b/native/tgwsproxy/mtproto_route_diagnostics_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"tg-ws-proxy/mtproxyfrontend"
+)
+
+func TestMtProtoWebSocketStreamExposesWorkerRouteDiagnostics(t *testing.T) {
+	stream := &mtProtoWebSocketStream{
+		sessionID: "session-media-dc2",
+		workerDst: "149.154.167.51",
+	}
+
+	provider, ok := any(stream).(mtproxyfrontend.RouteDiagnosticsProvider)
+	if !ok {
+		t.Fatal("mtProtoWebSocketStream must expose route diagnostics")
+	}
+	diagnostics := provider.RouteDiagnostics()
+	if diagnostics.SessionID != "session-media-dc2" {
+		t.Fatalf("session id=%q", diagnostics.SessionID)
+	}
+	if diagnostics.WorkerDst != "149.154.167.51" {
+		t.Fatalf("worker dst=%q", diagnostics.WorkerDst)
+	}
+}

--- a/native/tgwsproxy/mtproto_websocket_frames.go
+++ b/native/tgwsproxy/mtproto_websocket_frames.go
@@ -11,6 +11,14 @@ import (
 // fragmented message before it is exposed to the MTProto stream.
 const mtProtoMaxWebSocketMessageLen = 16 * 1024 * 1024
 
+// mtProtoMaxOutboundWebSocketPayloadLen deliberately keeps each outbound
+// WebSocket message below the 64 KiB reads produced by the MTProto bridge.
+// Real-device diagnostics for #29 showed repeated 64 KiB Worker messages with
+// no downstream response, followed by Cloudflare write timeouts. Splitting the
+// byte stream into smaller WebSocket messages preserves TCP stream semantics at
+// the Worker while adding backpressure between writes.
+const mtProtoMaxOutboundWebSocketPayloadLen = 16 * 1024
+
 // mtProtoSafeFrameSocket adds bounded WebSocket message reassembly to the
 // existing RawWebSocket without changing the Android-specific transport,
 // routing, cooldown, watchdog or diagnostics code around it.
@@ -39,11 +47,62 @@ func (s *mtProtoSafeFrameSocket) messageLimit() int {
 }
 
 func (s *mtProtoSafeFrameSocket) Send(data []byte) error {
-	return s.raw.Send(data)
+	if s == nil || s.raw == nil {
+		return fmt.Errorf("WebSocket closed")
+	}
+	if len(data) == 0 {
+		return s.writeFrameFull(opBinary, nil)
+	}
+
+	for len(data) > 0 {
+		chunkLen := len(data)
+		if chunkLen > mtProtoMaxOutboundWebSocketPayloadLen {
+			chunkLen = mtProtoMaxOutboundWebSocketPayloadLen
+		}
+		if err := s.writeFrameFull(opBinary, data[:chunkLen]); err != nil {
+			return err
+		}
+		data = data[chunkLen:]
+	}
+	return nil
 }
 
 func (s *mtProtoSafeFrameSocket) SendBatch(parts [][]byte) error {
-	return s.raw.SendBatch(parts)
+	for _, part := range parts {
+		if err := s.Send(part); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *mtProtoSafeFrameSocket) writeFrameFull(opcode int, payload []byte) error {
+	if s.raw.closed.Load() {
+		return fmt.Errorf("WebSocket closed")
+	}
+	frame := s.raw.buildFrame(opcode, payload, true)
+	s.raw.writeMu.Lock()
+	defer s.raw.writeMu.Unlock()
+	return writeFull(s.raw.conn, frame)
+}
+
+// writeFull turns net.Conn.Write into the same all-bytes-or-error contract that
+// Flowseal gets from StreamWriter.write()+drain(). A short successful Write is
+// legal for io.Writer and must not silently truncate a WebSocket frame.
+func writeFull(writer io.Writer, data []byte) error {
+	for len(data) > 0 {
+		n, err := writer.Write(data)
+		if n > 0 {
+			data = data[n:]
+		}
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+	}
+	return nil
 }
 
 func (s *mtProtoSafeFrameSocket) Close() {
@@ -66,19 +125,17 @@ func (s *mtProtoSafeFrameSocket) Recv() ([]byte, error) {
 			if len(closePayload) > 2 {
 				closePayload = closePayload[:2]
 			}
-			reply := s.raw.buildFrame(opClose, closePayload, true)
-			s.raw.writeMu.Lock()
-			_, _ = s.raw.conn.Write(reply)
-			s.raw.writeMu.Unlock()
+			_ = s.writeFrameFull(opClose, closePayload)
 			s.raw.closed.Store(true)
 			_ = s.raw.conn.Close()
 			return nil, io.EOF
 
 		case opPing:
-			pong := s.raw.buildFrame(opPong, payload, true)
-			s.raw.writeMu.Lock()
-			_, _ = s.raw.conn.Write(pong)
-			s.raw.writeMu.Unlock()
+			if err := s.writeFrameFull(opPong, payload); err != nil {
+				s.raw.closed.Store(true)
+				_ = s.raw.conn.Close()
+				return nil, err
+			}
 			continue
 
 		case opPong:

--- a/native/tgwsproxy/mtproto_websocket_frames_test.go
+++ b/native/tgwsproxy/mtproto_websocket_frames_test.go
@@ -12,9 +12,11 @@ import (
 )
 
 type frameTestConn struct {
-	reader *bytes.Reader
-	writes bytes.Buffer
-	closed bool
+	reader    *bytes.Reader
+	writes    bytes.Buffer
+	closed    bool
+	maxWrite  int
+	writeCalls int
 }
 
 func newFrameTestRaw(input []byte) (*RawWebSocket, *frameTestConn) {
@@ -30,6 +32,10 @@ func (c *frameTestConn) Read(p []byte) (int, error) {
 }
 
 func (c *frameTestConn) Write(p []byte) (int, error) {
+	c.writeCalls++
+	if c.maxWrite > 0 && len(p) > c.maxWrite {
+		p = p[:c.maxWrite]
+	}
 	return c.writes.Write(p)
 }
 
@@ -68,6 +74,57 @@ func testServerFrame(opcode int, payload []byte, fin bool) []byte {
 		copy(frame[10:], payload)
 		return frame
 	}
+}
+
+func clientFramePayloadLengths(t *testing.T, data []byte) []int {
+	t.Helper()
+	reader := bytes.NewReader(data)
+	lengths := make([]int, 0, 4)
+	for reader.Len() > 0 {
+		first, err := reader.ReadByte()
+		if err != nil {
+			t.Fatalf("read frame first byte: %v", err)
+		}
+		if first&0x0F != opBinary {
+			t.Fatalf("opcode=%d want=%d", first&0x0F, opBinary)
+		}
+		second, err := reader.ReadByte()
+		if err != nil {
+			t.Fatalf("read frame second byte: %v", err)
+		}
+		if second&0x80 == 0 {
+			t.Fatal("client frame must be masked")
+		}
+
+		payloadLen := uint64(second & 0x7F)
+		switch payloadLen {
+		case 126:
+			var extended [2]byte
+			if _, err := io.ReadFull(reader, extended[:]); err != nil {
+				t.Fatalf("read 16-bit payload length: %v", err)
+			}
+			payloadLen = uint64(binary.BigEndian.Uint16(extended[:]))
+		case 127:
+			var extended [8]byte
+			if _, err := io.ReadFull(reader, extended[:]); err != nil {
+				t.Fatalf("read 64-bit payload length: %v", err)
+			}
+			payloadLen = binary.BigEndian.Uint64(extended[:])
+		}
+
+		var mask [4]byte
+		if _, err := io.ReadFull(reader, mask[:]); err != nil {
+			t.Fatalf("read mask: %v", err)
+		}
+		if payloadLen > uint64(reader.Len()) {
+			t.Fatalf("payload length=%d remaining=%d", payloadLen, reader.Len())
+		}
+		if _, err := reader.Seek(int64(payloadLen), io.SeekCurrent); err != nil {
+			t.Fatalf("skip payload: %v", err)
+		}
+		lengths = append(lengths, int(payloadLen))
+	}
+	return lengths
 }
 
 func TestMtProtoSafeFrameSocketReassemblesFragmentedMessage(t *testing.T) {
@@ -141,6 +198,49 @@ func TestMtProtoSafeFrameSocketHandlesPingBetweenFragments(t *testing.T) {
 	}
 	if conn.writes.Len() == 0 {
 		t.Fatal("ping must produce a pong frame")
+	}
+}
+
+func TestMtProtoSafeFrameSocketSplitsLargeOutboundWrite(t *testing.T) {
+	raw, conn := newFrameTestRaw(nil)
+	socket := &mtProtoSafeFrameSocket{raw: raw}
+	payload := bytes.Repeat([]byte{0x5A}, 2*mtProtoMaxOutboundWebSocketPayloadLen+123)
+
+	if err := socket.Send(payload); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	lengths := clientFramePayloadLengths(t, conn.writes.Bytes())
+	want := []int{
+		mtProtoMaxOutboundWebSocketPayloadLen,
+		mtProtoMaxOutboundWebSocketPayloadLen,
+		123,
+	}
+	if len(lengths) != len(want) {
+		t.Fatalf("frame lengths=%v want=%v", lengths, want)
+	}
+	for i := range want {
+		if lengths[i] != want[i] {
+			t.Fatalf("frame lengths=%v want=%v", lengths, want)
+		}
+	}
+}
+
+func TestMtProtoSafeFrameSocketCompletesShortWrites(t *testing.T) {
+	raw, conn := newFrameTestRaw(nil)
+	conn.maxWrite = 7
+	socket := &mtProtoSafeFrameSocket{raw: raw}
+	payload := bytes.Repeat([]byte{0xA5}, 256)
+
+	if err := socket.Send(payload); err != nil {
+		t.Fatalf("send with short writer: %v", err)
+	}
+	if conn.writeCalls <= 1 {
+		t.Fatalf("write calls=%d, want multiple short writes", conn.writeCalls)
+	}
+	lengths := clientFramePayloadLengths(t, conn.writes.Bytes())
+	if len(lengths) != 1 || lengths[0] != len(payload) {
+		t.Fatalf("frame lengths=%v want=[%d]", lengths, len(payload))
 	}
 }
 

--- a/native/tgwsproxy/mtproto_worker_e2e_test.go
+++ b/native/tgwsproxy/mtproto_worker_e2e_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"tg-ws-proxy/mtproxyfrontend"
+	"tg-ws-proxy/tgwsroute"
+)
+
+// workerRelayHarnessSocket models the Cloudflare Worker boundary without
+// external networking: Send is WS -> Worker -> Telegram TCP and Recv is
+// Telegram TCP -> Worker -> WS.
+type workerRelayHarnessSocket struct {
+	mu       sync.Mutex
+	sent     [][]byte
+	recv     chan []byte
+	closeOnce sync.Once
+	closed   chan struct{}
+}
+
+func newWorkerRelayHarnessSocket() *workerRelayHarnessSocket {
+	return &workerRelayHarnessSocket{
+		recv:   make(chan []byte, 16),
+		closed: make(chan struct{}),
+	}
+}
+
+func (s *workerRelayHarnessSocket) Send(data []byte) error {
+	s.mu.Lock()
+	s.sent = append(s.sent, append([]byte(nil), data...))
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *workerRelayHarnessSocket) SendBatch(parts [][]byte) error {
+	for _, part := range parts {
+		if err := s.Send(part); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *workerRelayHarnessSocket) Recv() ([]byte, error) {
+	select {
+	case data := <-s.recv:
+		return append([]byte(nil), data...), nil
+	case <-s.closed:
+		return nil, io.EOF
+	}
+}
+
+func (s *workerRelayHarnessSocket) Close() {
+	s.closeOnce.Do(func() { close(s.closed) })
+}
+
+func (s *workerRelayHarnessSocket) sentFrames() [][]byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]byte, len(s.sent))
+	for i, frame := range s.sent {
+		out[i] = append([]byte(nil), frame...)
+	}
+	return out
+}
+
+func TestMtProtoWorkerE2EHarnessNormalBidirectionalLargeAndSequential(t *testing.T) {
+	withRuntimeSettings(t, func(settings runtimeSettings) runtimeSettings {
+		settings.Mode = modeWorkerOnly
+		settings.Worker.Enabled = true
+		settings.Worker.Domain = "example.workers.dev"
+		settings.Worker.Failover = workerFailoverSettings{}
+		settings.Worker.DestinationMode = tgwsroute.WorkerDestinationPreserveOriginalDst
+		settings.MtProtoWorkerPreconnect = false
+		return settings
+	})
+
+	socket := newWorkerRelayHarnessSocket()
+	var dialPath string
+	dials := 0
+	connector := &mtProtoWorkerConnector{
+		dial: func(_, path, _ string) (mtProtoFrameSocket, error) {
+			dials++
+			dialPath = path
+			return socket, nil
+		},
+	}
+
+	relayInit := buildTestInitWithSignedDC(t, 2)
+	conn, result := connector.Connect(context.Background(), mtproxyfrontend.OutboundRequest{
+		DCID:      2,
+		IsMedia:   false,
+		Transport: mtproxyfrontend.TransportPaddedIntermediate,
+		RelayInit: relayInit,
+	})
+	if result.Err != nil {
+		t.Fatalf("connect: %v", result.Err)
+	}
+	defer conn.Close()
+
+	if dials != 1 {
+		t.Fatalf("fresh dials=%d want=1", dials)
+	}
+	if result.ActualBackend != mtProtoWorkerBackend || result.FallbackUsed {
+		t.Fatalf("route truth=%+v", result)
+	}
+	if !containsAll(dialPath, "/apiws?", "dc=2", "dst=149.154.167.51", "media=0", "sid=") {
+		t.Fatalf("path=%s", dialPath)
+	}
+
+	frames := socket.sentFrames()
+	if len(frames) != 1 {
+		t.Fatalf("initial frames=%d want relay_init only", len(frames))
+	}
+	dc, media, ok := dcFromInit(frames[0])
+	if !ok || dc != 2 || media {
+		t.Fatalf("relay_init dc=%d media=%t ok=%t", dc, media, ok)
+	}
+
+	uploads := [][]byte{
+		[]byte("packet-one"),
+		[]byte("packet-two"),
+		[]byte{0x01, 0x02},
+		[]byte{0x03, 0x04, 0x05},
+		bytes.Repeat([]byte{0x51}, 96*1024),
+	}
+	for _, upload := range uploads {
+		n, err := conn.Write(upload)
+		if err != nil {
+			t.Fatalf("upload write: %v", err)
+		}
+		if n != len(upload) {
+			t.Fatalf("upload n=%d want=%d", n, len(upload))
+		}
+	}
+
+	frames = socket.sentFrames()
+	if len(frames) != 1+len(uploads) {
+		t.Fatalf("frames=%d want=%d", len(frames), 1+len(uploads))
+	}
+	for i, upload := range uploads {
+		if !bytes.Equal(frames[i+1], upload) {
+			t.Fatalf("upload frame[%d] changed len=%d", i, len(upload))
+		}
+	}
+
+	downloads := [][]byte{
+		[]byte("reply-one"),
+		[]byte("reply-two"),
+		bytes.Repeat([]byte{0x63}, 80*1024),
+	}
+	for _, download := range downloads {
+		socket.recv <- download
+		got := make([]byte, len(download))
+		if _, err := io.ReadFull(conn, got); err != nil {
+			t.Fatalf("download read: %v", err)
+		}
+		if !bytes.Equal(got, download) {
+			t.Fatalf("download changed len=%d", len(download))
+		}
+	}
+}
+
+func TestMtProtoWorkerE2EHarnessMediaDC4UploadDownload(t *testing.T) {
+	withRuntimeSettings(t, func(settings runtimeSettings) runtimeSettings {
+		settings.Mode = modeWorkerOnly
+		settings.Worker.Enabled = true
+		settings.Worker.Domain = "example.workers.dev"
+		settings.Worker.Failover = workerFailoverSettings{}
+		settings.Worker.DestinationMode = tgwsroute.WorkerDestinationExperimentalForceMediaDC4
+		settings.Worker.MediaFix = flowsealMediaFixConfig{
+			Enabled: true,
+			DC:      4,
+			IP:      "149.154.167.220",
+		}
+		settings.MtProtoWorkerPreconnect = false
+		return settings
+	})
+
+	socket := newWorkerRelayHarnessSocket()
+	var dialPath string
+	connector := &mtProtoWorkerConnector{
+		dial: func(_, path, _ string) (mtProtoFrameSocket, error) {
+			dialPath = path
+			return socket, nil
+		},
+	}
+
+	conn, result := connector.Connect(context.Background(), mtproxyfrontend.OutboundRequest{
+		DCID:      2,
+		IsMedia:   true,
+		Transport: mtproxyfrontend.TransportPaddedIntermediate,
+		RelayInit: buildTestInitWithSignedDC(t, -2),
+	})
+	if result.Err != nil {
+		t.Fatalf("connect: %v", result.Err)
+	}
+	defer conn.Close()
+
+	if !containsAll(dialPath, "/apiws?", "dc=4", "dst=149.154.167.220", "media=1", "sid=") {
+		t.Fatalf("path=%s", dialPath)
+	}
+	frames := socket.sentFrames()
+	if len(frames) != 1 {
+		t.Fatalf("frames=%d want=1", len(frames))
+	}
+	dc, media, ok := dcFromInit(frames[0])
+	if !ok || dc != 4 || !media {
+		t.Fatalf("patched relay_init dc=%d media=%t ok=%t", dc, media, ok)
+	}
+
+	upload := bytes.Repeat([]byte{0x7a}, 72*1024)
+	if n, err := conn.Write(upload); err != nil || n != len(upload) {
+		t.Fatalf("media upload n=%d err=%v", n, err)
+	}
+	frames = socket.sentFrames()
+	if len(frames) != 2 || !bytes.Equal(frames[1], upload) {
+		t.Fatal("media upload did not cross Worker harness unchanged after relay_init")
+	}
+
+	download := bytes.Repeat([]byte{0x29}, 73*1024)
+	socket.recv <- download
+	got := make([]byte, len(download))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("media download: %v", err)
+	}
+	if !bytes.Equal(got, download) {
+		t.Fatal("media download changed across Worker harness")
+	}
+}
+
+var _ mtProtoFrameSocket = (*workerRelayHarnessSocket)(nil)

--- a/native/tgwsproxy/mtproto_worker_e2e_test.go
+++ b/native/tgwsproxy/mtproto_worker_e2e_test.go
@@ -165,7 +165,7 @@ func TestMtProtoWorkerE2EHarnessNormalBidirectionalLargeAndSequential(t *testing
 	}
 }
 
-func TestMtProtoWorkerE2EHarnessMediaDC4UploadDownload(t *testing.T) {
+func TestMtProtoWorkerE2EHarnessMediaDestinationOverrideUploadDownload(t *testing.T) {
 	withRuntimeSettings(t, func(settings runtimeSettings) runtimeSettings {
 		settings.Mode = modeWorkerOnly
 		settings.Worker.Enabled = true
@@ -190,27 +190,31 @@ func TestMtProtoWorkerE2EHarnessMediaDC4UploadDownload(t *testing.T) {
 		},
 	}
 
+	relayInit := buildTestInitWithSignedDC(t, -2)
 	conn, result := connector.Connect(context.Background(), mtproxyfrontend.OutboundRequest{
 		DCID:      2,
 		IsMedia:   true,
 		Transport: mtproxyfrontend.TransportPaddedIntermediate,
-		RelayInit: buildTestInitWithSignedDC(t, -2),
+		RelayInit: relayInit,
 	})
 	if result.Err != nil {
 		t.Fatalf("connect: %v", result.Err)
 	}
 	defer conn.Close()
 
-	if !containsAll(dialPath, "/apiws?", "dc=4", "dst=149.154.167.220", "media=1", "sid=") {
+	if !containsAll(dialPath, "/apiws?", "dc=2", "dst=149.154.167.220", "media=1", "sid=") {
 		t.Fatalf("path=%s", dialPath)
 	}
 	frames := socket.sentFrames()
 	if len(frames) != 1 {
 		t.Fatalf("frames=%d want=1", len(frames))
 	}
+	if !bytes.Equal(frames[0], relayInit) {
+		t.Fatal("media destination override changed the original relay_init")
+	}
 	dc, media, ok := dcFromInit(frames[0])
-	if !ok || dc != 4 || !media {
-		t.Fatalf("patched relay_init dc=%d media=%t ok=%t", dc, media, ok)
+	if !ok || dc != 2 || !media {
+		t.Fatalf("relay_init dc=%d media=%t ok=%t", dc, media, ok)
 	}
 
 	upload := bytes.Repeat([]byte{0x7a}, 72*1024)

--- a/native/tgwsproxy/mtproto_worker_payload_trace.go
+++ b/native/tgwsproxy/mtproto_worker_payload_trace.go
@@ -32,7 +32,7 @@ func wrapMtProtoWorkerPayloadTrace(
 	sessionID string,
 	workerDst string,
 ) net.Conn {
-	if conn == nil || !request.IsMedia {
+	if conn == nil {
 		return conn
 	}
 	return &mtProtoWorkerPayloadTraceConn{

--- a/native/tgwsproxy/mtproto_worker_payload_trace.go
+++ b/native/tgwsproxy/mtproto_worker_payload_trace.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"tg-ws-proxy/mtproxyfrontend"
+)
+
+const mtProtoWorkerPayloadTraceLimit = 16
+
+type mtProtoWorkerPayloadTraceConn struct {
+	net.Conn
+
+	sessionID string
+	signedDC  int16
+	dc        int
+	media     bool
+	workerDst string
+	started   time.Time
+
+	mu         sync.Mutex
+	upChunks   int
+	downChunks int
+}
+
+func wrapMtProtoWorkerPayloadTrace(
+	conn net.Conn,
+	request mtproxyfrontend.OutboundRequest,
+	sessionID string,
+	workerDst string,
+) net.Conn {
+	if conn == nil || !request.IsMedia {
+		return conn
+	}
+	return &mtProtoWorkerPayloadTraceConn{
+		Conn:      conn,
+		sessionID: strings.TrimSpace(sessionID),
+		signedDC:  request.SignedDC,
+		dc:        request.DCID,
+		media:     request.IsMedia,
+		workerDst: strings.TrimSpace(workerDst),
+		started:   time.Now(),
+	}
+}
+
+func (c *mtProtoWorkerPayloadTraceConn) Read(dst []byte) (int, error) {
+	n, err := c.Conn.Read(dst)
+	if n > 0 {
+		c.traceChunk("worker_to_client", n)
+	}
+	return n, err
+}
+
+func (c *mtProtoWorkerPayloadTraceConn) Write(data []byte) (int, error) {
+	n, err := c.Conn.Write(data)
+	if n > 0 {
+		c.traceChunk("client_to_worker", n)
+	}
+	return n, err
+}
+
+func (c *mtProtoWorkerPayloadTraceConn) traceChunk(direction string, size int) {
+	if size <= 0 || logInfo == nil {
+		return
+	}
+
+	c.mu.Lock()
+	var index int
+	switch direction {
+	case "client_to_worker":
+		if c.upChunks >= mtProtoWorkerPayloadTraceLimit {
+			c.mu.Unlock()
+			return
+		}
+		c.upChunks++
+		index = c.upChunks
+	case "worker_to_client":
+		if c.downChunks >= mtProtoWorkerPayloadTraceLimit {
+			c.mu.Unlock()
+			return
+		}
+		c.downChunks++
+		index = c.downChunks
+	default:
+		c.mu.Unlock()
+		return
+	}
+	elapsed := time.Since(c.started).Milliseconds()
+	sessionID := c.sessionID
+	signedDC := c.signedDC
+	dc := c.dc
+	media := c.media
+	workerDst := c.workerDst
+	c.mu.Unlock()
+
+	logInfo.Printf(
+		"MTProto Worker payload trace session_id=%s signed_dc=%d dc=%d media=%t worker_dst=%s direction=%s chunk_index=%d bytes=%d elapsed_ms=%d",
+		mtProtoStatusField(sessionID),
+		signedDC,
+		dc,
+		media,
+		mtProtoStatusField(workerDst),
+		direction,
+		index,
+		size,
+		elapsed,
+	)
+}
+
+func (c *mtProtoWorkerPayloadTraceConn) RouteDiagnostics() mtproxyfrontend.RouteDiagnostics {
+	diagnostics := mtproxyfrontend.RouteDiagnostics{
+		SessionID: c.sessionID,
+		WorkerDst: c.workerDst,
+	}
+	if provider, ok := c.Conn.(mtproxyfrontend.RouteDiagnosticsProvider); ok {
+		provided := provider.RouteDiagnostics()
+		if strings.TrimSpace(provided.SessionID) != "" {
+			diagnostics.SessionID = strings.TrimSpace(provided.SessionID)
+		}
+		if strings.TrimSpace(provided.WorkerDst) != "" {
+			diagnostics.WorkerDst = strings.TrimSpace(provided.WorkerDst)
+		}
+	}
+	return diagnostics
+}
+
+var _ net.Conn = (*mtProtoWorkerPayloadTraceConn)(nil)
+var _ mtproxyfrontend.RouteDiagnosticsProvider = (*mtProtoWorkerPayloadTraceConn)(nil)

--- a/native/tgwsproxy/mtproto_worker_payload_trace_test.go
+++ b/native/tgwsproxy/mtproto_worker_payload_trace_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"tg-ws-proxy/mtproxyfrontend"
+)
+
+func TestMtProtoWorkerPayloadTraceLogsFirst16ChunksPerDirection(t *testing.T) {
+	previousLogInfo := logInfo
+	var logs bytes.Buffer
+	logInfo = log.New(&logs, "", 0)
+	t.Cleanup(func() { logInfo = previousLogInfo })
+
+	recv := make([][]byte, 17)
+	for i := range recv {
+		recv[i] = bytes.Repeat([]byte{byte(i + 1)}, i+1)
+	}
+	socket := &fakeMtProtoFrameSocket{recv: recv}
+	base := &mtProtoWebSocketStream{socket: socket}
+	request := mtproxyfrontend.OutboundRequest{
+		DCID:     2,
+		SignedDC: -2,
+		IsMedia:  true,
+	}
+	traced := wrapMtProtoWorkerPayloadTrace(base, request, "media-session", "149.154.167.51")
+
+	for i := 0; i < 17; i++ {
+		payload := bytes.Repeat([]byte{0xA5}, i+1)
+		if n, err := traced.Write(payload); err != nil || n != len(payload) {
+			t.Fatalf("write[%d] n=%d err=%v", i, n, err)
+		}
+	}
+
+	buf := make([]byte, 128)
+	for i := 0; i < 17; i++ {
+		n, err := traced.Read(buf)
+		if err != nil {
+			t.Fatalf("read[%d]: %v", i, err)
+		}
+		if n != i+1 {
+			t.Fatalf("read[%d] n=%d want=%d", i, n, i+1)
+		}
+	}
+
+	text := logs.String()
+	if got := strings.Count(text, "direction=client_to_worker"); got != mtProtoWorkerPayloadTraceLimit {
+		t.Fatalf("client_to_worker traces=%d want=%d\n%s", got, mtProtoWorkerPayloadTraceLimit, text)
+	}
+	if got := strings.Count(text, "direction=worker_to_client"); got != mtProtoWorkerPayloadTraceLimit {
+		t.Fatalf("worker_to_client traces=%d want=%d\n%s", got, mtProtoWorkerPayloadTraceLimit, text)
+	}
+	for _, want := range []string{
+		"session_id=media-session",
+		"signed_dc=-2",
+		"dc=2",
+		"media=true",
+		"worker_dst=149.154.167.51",
+		"direction=client_to_worker chunk_index=16",
+		"direction=worker_to_client chunk_index=16",
+		"bytes=16",
+		"elapsed_ms=",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in trace:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "chunk_index=17") {
+		t.Fatalf("trace exceeded bounded limit:\n%s", text)
+	}
+}
+
+func TestMtProtoWorkerPayloadTraceSkipsNonMediaAndPreservesDiagnostics(t *testing.T) {
+	base := &mtProtoWebSocketStream{
+		socket:    &fakeMtProtoFrameSocket{},
+		sessionID: "underlying-session",
+		workerDst: "149.154.167.51",
+	}
+	nonMedia := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: 2, IsMedia: false}
+	if got := wrapMtProtoWorkerPayloadTrace(base, nonMedia, "ignored", "ignored"); got != base {
+		t.Fatal("non-media Worker connection must not be wrapped")
+	}
+
+	media := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: -2, IsMedia: true}
+	wrapped := wrapMtProtoWorkerPayloadTrace(base, media, "fallback-session", "149.154.167.220")
+	diagnostics := mtproxyfrontend.RouteDiagnosticsFor(wrapped, media)
+	if diagnostics.SessionID != "underlying-session" {
+		t.Fatalf("session id=%q", diagnostics.SessionID)
+	}
+	if diagnostics.WorkerDst != "149.154.167.51" {
+		t.Fatalf("worker dst=%q", diagnostics.WorkerDst)
+	}
+}

--- a/native/tgwsproxy/mtproto_worker_payload_trace_test.go
+++ b/native/tgwsproxy/mtproto_worker_payload_trace_test.go
@@ -73,24 +73,58 @@ func TestMtProtoWorkerPayloadTraceLogsFirst16ChunksPerDirection(t *testing.T) {
 	}
 }
 
-func TestMtProtoWorkerPayloadTraceSkipsNonMediaAndPreservesDiagnostics(t *testing.T) {
+func TestMtProtoWorkerPayloadTraceIncludesNonMediaWorkerSessions(t *testing.T) {
+	previousLogInfo := logInfo
+	var logs bytes.Buffer
+	logInfo = log.New(&logs, "", 0)
+	t.Cleanup(func() { logInfo = previousLogInfo })
+
 	base := &mtProtoWebSocketStream{
-		socket:    &fakeMtProtoFrameSocket{},
+		socket:    &fakeMtProtoFrameSocket{recv: [][]byte{{0x42, 0x43}}},
 		sessionID: "underlying-session",
 		workerDst: "149.154.167.51",
 	}
-	nonMedia := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: 2, IsMedia: false}
-	if got := wrapMtProtoWorkerPayloadTrace(base, nonMedia, "ignored", "ignored"); got != base {
-		t.Fatal("non-media Worker connection must not be wrapped")
+	request := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: 2, IsMedia: false}
+	wrapped := wrapMtProtoWorkerPayloadTrace(base, request, "fallback-session", "149.154.167.51")
+	if wrapped == base {
+		t.Fatal("non-media Worker connection must be wrapped for diagnostic tracing")
 	}
 
-	media := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: -2, IsMedia: true}
-	wrapped := wrapMtProtoWorkerPayloadTrace(base, media, "fallback-session", "149.154.167.220")
-	diagnostics := mtproxyfrontend.RouteDiagnosticsFor(wrapped, media)
+	if n, err := wrapped.Write([]byte{0x10, 0x20, 0x30}); err != nil || n != 3 {
+		t.Fatalf("write n=%d err=%v", n, err)
+	}
+	buf := make([]byte, 8)
+	if n, err := wrapped.Read(buf); err != nil || n != 2 {
+		t.Fatalf("read n=%d err=%v", n, err)
+	}
+
+	text := logs.String()
+	for _, want := range []string{
+		"session_id=fallback-session",
+		"signed_dc=2",
+		"dc=2",
+		"media=false",
+		"worker_dst=149.154.167.51",
+		"direction=client_to_worker chunk_index=1 bytes=3",
+		"direction=worker_to_client chunk_index=1 bytes=2",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in trace:\n%s", want, text)
+		}
+	}
+
+	diagnostics := mtproxyfrontend.RouteDiagnosticsFor(wrapped, request)
 	if diagnostics.SessionID != "underlying-session" {
 		t.Fatalf("session id=%q", diagnostics.SessionID)
 	}
 	if diagnostics.WorkerDst != "149.154.167.51" {
 		t.Fatalf("worker dst=%q", diagnostics.WorkerDst)
+	}
+}
+
+func TestMtProtoWorkerPayloadTraceNilConnectionIsUnchanged(t *testing.T) {
+	request := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: 2, IsMedia: false}
+	if got := wrapMtProtoWorkerPayloadTrace(nil, request, "session", "149.154.167.51"); got != nil {
+		t.Fatal("nil Worker connection must remain nil")
 	}
 }

--- a/native/tgwsproxy/mtproto_worker_route.go
+++ b/native/tgwsproxy/mtproto_worker_route.go
@@ -398,6 +398,7 @@ func (c *mtProtoWorkerConnector) Connect(
 			workerStream.sessionID = sessionID
 			workerStream.workerDst = target
 		}
+		stream = wrapMtProtoWorkerPayloadTrace(stream, request, sessionID, target)
 
 		result.ActualBackend = mtProtoWorkerBackend
 		result.Reason = "connected"

--- a/native/tgwsproxy/mtproto_worker_route.go
+++ b/native/tgwsproxy/mtproto_worker_route.go
@@ -264,7 +264,11 @@ func (c *mtProtoWorkerConnector) Connect(
 	}
 
 	workerRelayInit := request.RelayInit
-	if effectiveDC != request.DCID || effectiveMedia != request.IsMedia {
+	// A Flowseal media fix changes only the physical Worker destination.
+	// Rewriting relay_init from -DC2 to -DC4 makes Telegram treat the stream
+	// as a different logical DC and causes the media session to close.
+	if !destination.FlowsealMediaFixApplied &&
+		(effectiveDC != request.DCID || effectiveMedia != request.IsMedia) {
 		signedDC := effectiveDC
 		if effectiveMedia {
 			signedDC = -effectiveDC

--- a/native/tgwsproxy/mtproto_worker_route.go
+++ b/native/tgwsproxy/mtproto_worker_route.go
@@ -112,7 +112,7 @@ func (c *mtProtoRouteConnector) Connect(
 		}
 		if logInfo != nil {
 			logInfo.Printf("MTProto route candidate failed route=%s selected_backend=%s reason=%s error=%v",
-				route, selectedBackend, mtProtoStatusField(result.Reason), lastErr)
+				route, selectedBackend, mtProtoStatusField(lastResult.Reason), lastErr)
 		}
 	}
 
@@ -293,7 +293,10 @@ func (c *mtProtoWorkerConnector) Connect(
 		return nil, result
 	}
 
-	sessionID := newWorkerSessionID()
+	// The frontend and Worker connector independently derive the same opaque
+	// identifier from relay_init, so every lifecycle log can be correlated
+	// without exposing relay key material or relying on log ordering.
+	sessionID := mtproxyfrontend.SessionIDForRequest(request)
 	var lastErr error
 	var lastReason string
 	for i := 0; i < maxAttempts; i++ {
@@ -307,7 +310,9 @@ func (c *mtProtoWorkerConnector) Connect(
 		)
 		if logInfo != nil {
 			logInfo.Printf(
-				"MTProto route truth frontend=MTProto selected_backend=%s actual_backend=none fallback_used=false reason=connecting dc=%d media=%t effective_dc=%d effective_media=%t transport=%s worker_host=%s worker_dst=%s destination_mode=%s effective_destination_mode=%s attempt=%d",
+				"MTProto route truth frontend=MTProto session_id=%s signed_dc=%d selected_backend=%s actual_backend=none fallback_used=false reason=connecting dc=%d media=%t effective_dc=%d effective_media=%t transport=%s worker_host=%s worker_dst=%s destination_mode=%s effective_destination_mode=%s attempt=%d",
+				sessionID,
+				request.SignedDC,
 				mtProtoWorkerBackend,
 				request.DCID,
 				request.IsMedia,
@@ -334,7 +339,9 @@ func (c *mtProtoWorkerConnector) Connect(
 			ws = pooled
 			if logInfo != nil {
 				logInfo.Printf(
-					"MTProto Worker WS preconnect hit dc=%d media=%t worker_host=%s worker_dst=%s attempt=%d",
+					"MTProto Worker WS preconnect hit session_id=%s signed_dc=%d dc=%d media=%t worker_host=%s worker_dst=%s attempt=%d",
+					sessionID,
+					request.SignedDC,
 					effectiveDC,
 					effectiveMedia,
 					candidate.Domain,
@@ -346,7 +353,9 @@ func (c *mtProtoWorkerConnector) Connect(
 			preconnectEnabled := workerWsPreconnectActive()
 			if logInfo != nil && preconnectEnabled {
 				logInfo.Printf(
-					"MTProto Worker WS preconnect miss dc=%d media=%t worker_host=%s worker_dst=%s attempt=%d",
+					"MTProto Worker WS preconnect miss session_id=%s signed_dc=%d dc=%d media=%t worker_host=%s worker_dst=%s attempt=%d",
+					sessionID,
+					request.SignedDC,
 					effectiveDC,
 					effectiveMedia,
 					candidate.Domain,
@@ -356,7 +365,9 @@ func (c *mtProtoWorkerConnector) Connect(
 			}
 			if logInfo != nil {
 				logInfo.Printf(
-					"MTProto Worker WS fresh dial dc=%d media=%t worker_host=%s worker_dst=%s preconnect_enabled=%t attempt=%d",
+					"MTProto Worker WS fresh dial session_id=%s signed_dc=%d dc=%d media=%t worker_host=%s worker_dst=%s preconnect_enabled=%t attempt=%d",
+					sessionID,
+					request.SignedDC,
 					effectiveDC,
 					effectiveMedia,
 					candidate.Domain,
@@ -383,6 +394,10 @@ func (c *mtProtoWorkerConnector) Connect(
 			}
 			continue
 		}
+		if workerStream, ok := stream.(*mtProtoWebSocketStream); ok {
+			workerStream.sessionID = sessionID
+			workerStream.workerDst = target
+		}
 
 		result.ActualBackend = mtProtoWorkerBackend
 		result.Reason = "connected"
@@ -406,14 +421,16 @@ func mtProtoWorkerConfigured() bool {
 }
 
 type mtProtoWebSocketStream struct {
-	socket   mtProtoFrameSocket
-	splitter *MsgSplitter
-	local    net.Addr
-	remote   net.Addr
-	readMu   sync.Mutex
-	readBuf  []byte
-	closeMu  sync.Mutex
-	closed   bool
+	socket    mtProtoFrameSocket
+	splitter  *MsgSplitter
+	local     net.Addr
+	remote    net.Addr
+	sessionID string
+	workerDst string
+	readMu    sync.Mutex
+	readBuf   []byte
+	closeMu   sync.Mutex
+	closed    bool
 }
 
 func (s *mtProtoWebSocketStream) Read(dst []byte) (int, error) {
@@ -494,6 +511,13 @@ func (s *mtProtoWebSocketStream) SetWriteDeadline(time.Time) error {
 	return nil
 }
 
+func (s *mtProtoWebSocketStream) RouteDiagnostics() mtproxyfrontend.RouteDiagnostics {
+	return mtproxyfrontend.RouteDiagnostics{
+		SessionID: strings.TrimSpace(s.sessionID),
+		WorkerDst: strings.TrimSpace(s.workerDst),
+	}
+}
+
 type mtProtoNetAddr string
 
 func (a mtProtoNetAddr) Network() string {
@@ -505,6 +529,7 @@ func (a mtProtoNetAddr) String() string {
 }
 
 var (
-	_ net.Conn  = (*mtProtoWebSocketStream)(nil)
-	_ io.Closer = (*mtProtoWebSocketStream)(nil)
+	_ net.Conn                                 = (*mtProtoWebSocketStream)(nil)
+	_ io.Closer                                = (*mtProtoWebSocketStream)(nil)
+	_ mtproxyfrontend.RouteDiagnosticsProvider = (*mtProtoWebSocketStream)(nil)
 )

--- a/native/tgwsproxy/mtproto_worker_route_test.go
+++ b/native/tgwsproxy/mtproto_worker_route_test.go
@@ -97,7 +97,7 @@ func TestMtProtoWorkerConnectorUsesFlowsealDCMapDestination(t *testing.T) {
 	}
 }
 
-func TestMtProtoWorkerConnectorAlignsExperimentalMediaDestinationAndRelayInit(t *testing.T) {
+func TestMtProtoWorkerConnectorMediaDestinationOverridePreservesRelayInit(t *testing.T) {
 	withRuntimeSettings(t, func(settings runtimeSettings) runtimeSettings {
 		settings.Worker.Enabled = true
 		settings.Worker.Domain = "example.workers.dev"
@@ -131,17 +131,17 @@ func TestMtProtoWorkerConnectorAlignsExperimentalMediaDestinationAndRelayInit(t 
 	}
 	defer conn.Close()
 
-	if !containsAll(dialPath, "/apiws?", "dc=4", "dst=149.154.167.220", "media=1", "sid=") {
+	if !containsAll(dialPath, "/apiws?", "dc=2", "dst=149.154.167.220", "media=1", "sid=") {
 		t.Fatalf("path=%s", dialPath)
 	}
 	if len(socket.sent) != 1 {
 		t.Fatalf("sent frames=%d", len(socket.sent))
 	}
-	if bytes.Equal(socket.sent[0], relayInit) {
-		t.Fatal("expected relay init route metadata to be patched for effective DC4 media destination")
+	if !bytes.Equal(socket.sent[0], relayInit) {
+		t.Fatal("media destination override must preserve the original DC2 media relay init")
 	}
 	dc, isMedia, ok := dcFromInit(socket.sent[0])
-	if !ok || dc != 4 || !isMedia {
+	if !ok || dc != 2 || !isMedia {
 		t.Fatalf("relay init dc=%d media=%t ok=%t", dc, isMedia, ok)
 	}
 }

--- a/native/tgwsproxy/mtproxyfrontend/route_diagnostics.go
+++ b/native/tgwsproxy/mtproxyfrontend/route_diagnostics.go
@@ -1,0 +1,48 @@
+package mtproxyfrontend
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net"
+	"strings"
+)
+
+// RouteDiagnostics contains correlation metadata that is safe to expose in
+// runtime logs. SessionID is derived from the random relay init through SHA-256
+// so no obfuscation key material is logged directly.
+type RouteDiagnostics struct {
+	SessionID string
+	WorkerDst string
+}
+
+// RouteDiagnosticsProvider lets an outbound connection expose route-specific
+// metadata without coupling the MTProto frontend to a concrete backend.
+type RouteDiagnosticsProvider interface {
+	RouteDiagnostics() RouteDiagnostics
+}
+
+// SessionIDForRequest returns a stable identifier for one MTProto relay
+// session. Real requests have a freshly generated relay init, so the truncated
+// SHA-256 value is unique enough for diagnostic correlation while remaining
+// non-sensitive.
+func SessionIDForRequest(request OutboundRequest) string {
+	sum := sha256.Sum256(request.RelayInit)
+	return hex.EncodeToString(sum[:8])
+}
+
+// RouteDiagnosticsFor combines request-level correlation with optional
+// backend-specific metadata exposed by the connected stream.
+func RouteDiagnosticsFor(conn net.Conn, request OutboundRequest) RouteDiagnostics {
+	diagnostics := RouteDiagnostics{SessionID: SessionIDForRequest(request)}
+	provider, ok := conn.(RouteDiagnosticsProvider)
+	if !ok {
+		return diagnostics
+	}
+
+	provided := provider.RouteDiagnostics()
+	if strings.TrimSpace(provided.SessionID) != "" {
+		diagnostics.SessionID = strings.TrimSpace(provided.SessionID)
+	}
+	diagnostics.WorkerDst = strings.TrimSpace(provided.WorkerDst)
+	return diagnostics
+}

--- a/native/tgwsproxy/mtproxyfrontend/route_diagnostics_test.go
+++ b/native/tgwsproxy/mtproxyfrontend/route_diagnostics_test.go
@@ -1,0 +1,58 @@
+package mtproxyfrontend
+
+import (
+	"net"
+	"testing"
+)
+
+type testRouteDiagnosticsConn struct {
+	net.Conn
+	diagnostics RouteDiagnostics
+}
+
+func (c *testRouteDiagnosticsConn) RouteDiagnostics() RouteDiagnostics {
+	return c.diagnostics
+}
+
+func TestSessionIDForRequestStableAndDistinct(t *testing.T) {
+	first := OutboundRequest{RelayInit: []byte("relay-init-a")}
+	second := OutboundRequest{RelayInit: []byte("relay-init-b")}
+
+	firstID := SessionIDForRequest(first)
+	if len(firstID) != 16 {
+		t.Fatalf("session id length=%d want=16: %q", len(firstID), firstID)
+	}
+	if SessionIDForRequest(first) != firstID {
+		t.Fatal("session id must be stable for the same request")
+	}
+	if SessionIDForRequest(second) == firstID {
+		t.Fatal("different relay init values must not share a session id")
+	}
+}
+
+func TestRouteDiagnosticsForUsesBackendMetadata(t *testing.T) {
+	request := OutboundRequest{RelayInit: []byte("relay-init")}
+	conn := &testRouteDiagnosticsConn{diagnostics: RouteDiagnostics{
+		SessionID: "worker-session",
+		WorkerDst: "149.154.167.51",
+	}}
+
+	diagnostics := RouteDiagnosticsFor(conn, request)
+	if diagnostics.SessionID != "worker-session" {
+		t.Fatalf("session id=%q", diagnostics.SessionID)
+	}
+	if diagnostics.WorkerDst != "149.154.167.51" {
+		t.Fatalf("worker dst=%q", diagnostics.WorkerDst)
+	}
+}
+
+func TestRouteDiagnosticsForFallsBackToRequestSession(t *testing.T) {
+	request := OutboundRequest{RelayInit: []byte("relay-init")}
+	diagnostics := RouteDiagnosticsFor(nil, request)
+	if diagnostics.SessionID != SessionIDForRequest(request) {
+		t.Fatalf("session id=%q", diagnostics.SessionID)
+	}
+	if diagnostics.WorkerDst != "" {
+		t.Fatalf("worker dst=%q want empty", diagnostics.WorkerDst)
+	}
+}

--- a/native/tgwsproxy/mtproxyfrontend/runtime.go
+++ b/native/tgwsproxy/mtproxyfrontend/runtime.go
@@ -454,9 +454,28 @@ func (r *Runtime) handleConnection(ctx context.Context, conn net.Conn, config Co
 
 	r.log("MTProto route connected frontend=MTProto selected_backend=%s actual_backend=%s fallback_used=%t reason=%s",
 		result.SelectedBackend, result.ActualBackend, result.FallbackUsed, result.Reason)
-	bridgeTransformedStreams(ctx, clientConn, outbound, request.ClientToRelay, request.RelayToClient)
+	bridge := bridgeTransformedStreams(ctx, clientConn, outbound, request.ClientToRelay, request.RelayToClient)
+	bridgeError := "none"
+	if bridge.Err != nil {
+		bridgeError = sanitizeStatusField(bridge.Err.Error())
+	}
+	r.log(
+		"MTProto bridge closed frontend=MTProto selected_backend=%s actual_backend=%s fallback_used=%t first_terminator=%s close_reason=%s up_bytes=%d down_bytes=%d up_chunks=%d down_chunks=%d duration_ms=%d error=%s",
+		result.SelectedBackend,
+		result.ActualBackend,
+		result.FallbackUsed,
+		bridge.FirstTerminator,
+		bridge.CloseReason,
+		bridge.UpBytes,
+		bridge.DownBytes,
+		bridge.UpChunks,
+		bridge.DownChunks,
+		bridge.Duration.Milliseconds(),
+		bridgeError,
+	)
 	r.updateRouteTruth(OutboundResult{
 		SelectedBackend: result.SelectedBackend,
+		ActualBackend:   result.ActualBackend,
 		FallbackUsed:    result.FallbackUsed,
 		Reason:          "connection_closed",
 	})
@@ -551,38 +570,87 @@ func emptyStatusField(value string) string {
 	return value
 }
 
+type bridgeDirectionResult struct {
+	Direction string
+	Bytes     int64
+	Chunks    int64
+	Reason    string
+	Err       error
+}
+
+type bridgeResult struct {
+	UpBytes         int64
+	DownBytes       int64
+	UpChunks        int64
+	DownChunks      int64
+	FirstTerminator string
+	CloseReason     string
+	Err             error
+	Duration        time.Duration
+}
+
 func bridgeTransformedStreams(
 	ctx context.Context,
 	client net.Conn,
 	outbound net.Conn,
 	upTransform StreamTransform,
 	downTransform StreamTransform,
-) {
-	ctx, cancel := context.WithCancel(ctx)
+) bridgeResult {
+	started := time.Now()
+	bridgeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	results := make(chan bridgeDirectionResult, 2)
 	go func() {
-		<-ctx.Done()
+		<-bridgeCtx.Done()
 		_ = client.Close()
 		_ = outbound.Close()
 	}()
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go copyTransformed(&wg, cancel, outbound, client, upTransform)
-	go copyTransformed(&wg, cancel, client, outbound, downTransform)
+	go copyTransformed(&wg, bridgeCtx, results, "client_to_upstream", outbound, client, upTransform)
+	go copyTransformed(&wg, bridgeCtx, results, "upstream_to_client", client, outbound, downTransform)
+
+	first := <-results
+	cancel()
 	wg.Wait()
+	second := <-results
+
+	result := bridgeResult{
+		FirstTerminator: first.Direction,
+		CloseReason:     first.Reason,
+		Err:             first.Err,
+		Duration:        time.Since(started),
+	}
+	applyBridgeDirectionResult(&result, first)
+	applyBridgeDirectionResult(&result, second)
+	return result
+}
+
+func applyBridgeDirectionResult(result *bridgeResult, direction bridgeDirectionResult) {
+	if direction.Direction == "client_to_upstream" {
+		result.UpBytes = direction.Bytes
+		result.UpChunks = direction.Chunks
+		return
+	}
+	result.DownBytes = direction.Bytes
+	result.DownChunks = direction.Chunks
 }
 
 func copyTransformed(
 	wg *sync.WaitGroup,
-	cancel context.CancelFunc,
+	ctx context.Context,
+	results chan<- bridgeDirectionResult,
+	direction string,
 	dst io.Writer,
 	src io.Reader,
 	transform StreamTransform,
 ) {
 	defer wg.Done()
-	defer cancel()
+	outcome := bridgeDirectionResult{Direction: direction}
+	defer func() { results <- outcome }()
+
 	buf := make([]byte, 64*1024)
 	for {
 		n, err := src.Read(buf)
@@ -592,10 +660,27 @@ func copyTransformed(
 				chunk = transform(chunk)
 			}
 			if writeErr := writeFull(dst, chunk); writeErr != nil {
+				if ctx.Err() != nil {
+					outcome.Reason = "cancelled"
+				} else {
+					outcome.Reason = "write_error"
+					outcome.Err = writeErr
+				}
 				return
 			}
+			outcome.Bytes += int64(n)
+			outcome.Chunks++
 		}
 		if err != nil {
+			switch {
+			case errors.Is(err, io.EOF):
+				outcome.Reason = "eof"
+			case ctx.Err() != nil:
+				outcome.Reason = "cancelled"
+			default:
+				outcome.Reason = "read_error"
+				outcome.Err = err
+			}
 			return
 		}
 	}

--- a/native/tgwsproxy/mtproxyfrontend/runtime.go
+++ b/native/tgwsproxy/mtproxyfrontend/runtime.go
@@ -439,20 +439,30 @@ func (r *Runtime) handleConnection(ctx context.Context, conn net.Conn, config Co
 	if config.FakeTLSDomain != "" {
 		r.noteFakeTLSAccepted()
 	}
-	r.log("MTProto route request remote=%s signed_dc=%d dc=%d media=%t test_dc=%t transport=%s selected_backend=%s",
-		remote, request.SignedDC, request.DCID, request.IsMedia, request.IsTestDC, request.Transport, r.connector.Capability().SelectedBackend)
+
+	sessionID := SessionIDForRequest(request)
+	r.log("MTProto route request session_id=%s remote=%s signed_dc=%d dc=%d media=%t test_dc=%t transport=%s selected_backend=%s",
+		sessionID, remote, request.SignedDC, request.DCID, request.IsMedia, request.IsTestDC, request.Transport, r.connector.Capability().SelectedBackend)
 
 	outbound, result := r.connector.Connect(ctx, request)
 	r.updateRouteTruth(result)
 	if result.Err != nil || outbound == nil {
-		r.log("MTProto route failed frontend=MTProto selected_backend=%s actual_backend=%s fallback_used=%t reason=%s error=%v",
+		r.log("MTProto route failed frontend=MTProto session_id=%s signed_dc=%d dc=%d media=%t worker_dst=none selected_backend=%s actual_backend=%s fallback_used=%t reason=%s error=%v",
+			sessionID, request.SignedDC, request.DCID, request.IsMedia,
 			emptyStatusField(result.SelectedBackend), emptyStatusField(result.ActualBackend),
 			result.FallbackUsed, emptyStatusField(result.Reason), result.Err)
 		return
 	}
 	defer outbound.Close()
 
-	r.log("MTProto route connected frontend=MTProto selected_backend=%s actual_backend=%s fallback_used=%t reason=%s",
+	diagnostics := RouteDiagnosticsFor(outbound, request)
+	if diagnostics.SessionID != "" {
+		sessionID = diagnostics.SessionID
+	}
+	workerDst := emptyStatusField(diagnostics.WorkerDst)
+
+	r.log("MTProto route connected frontend=MTProto session_id=%s signed_dc=%d dc=%d media=%t worker_dst=%s selected_backend=%s actual_backend=%s fallback_used=%t reason=%s",
+		sessionID, request.SignedDC, request.DCID, request.IsMedia, workerDst,
 		result.SelectedBackend, result.ActualBackend, result.FallbackUsed, result.Reason)
 	bridge := bridgeTransformedStreams(ctx, clientConn, outbound, request.ClientToRelay, request.RelayToClient)
 	bridgeError := "none"
@@ -460,7 +470,12 @@ func (r *Runtime) handleConnection(ctx context.Context, conn net.Conn, config Co
 		bridgeError = sanitizeStatusField(bridge.Err.Error())
 	}
 	r.log(
-		"MTProto bridge closed frontend=MTProto selected_backend=%s actual_backend=%s fallback_used=%t first_terminator=%s close_reason=%s up_bytes=%d down_bytes=%d up_chunks=%d down_chunks=%d duration_ms=%d error=%s",
+		"MTProto bridge closed frontend=MTProto session_id=%s signed_dc=%d dc=%d media=%t worker_dst=%s selected_backend=%s actual_backend=%s fallback_used=%t first_terminator=%s close_reason=%s up_bytes=%d down_bytes=%d up_chunks=%d down_chunks=%d duration_ms=%d error=%s",
+		sessionID,
+		request.SignedDC,
+		request.DCID,
+		request.IsMedia,
+		workerDst,
 		result.SelectedBackend,
 		result.ActualBackend,
 		result.FallbackUsed,

--- a/native/tgwsproxy/mtproxyfrontend/runtime.go
+++ b/native/tgwsproxy/mtproxyfrontend/runtime.go
@@ -439,8 +439,8 @@ func (r *Runtime) handleConnection(ctx context.Context, conn net.Conn, config Co
 	if config.FakeTLSDomain != "" {
 		r.noteFakeTLSAccepted()
 	}
-	r.log("MTProto route request remote=%s dc=%d media=%t test_dc=%t transport=%s selected_backend=%s",
-		remote, request.DCID, request.IsMedia, request.IsTestDC, request.Transport, r.connector.Capability().SelectedBackend)
+	r.log("MTProto route request remote=%s signed_dc=%d dc=%d media=%t test_dc=%t transport=%s selected_backend=%s",
+		remote, request.SignedDC, request.DCID, request.IsMedia, request.IsTestDC, request.Transport, r.connector.Capability().SelectedBackend)
 
 	outbound, result := r.connector.Connect(ctx, request)
 	r.updateRouteTruth(result)

--- a/native/tgwsproxy/mtproxyfrontend/runtime_test.go
+++ b/native/tgwsproxy/mtproxyfrontend/runtime_test.go
@@ -1,9 +1,13 @@
 package mtproxyfrontend
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"net"
 	"strings"
 	"testing"
+	"time"
 )
 
 const testSecret = "0123456789abcdef0123456789abcdef"
@@ -105,4 +109,144 @@ func reservePort(t *testing.T) int {
 	}
 	defer listener.Close()
 	return listener.Addr().(*net.TCPAddr).Port
+}
+
+
+func TestBridgeTransformedStreamsBidirectionalLargeAndSequentialPayload(t *testing.T) {
+	clientPeer, clientBridge := net.Pipe()
+	outboundBridge, upstreamPeer := net.Pipe()
+	defer clientPeer.Close()
+	defer upstreamPeer.Close()
+
+	resultCh := make(chan bridgeResult, 1)
+	go func() {
+		resultCh <- bridgeTransformedStreams(
+			context.Background(),
+			clientBridge,
+			outboundBridge,
+			xorTransformForBridgeTest(0x5a),
+			xorTransformForBridgeTest(0xa5),
+		)
+	}()
+
+	upPayloads := [][]byte{
+		[]byte("first-packet"),
+		[]byte("second-packet"),
+		bytes.Repeat([]byte{0x31}, 96*1024),
+	}
+	var wantUpBytes int64
+	for _, payload := range upPayloads {
+		wantUpBytes += int64(len(payload))
+		expected := xorBytesForBridgeTest(payload, 0x5a)
+		writeAndReadFullForBridgeTest(t, clientPeer, upstreamPeer, payload, expected)
+	}
+
+	downPayloads := [][]byte{
+		[]byte("reply-one"),
+		[]byte("reply-two"),
+		bytes.Repeat([]byte{0x72}, 80*1024),
+	}
+	var wantDownBytes int64
+	for _, payload := range downPayloads {
+		wantDownBytes += int64(len(payload))
+		expected := xorBytesForBridgeTest(payload, 0xa5)
+		writeAndReadFullForBridgeTest(t, upstreamPeer, clientPeer, payload, expected)
+	}
+
+	if err := clientPeer.Close(); err != nil {
+		t.Fatalf("close client: %v", err)
+	}
+
+	select {
+	case result := <-resultCh:
+		if result.FirstTerminator != "client_to_upstream" {
+			t.Fatalf("first terminator=%s", result.FirstTerminator)
+		}
+		if result.CloseReason != "eof" {
+			t.Fatalf("close reason=%s err=%v", result.CloseReason, result.Err)
+		}
+		if result.UpBytes != wantUpBytes {
+			t.Fatalf("up bytes=%d want=%d", result.UpBytes, wantUpBytes)
+		}
+		if result.DownBytes != wantDownBytes {
+			t.Fatalf("down bytes=%d want=%d", result.DownBytes, wantDownBytes)
+		}
+		if result.UpChunks == 0 || result.DownChunks == 0 {
+			t.Fatalf("chunks up=%d down=%d", result.UpChunks, result.DownChunks)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("bridge did not terminate")
+	}
+}
+
+func TestBridgeTransformedStreamsReportsUpstreamClose(t *testing.T) {
+	clientPeer, clientBridge := net.Pipe()
+	outboundBridge, upstreamPeer := net.Pipe()
+	defer clientPeer.Close()
+
+	resultCh := make(chan bridgeResult, 1)
+	go func() {
+		resultCh <- bridgeTransformedStreams(
+			context.Background(),
+			clientBridge,
+			outboundBridge,
+			nil,
+			nil,
+		)
+	}()
+
+	payload := []byte("request")
+	writeAndReadFullForBridgeTest(t, clientPeer, upstreamPeer, payload, payload)
+	if err := upstreamPeer.Close(); err != nil {
+		t.Fatalf("close upstream: %v", err)
+	}
+
+	select {
+	case result := <-resultCh:
+		if result.FirstTerminator != "upstream_to_client" {
+			t.Fatalf("first terminator=%s", result.FirstTerminator)
+		}
+		if result.CloseReason != "eof" {
+			t.Fatalf("close reason=%s err=%v", result.CloseReason, result.Err)
+		}
+		if result.UpBytes != int64(len(payload)) {
+			t.Fatalf("up bytes=%d want=%d", result.UpBytes, len(payload))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("bridge did not terminate")
+	}
+}
+
+func xorTransformForBridgeTest(mask byte) StreamTransform {
+	return func(in []byte) []byte {
+		return xorBytesForBridgeTest(in, mask)
+	}
+}
+
+func xorBytesForBridgeTest(in []byte, mask byte) []byte {
+	out := make([]byte, len(in))
+	for i, b := range in {
+		out[i] = b ^ mask
+	}
+	return out
+}
+
+func writeAndReadFullForBridgeTest(t *testing.T, writer net.Conn, reader net.Conn, input, expected []byte) {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := writer.Write(input)
+		errCh <- err
+	}()
+
+	got := make([]byte, len(expected))
+	if _, err := io.ReadFull(reader, got); err != nil {
+		t.Fatalf("read full: %v", err)
+	}
+	if !bytes.Equal(got, expected) {
+		t.Fatalf("payload mismatch len=%d", len(expected))
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("write: %v", err)
+	}
 }

--- a/native/tgwsproxy/mtproxyfrontend/session.go
+++ b/native/tgwsproxy/mtproxyfrontend/session.go
@@ -45,6 +45,7 @@ type StreamTransform func([]byte) []byte
 
 type OutboundRequest struct {
 	DCID          int
+	SignedDC      int16
 	IsMedia       bool
 	IsTestDC      bool
 	Transport     Transport
@@ -136,6 +137,7 @@ func prepareOutboundRequest(
 
 	return OutboundRequest{
 		DCID:          dc,
+		SignedDC:      signedDC,
 		IsMedia:       signedDC < 0,
 		IsTestDC:      isTestDC,
 		Transport:     transport,

--- a/native/tgwsproxy/mtproxyfrontend/session_test.go
+++ b/native/tgwsproxy/mtproxyfrontend/session_test.go
@@ -29,8 +29,8 @@ func TestPrepareOutboundRequestExtractsRouteMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareOutboundRequest: %v", err)
 	}
-	if request.DCID != 2 || !request.IsMedia {
-		t.Fatalf("route metadata dc=%d media=%t", request.DCID, request.IsMedia)
+	if request.SignedDC != -2 || request.DCID != 2 || !request.IsMedia {
+		t.Fatalf("route metadata signed_dc=%d dc=%d media=%t", request.SignedDC, request.DCID, request.IsMedia)
 	}
 	if request.Transport != TransportPaddedIntermediate {
 		t.Fatalf("transport=%s", request.Transport)
@@ -60,6 +60,9 @@ func TestOutboundTransformsRoundTrip(t *testing.T) {
 	request, _, err := prepareOutboundRequest(server, testSecret, "", false, false)
 	if err != nil {
 		t.Fatalf("prepareOutboundRequest: %v", err)
+	}
+	if request.SignedDC != 4 || request.DCID != 4 || request.IsMedia {
+		t.Fatalf("route metadata signed_dc=%d dc=%d media=%t", request.SignedDC, request.DCID, request.IsMedia)
 	}
 
 	clientPlain := []byte("client-to-telegram-payload")
@@ -168,8 +171,8 @@ func TestPrepareOutboundRequestMarksHighDcAsTestDc(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareOutboundRequest: %v", err)
 	}
-	if request.DCID != 2 || !request.IsTestDC {
-		t.Fatalf("route metadata dc=%d test=%t", request.DCID, request.IsTestDC)
+	if request.SignedDC != 10002 || request.DCID != 2 || !request.IsTestDC {
+		t.Fatalf("route metadata signed_dc=%d dc=%d test=%t", request.SignedDC, request.DCID, request.IsTestDC)
 	}
 
 	relayDecryptor, err := newAESCTR(request.RelayInit[8:40], request.RelayInit[40:56])

--- a/native/tgwsproxy/tgwsroute/flowseal_destination.go
+++ b/native/tgwsproxy/tgwsroute/flowseal_destination.go
@@ -131,7 +131,15 @@ func ResolveCfWorkerDestination(input WorkerDestinationInput) WorkerDestinationP
 
 	if applyMediaFix {
 		plan.FlowsealMediaFixApplied = true
-		plan.EffectiveDC = mediaFix.DC
+		// Keep Telegram's logical DC/media identity intact. The Flowseal-style
+		// media fix is a physical destination override only: a DC2 media
+		// handshake must stay DC2 media even when TCP is sent to 149.154.167.220.
+		// mediaFix.DC remains only as a fallback for synthetic/unknown routes
+		// that do not carry a valid logical DC.
+		plan.EffectiveDC = input.DCID
+		if plan.EffectiveDC <= 0 {
+			plan.EffectiveDC = mediaFix.DC
+		}
 		plan.EffectiveIsMedia = true
 		plan.WorkerDst = mediaFix.IP
 		plan.WorkerDstSource = WorkerDstSourceFlowsealMediaDC4Fix

--- a/native/tgwsproxy/tgwsroute/flowseal_destination_test.go
+++ b/native/tgwsproxy/tgwsroute/flowseal_destination_test.go
@@ -82,7 +82,7 @@ func TestResolveCfWorkerDestination_ExperimentalForceRequiresExplicitFlag(t *tes
 	}
 }
 
-func TestResolveCfWorkerDestination_ExperimentalForceMediaDC4(t *testing.T) {
+func TestResolveCfWorkerDestination_ExperimentalMediaOverridePreservesLogicalDC(t *testing.T) {
 	plan := ResolveCfWorkerDestination(WorkerDestinationInput{
 		WorkerDomain:  "example.workers.dev",
 		DCID:          2,
@@ -106,7 +106,7 @@ func TestResolveCfWorkerDestination_ExperimentalForceMediaDC4(t *testing.T) {
 	if plan.EffectiveDestinationMode != WorkerDestinationExperimentalForceMediaDC4 {
 		t.Fatalf("effective_destination_mode=%q", plan.EffectiveDestinationMode)
 	}
-	if plan.EffectiveDC != 4 || !plan.EffectiveIsMedia {
+	if plan.EffectiveDC != 2 || !plan.EffectiveIsMedia {
 		t.Fatalf("effective dc/media = %d/%t", plan.EffectiveDC, plan.EffectiveIsMedia)
 	}
 	if plan.WorkerDst != "149.154.167.220" {
@@ -118,7 +118,7 @@ func TestResolveCfWorkerDestination_ExperimentalForceMediaDC4(t *testing.T) {
 	if !strings.Contains(plan.WorkerURL, "media=1") {
 		t.Fatalf("workerURL=%s", plan.WorkerURL)
 	}
-	if !strings.Contains(plan.WorkerURL, "dc=4") {
+	if !strings.Contains(plan.WorkerURL, "dc=2") {
 		t.Fatalf("workerURL=%s", plan.WorkerURL)
 	}
 }


### PR DESCRIPTION
## Зависимость

Этот PR построен поверх #36 и завершает диагностическую/регрессионную часть стека v1.10.14:

- #34 — effective Worker destination;
- #35 — Flowseal-compatible Worker framing;
- #36 — stable/fresh Worker dial semantics;
- этот PR — end-to-end regression gate и диагностика проблемы #29.

## Автоматические проверки

Локальный Worker relay harness без внешней сети проверяет:

- normal Worker-only session;
- media session с отрицательным signed DC;
- upload/download;
- несколько последовательных payload;
- fragmented writes;
- payload >64 KiB;
- fresh dial без fallback;
- сохранение исходного relay-init при media destination override.

## Результат ручной проверки

Проблема #29 **ещё не считается исправленной** до повторной проверки на Android.

Логи подтвердили реальные запросы вида:

```text
signed_dc=-2 dc=2 media=true worker_dst=149.154.167.51
signed_dc=-4 dc=4 media=true worker_dst=149.154.167.91
```

## End-to-end session correlation

Commit `0fb7d77d93310480594ae97a73380560963ab3de` добавляет единый диагностический `session_id` на весь жизненный цикл соединения:

```text
route request
→ route truth
→ Worker dial / preconnect
→ route connected
→ bridge closed
```

`session_id` вычисляется как короткий SHA-256 fingerprint случайного `relay_init`; исходный relay key material в лог не попадает.

Для Worker `route connected` и `bridge closed` содержат:

```text
session_id=...
signed_dc=...
dc=...
media=...
worker_dst=...
```

## Payload diagnostics

Последующая трассировка показала воспроизводимый паттерн крупных Worker-сессий: несколько подряд исходящих chunks по `65536` байт, отсутствие `worker_to_client` данных и затем `write timeout` / `broken pipe` на соединении с Cloudflare. При этом короткие MTProto-сессии через тот же Worker продолжают отвечать.

## A/B mitigation: bounded Worker WebSocket writes

Head `cf63259a49e2c49b1d412e45abe73f87cbc3ba19` добавляет экспериментальное исправление для повторной проверки #29:

- крупный outbound MTProto WebSocket payload разбивается на сообщения максимум по `16 KiB`;
- каждый WebSocket frame записывается полностью, даже если `net.Conn.Write` возвращает допустимый short write;
- `SendBatch`, pong и close используют тот же full-write contract;
- добавлены unit-тесты на `16 KiB` segmentation и искусственные short writes.

Это сохраняет порядок байтов TCP-потока на Worker, но исключает наблюдавшуюся серию одиночных 64-KiB WebSocket messages. До успешной ручной проверки на устройстве #29 остаётся открытым.

Relates #33
Relates #29