### PR TITLE
[diag][#29] Trace low-level Worker WebSocket writes

### DIFF
--- a/native/tgwsproxy/mtproto_websocket_frames.go
+++ b/native/tgwsproxy/mtproto_websocket_frames.go
@@ -11,14 +11,6 @@ import (
 // fragmented message before it is exposed to the MTProto stream.
 const mtProtoMaxWebSocketMessageLen = 16 * 1024 * 1024
 
-// mtProtoMaxOutboundWebSocketPayloadLen deliberately keeps each outbound
-// WebSocket message below the 64 KiB reads produced by the MTProto bridge.
-// Real-device diagnostics for #29 showed repeated 64 KiB Worker messages with
-// no downstream response, followed by Cloudflare write timeouts. Splitting the
-// byte stream into smaller WebSocket messages preserves TCP stream semantics at
-// the Worker while adding backpressure between writes.
-const mtProtoMaxOutboundWebSocketPayloadLen = 16 * 1024
-
 // mtProtoSafeFrameSocket adds bounded WebSocket message reassembly to the
 // existing RawWebSocket without changing the Android-specific transport,
 // routing, cooldown, watchdog or diagnostics code around it.
@@ -50,21 +42,11 @@ func (s *mtProtoSafeFrameSocket) Send(data []byte) error {
 	if s == nil || s.raw == nil {
 		return fmt.Errorf("WebSocket closed")
 	}
-	if len(data) == 0 {
-		return s.writeFrameFull(opBinary, nil)
-	}
-
-	for len(data) > 0 {
-		chunkLen := len(data)
-		if chunkLen > mtProtoMaxOutboundWebSocketPayloadLen {
-			chunkLen = mtProtoMaxOutboundWebSocketPayloadLen
-		}
-		if err := s.writeFrameFull(opBinary, data[:chunkLen]); err != nil {
-			return err
-		}
-		data = data[chunkLen:]
-	}
-	return nil
+	// Preserve the working protocol behaviour: one MTProto bridge write maps to
+	// exactly one WebSocket message. The 16 KiB segmentation experiment broke
+	// normal Telegram connectivity because the Worker treats WebSocket message
+	// boundaries as write boundaries to the Telegram DC.
+	return s.writeFrameFull(opBinary, data)
 }
 
 func (s *mtProtoSafeFrameSocket) SendBatch(parts [][]byte) error {
@@ -86,9 +68,9 @@ func (s *mtProtoSafeFrameSocket) writeFrameFull(opcode int, payload []byte) erro
 	return writeFull(s.raw.conn, frame)
 }
 
-// writeFull turns net.Conn.Write into the same all-bytes-or-error contract that
-// Flowseal gets from StreamWriter.write()+drain(). A short successful Write is
-// legal for io.Writer and must not silently truncate a WebSocket frame.
+// writeFull gives a WebSocket frame an all-bytes-or-error write contract. A
+// short successful net.Conn.Write is legal and must not silently truncate a
+// frame; the loop also lets the frame-level diagnostic identify such writes.
 func writeFull(writer io.Writer, data []byte) error {
 	for len(data) > 0 {
 		n, err := writer.Write(data)

--- a/native/tgwsproxy/mtproto_websocket_frames.go
+++ b/native/tgwsproxy/mtproto_websocket_frames.go
@@ -11,17 +11,6 @@ import (
 // fragmented message before it is exposed to the MTProto stream.
 const mtProtoMaxWebSocketMessageLen = 16 * 1024 * 1024
 
-// Android consistently delivers bulk MTProto traffic to the bridge in exact
-// 64 KiB reads. Sending such a read as one WebSocket frame makes Cloudflare
-// stop draining the connection in the failing #29 trace. Keep the WebSocket
-// message boundary intact, but fragment only messages that reach that
-// threshold into RFC 6455 continuation frames. The Worker still receives one
-// message event and therefore performs one TCP write to the Telegram DC.
-const (
-	mtProtoOutboundFragmentThreshold  = 64 * 1024
-	mtProtoOutboundFragmentPayloadLen = 16 * 1024
-)
-
 // mtProtoSafeFrameSocket adds bounded WebSocket message reassembly to the
 // existing RawWebSocket without changing the Android-specific transport,
 // routing, cooldown, watchdog or diagnostics code around it.
@@ -53,10 +42,11 @@ func (s *mtProtoSafeFrameSocket) Send(data []byte) error {
 	if s == nil || s.raw == nil {
 		return fmt.Errorf("WebSocket closed")
 	}
-	if len(data) < mtProtoOutboundFragmentThreshold {
-		return s.writeFrameFull(opBinary, data)
-	}
-	return s.writeMessageFragmented(data)
+	// Preserve the working protocol behaviour: one MTProto bridge write maps to
+	// exactly one WebSocket message. The 16 KiB segmentation experiment broke
+	// normal Telegram connectivity because the Worker treats WebSocket message
+	// boundaries as write boundaries to the Telegram DC.
+	return s.writeFrameFull(opBinary, data)
 }
 
 func (s *mtProtoSafeFrameSocket) SendBatch(parts [][]byte) error {
@@ -64,42 +54,6 @@ func (s *mtProtoSafeFrameSocket) SendBatch(parts [][]byte) error {
 		if err := s.Send(part); err != nil {
 			return err
 		}
-	}
-	return nil
-}
-
-// writeMessageFragmented preserves one logical WebSocket message while
-// avoiding a single frame with a 64-bit payload-length field. The first frame
-// is binary with FIN=0, middle frames are continuation frames with FIN=0, and
-// the final continuation frame has FIN=1. Each frame is independently masked
-// as required for client-to-server WebSocket traffic.
-func (s *mtProtoSafeFrameSocket) writeMessageFragmented(payload []byte) error {
-	if s.raw.closed.Load() {
-		return fmt.Errorf("WebSocket closed")
-	}
-
-	s.raw.writeMu.Lock()
-	defer s.raw.writeMu.Unlock()
-
-	for offset := 0; offset < len(payload); {
-		end := offset + mtProtoOutboundFragmentPayloadLen
-		if end > len(payload) {
-			end = len(payload)
-		}
-
-		opcode := opContinuation
-		if offset == 0 {
-			opcode = opBinary
-		}
-		fin := end == len(payload)
-		frame := s.raw.buildFrame(opcode, payload[offset:end], true)
-		if !fin {
-			frame[0] &^= 0x80
-		}
-		if err := writeFull(s.raw.conn, frame); err != nil {
-			return err
-		}
-		offset = end
 	}
 	return nil
 }

--- a/native/tgwsproxy/mtproto_websocket_frames.go
+++ b/native/tgwsproxy/mtproto_websocket_frames.go
@@ -11,6 +11,17 @@ import (
 // fragmented message before it is exposed to the MTProto stream.
 const mtProtoMaxWebSocketMessageLen = 16 * 1024 * 1024
 
+// Android consistently delivers bulk MTProto traffic to the bridge in exact
+// 64 KiB reads. Sending such a read as one WebSocket frame makes Cloudflare
+// stop draining the connection in the failing #29 trace. Keep the WebSocket
+// message boundary intact, but fragment only messages that reach that
+// threshold into RFC 6455 continuation frames. The Worker still receives one
+// message event and therefore performs one TCP write to the Telegram DC.
+const (
+	mtProtoOutboundFragmentThreshold  = 64 * 1024
+	mtProtoOutboundFragmentPayloadLen = 16 * 1024
+)
+
 // mtProtoSafeFrameSocket adds bounded WebSocket message reassembly to the
 // existing RawWebSocket without changing the Android-specific transport,
 // routing, cooldown, watchdog or diagnostics code around it.
@@ -42,11 +53,10 @@ func (s *mtProtoSafeFrameSocket) Send(data []byte) error {
 	if s == nil || s.raw == nil {
 		return fmt.Errorf("WebSocket closed")
 	}
-	// Preserve the working protocol behaviour: one MTProto bridge write maps to
-	// exactly one WebSocket message. The 16 KiB segmentation experiment broke
-	// normal Telegram connectivity because the Worker treats WebSocket message
-	// boundaries as write boundaries to the Telegram DC.
-	return s.writeFrameFull(opBinary, data)
+	if len(data) < mtProtoOutboundFragmentThreshold {
+		return s.writeFrameFull(opBinary, data)
+	}
+	return s.writeMessageFragmented(data)
 }
 
 func (s *mtProtoSafeFrameSocket) SendBatch(parts [][]byte) error {
@@ -54,6 +64,42 @@ func (s *mtProtoSafeFrameSocket) SendBatch(parts [][]byte) error {
 		if err := s.Send(part); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// writeMessageFragmented preserves one logical WebSocket message while
+// avoiding a single frame with a 64-bit payload-length field. The first frame
+// is binary with FIN=0, middle frames are continuation frames with FIN=0, and
+// the final continuation frame has FIN=1. Each frame is independently masked
+// as required for client-to-server WebSocket traffic.
+func (s *mtProtoSafeFrameSocket) writeMessageFragmented(payload []byte) error {
+	if s.raw.closed.Load() {
+		return fmt.Errorf("WebSocket closed")
+	}
+
+	s.raw.writeMu.Lock()
+	defer s.raw.writeMu.Unlock()
+
+	for offset := 0; offset < len(payload); {
+		end := offset + mtProtoOutboundFragmentPayloadLen
+		if end > len(payload) {
+			end = len(payload)
+		}
+
+		opcode := opContinuation
+		if offset == 0 {
+			opcode = opBinary
+		}
+		fin := end == len(payload)
+		frame := s.raw.buildFrame(opcode, payload[offset:end], true)
+		if !fin {
+			frame[0] &^= 0x80
+		}
+		if err := writeFull(s.raw.conn, frame); err != nil {
+			return err
+		}
+		offset = end
 	}
 	return nil
 }

--- a/native/tgwsproxy/mtproto_websocket_frames_test.go
+++ b/native/tgwsproxy/mtproto_websocket_frames_test.go
@@ -76,17 +76,20 @@ func testServerFrame(opcode int, payload []byte, fin bool) []byte {
 	}
 }
 
-func clientFramePayloadLengths(t *testing.T, data []byte) []int {
+type clientFrameMeta struct {
+	opcode  int
+	fin     bool
+	payload []byte
+}
+
+func clientFrames(t *testing.T, data []byte) []clientFrameMeta {
 	t.Helper()
 	reader := bytes.NewReader(data)
-	lengths := make([]int, 0, 4)
+	frames := make([]clientFrameMeta, 0, 4)
 	for reader.Len() > 0 {
 		first, err := reader.ReadByte()
 		if err != nil {
 			t.Fatalf("read frame first byte: %v", err)
-		}
-		if first&0x0F != opBinary {
-			t.Fatalf("opcode=%d want=%d", first&0x0F, opBinary)
 		}
 		second, err := reader.ReadByte()
 		if err != nil {
@@ -119,10 +122,26 @@ func clientFramePayloadLengths(t *testing.T, data []byte) []int {
 		if payloadLen > uint64(reader.Len()) {
 			t.Fatalf("payload length=%d remaining=%d", payloadLen, reader.Len())
 		}
-		if _, err := reader.Seek(int64(payloadLen), io.SeekCurrent); err != nil {
-			t.Fatalf("skip payload: %v", err)
+		payload := make([]byte, int(payloadLen))
+		if _, err := io.ReadFull(reader, payload); err != nil {
+			t.Fatalf("read payload: %v", err)
 		}
-		lengths = append(lengths, int(payloadLen))
+		xorMaskInPlace(payload, mask[:])
+		frames = append(frames, clientFrameMeta{
+			opcode:  int(first & 0x0F),
+			fin:     first&0x80 != 0,
+			payload: payload,
+		})
+	}
+	return frames
+}
+
+func clientFramePayloadLengths(t *testing.T, data []byte) []int {
+	t.Helper()
+	frames := clientFrames(t, data)
+	lengths := make([]int, 0, len(frames))
+	for _, frame := range frames {
+		lengths = append(lengths, len(frame.payload))
 	}
 	return lengths
 }
@@ -201,18 +220,57 @@ func TestMtProtoSafeFrameSocketHandlesPingBetweenFragments(t *testing.T) {
 	}
 }
 
-func TestMtProtoSafeFrameSocketPreservesLargeOutboundWriteAsSingleMessage(t *testing.T) {
+func TestMtProtoSafeFrameSocketLeavesSub64KiBOutboundWriteAsSingleFrame(t *testing.T) {
 	raw, conn := newFrameTestRaw(nil)
 	socket := &mtProtoSafeFrameSocket{raw: raw}
-	payload := bytes.Repeat([]byte{0x5A}, 65536)
+	payload := bytes.Repeat([]byte{0x4B}, mtProtoOutboundFragmentThreshold-1)
 
 	if err := socket.Send(payload); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 
-	lengths := clientFramePayloadLengths(t, conn.writes.Bytes())
-	if len(lengths) != 1 || lengths[0] != len(payload) {
-		t.Fatalf("frame lengths=%v want=[%d]", lengths, len(payload))
+	frames := clientFrames(t, conn.writes.Bytes())
+	if len(frames) != 1 {
+		t.Fatalf("frames=%d want=1", len(frames))
+	}
+	if frames[0].opcode != opBinary || !frames[0].fin {
+		t.Fatalf("frame opcode=%d fin=%t want binary final", frames[0].opcode, frames[0].fin)
+	}
+	if !bytes.Equal(frames[0].payload, payload) {
+		t.Fatal("single-frame payload changed")
+	}
+}
+
+func TestMtProtoSafeFrameSocketFragments64KiBOutboundWriteAsSingleMessage(t *testing.T) {
+	raw, conn := newFrameTestRaw(nil)
+	socket := &mtProtoSafeFrameSocket{raw: raw}
+	payload := bytes.Repeat([]byte{0x5A}, mtProtoOutboundFragmentThreshold)
+
+	if err := socket.Send(payload); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	frames := clientFrames(t, conn.writes.Bytes())
+	if len(frames) != 4 {
+		t.Fatalf("frames=%d want=4", len(frames))
+	}
+	var reassembled []byte
+	for i, frame := range frames {
+		wantOpcode := opContinuation
+		if i == 0 {
+			wantOpcode = opBinary
+		}
+		wantFIN := i == len(frames)-1
+		if frame.opcode != wantOpcode || frame.fin != wantFIN {
+			t.Fatalf("frame %d opcode=%d fin=%t want opcode=%d fin=%t", i, frame.opcode, frame.fin, wantOpcode, wantFIN)
+		}
+		if len(frame.payload) != mtProtoOutboundFragmentPayloadLen {
+			t.Fatalf("frame %d payload=%d want=%d", i, len(frame.payload), mtProtoOutboundFragmentPayloadLen)
+		}
+		reassembled = append(reassembled, frame.payload...)
+	}
+	if !bytes.Equal(reassembled, payload) {
+		t.Fatal("fragmented WebSocket message payload changed")
 	}
 }
 

--- a/native/tgwsproxy/mtproto_websocket_frames_test.go
+++ b/native/tgwsproxy/mtproto_websocket_frames_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 type frameTestConn struct {
-	reader    *bytes.Reader
-	writes    bytes.Buffer
-	closed    bool
-	maxWrite  int
+	reader     *bytes.Reader
+	writes     bytes.Buffer
+	closed     bool
+	maxWrite   int
 	writeCalls int
 }
 
@@ -201,28 +201,18 @@ func TestMtProtoSafeFrameSocketHandlesPingBetweenFragments(t *testing.T) {
 	}
 }
 
-func TestMtProtoSafeFrameSocketSplitsLargeOutboundWrite(t *testing.T) {
+func TestMtProtoSafeFrameSocketPreservesLargeOutboundWriteAsSingleMessage(t *testing.T) {
 	raw, conn := newFrameTestRaw(nil)
 	socket := &mtProtoSafeFrameSocket{raw: raw}
-	payload := bytes.Repeat([]byte{0x5A}, 2*mtProtoMaxOutboundWebSocketPayloadLen+123)
+	payload := bytes.Repeat([]byte{0x5A}, 65536)
 
 	if err := socket.Send(payload); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 
 	lengths := clientFramePayloadLengths(t, conn.writes.Bytes())
-	want := []int{
-		mtProtoMaxOutboundWebSocketPayloadLen,
-		mtProtoMaxOutboundWebSocketPayloadLen,
-		123,
-	}
-	if len(lengths) != len(want) {
-		t.Fatalf("frame lengths=%v want=%v", lengths, want)
-	}
-	for i := range want {
-		if lengths[i] != want[i] {
-			t.Fatalf("frame lengths=%v want=%v", lengths, want)
-		}
+	if len(lengths) != 1 || lengths[0] != len(payload) {
+		t.Fatalf("frame lengths=%v want=[%d]", lengths, len(payload))
 	}
 }
 

--- a/native/tgwsproxy/mtproto_websocket_frames_test.go
+++ b/native/tgwsproxy/mtproto_websocket_frames_test.go
@@ -76,20 +76,17 @@ func testServerFrame(opcode int, payload []byte, fin bool) []byte {
 	}
 }
 
-type clientFrameMeta struct {
-	opcode  int
-	fin     bool
-	payload []byte
-}
-
-func clientFrames(t *testing.T, data []byte) []clientFrameMeta {
+func clientFramePayloadLengths(t *testing.T, data []byte) []int {
 	t.Helper()
 	reader := bytes.NewReader(data)
-	frames := make([]clientFrameMeta, 0, 4)
+	lengths := make([]int, 0, 4)
 	for reader.Len() > 0 {
 		first, err := reader.ReadByte()
 		if err != nil {
 			t.Fatalf("read frame first byte: %v", err)
+		}
+		if first&0x0F != opBinary {
+			t.Fatalf("opcode=%d want=%d", first&0x0F, opBinary)
 		}
 		second, err := reader.ReadByte()
 		if err != nil {
@@ -122,26 +119,10 @@ func clientFrames(t *testing.T, data []byte) []clientFrameMeta {
 		if payloadLen > uint64(reader.Len()) {
 			t.Fatalf("payload length=%d remaining=%d", payloadLen, reader.Len())
 		}
-		payload := make([]byte, int(payloadLen))
-		if _, err := io.ReadFull(reader, payload); err != nil {
-			t.Fatalf("read payload: %v", err)
+		if _, err := reader.Seek(int64(payloadLen), io.SeekCurrent); err != nil {
+			t.Fatalf("skip payload: %v", err)
 		}
-		xorMaskInPlace(payload, mask[:])
-		frames = append(frames, clientFrameMeta{
-			opcode:  int(first & 0x0F),
-			fin:     first&0x80 != 0,
-			payload: payload,
-		})
-	}
-	return frames
-}
-
-func clientFramePayloadLengths(t *testing.T, data []byte) []int {
-	t.Helper()
-	frames := clientFrames(t, data)
-	lengths := make([]int, 0, len(frames))
-	for _, frame := range frames {
-		lengths = append(lengths, len(frame.payload))
+		lengths = append(lengths, int(payloadLen))
 	}
 	return lengths
 }
@@ -220,57 +201,18 @@ func TestMtProtoSafeFrameSocketHandlesPingBetweenFragments(t *testing.T) {
 	}
 }
 
-func TestMtProtoSafeFrameSocketLeavesSub64KiBOutboundWriteAsSingleFrame(t *testing.T) {
+func TestMtProtoSafeFrameSocketPreservesLargeOutboundWriteAsSingleMessage(t *testing.T) {
 	raw, conn := newFrameTestRaw(nil)
 	socket := &mtProtoSafeFrameSocket{raw: raw}
-	payload := bytes.Repeat([]byte{0x4B}, mtProtoOutboundFragmentThreshold-1)
+	payload := bytes.Repeat([]byte{0x5A}, 65536)
 
 	if err := socket.Send(payload); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 
-	frames := clientFrames(t, conn.writes.Bytes())
-	if len(frames) != 1 {
-		t.Fatalf("frames=%d want=1", len(frames))
-	}
-	if frames[0].opcode != opBinary || !frames[0].fin {
-		t.Fatalf("frame opcode=%d fin=%t want binary final", frames[0].opcode, frames[0].fin)
-	}
-	if !bytes.Equal(frames[0].payload, payload) {
-		t.Fatal("single-frame payload changed")
-	}
-}
-
-func TestMtProtoSafeFrameSocketFragments64KiBOutboundWriteAsSingleMessage(t *testing.T) {
-	raw, conn := newFrameTestRaw(nil)
-	socket := &mtProtoSafeFrameSocket{raw: raw}
-	payload := bytes.Repeat([]byte{0x5A}, mtProtoOutboundFragmentThreshold)
-
-	if err := socket.Send(payload); err != nil {
-		t.Fatalf("send: %v", err)
-	}
-
-	frames := clientFrames(t, conn.writes.Bytes())
-	if len(frames) != 4 {
-		t.Fatalf("frames=%d want=4", len(frames))
-	}
-	var reassembled []byte
-	for i, frame := range frames {
-		wantOpcode := opContinuation
-		if i == 0 {
-			wantOpcode = opBinary
-		}
-		wantFIN := i == len(frames)-1
-		if frame.opcode != wantOpcode || frame.fin != wantFIN {
-			t.Fatalf("frame %d opcode=%d fin=%t want opcode=%d fin=%t", i, frame.opcode, frame.fin, wantOpcode, wantFIN)
-		}
-		if len(frame.payload) != mtProtoOutboundFragmentPayloadLen {
-			t.Fatalf("frame %d payload=%d want=%d", i, len(frame.payload), mtProtoOutboundFragmentPayloadLen)
-		}
-		reassembled = append(reassembled, frame.payload...)
-	}
-	if !bytes.Equal(reassembled, payload) {
-		t.Fatal("fragmented WebSocket message payload changed")
+	lengths := clientFramePayloadLengths(t, conn.writes.Bytes())
+	if len(lengths) != 1 || lengths[0] != len(payload) {
+		t.Fatalf("frame lengths=%v want=[%d]", lengths, len(payload))
 	}
 }
 

--- a/native/tgwsproxy/mtproto_worker_frame_trace.go
+++ b/native/tgwsproxy/mtproto_worker_frame_trace.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"encoding/binary"
+	"net"
+	"sync"
+	"time"
+
+	"tg-ws-proxy/mtproxyfrontend"
+)
+
+const mtProtoWorkerFrameTraceLimit = 32
+
+type mtProtoWorkerFrameTraceConn struct {
+	net.Conn
+
+	sessionID string
+	signedDC  int16
+	dc        int
+	media     bool
+	workerDst string
+	started   time.Time
+
+	mu sync.Mutex
+
+	writeCallIndex int
+	frameIndex     int
+	frameRemaining int
+	frameOpcode    int
+	framePayload   int
+	frameBytes     int
+}
+
+func installMtProtoWorkerFrameTrace(
+	conn net.Conn,
+	request mtproxyfrontend.OutboundRequest,
+	sessionID string,
+	workerDst string,
+) {
+	stream, ok := conn.(*mtProtoWebSocketStream)
+	if !ok || stream == nil {
+		return
+	}
+	safeSocket, ok := stream.socket.(*mtProtoSafeFrameSocket)
+	if !ok || safeSocket == nil || safeSocket.raw == nil || safeSocket.raw.conn == nil {
+		return
+	}
+	if _, alreadyWrapped := safeSocket.raw.conn.(*mtProtoWorkerFrameTraceConn); alreadyWrapped {
+		return
+	}
+
+	safeSocket.raw.conn = &mtProtoWorkerFrameTraceConn{
+		Conn:      safeSocket.raw.conn,
+		sessionID: mtProtoStatusField(sessionID),
+		signedDC:  request.SignedDC,
+		dc:        request.DCID,
+		media:     request.IsMedia,
+		workerDst: mtProtoStatusField(workerDst),
+		started:   time.Now(),
+	}
+}
+
+func (c *mtProtoWorkerFrameTraceConn) Write(data []byte) (int, error) {
+	if len(data) == 0 {
+		return c.Conn.Write(data)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.frameRemaining == 0 {
+		if opcode, payloadBytes, frameBytes, ok := mtProtoOutboundFrameInfo(data); ok {
+			c.frameIndex++
+			c.frameOpcode = opcode
+			c.framePayload = payloadBytes
+			c.frameBytes = frameBytes
+			c.frameRemaining = frameBytes
+		} else {
+			c.frameIndex++
+			c.frameOpcode = -1
+			c.framePayload = -1
+			c.frameBytes = len(data)
+			c.frameRemaining = len(data)
+		}
+	}
+
+	c.writeCallIndex++
+	writeCallIndex := c.writeCallIndex
+	frameIndex := c.frameIndex
+	frameOpcode := c.frameOpcode
+	framePayload := c.framePayload
+	frameBytes := c.frameBytes
+	requestedBytes := len(data)
+
+	writeStarted := time.Now()
+	n, err := c.Conn.Write(data)
+	writeMS := time.Since(writeStarted).Milliseconds()
+
+	if n > 0 {
+		c.frameRemaining -= n
+		if c.frameRemaining < 0 {
+			c.frameRemaining = 0
+		}
+	}
+	remaining := c.frameRemaining
+	completed := remaining == 0
+	shortWrite := err == nil && n < requestedBytes
+
+	result := "ok"
+	errorField := "none"
+	if err != nil {
+		result = "error"
+		errorField = mtProtoStatusField(err.Error())
+	}
+
+	if logInfo != nil && (frameIndex <= mtProtoWorkerFrameTraceLimit || err != nil || shortWrite) {
+		logInfo.Printf(
+			"MTProto Worker WS frame trace session_id=%s signed_dc=%d dc=%d media=%t worker_dst=%s frame_index=%d opcode=%d frame_payload_bytes=%d frame_bytes=%d write_call=%d requested_bytes=%d written_bytes=%d frame_remaining=%d completed=%t short_write=%t write_ms=%d elapsed_ms=%d result=%s error=%s",
+			c.sessionID,
+			c.signedDC,
+			c.dc,
+			c.media,
+			c.workerDst,
+			frameIndex,
+			frameOpcode,
+			framePayload,
+			frameBytes,
+			writeCallIndex,
+			requestedBytes,
+			n,
+			remaining,
+			completed,
+			shortWrite,
+			writeMS,
+			time.Since(c.started).Milliseconds(),
+			result,
+			errorField,
+		)
+	}
+
+	return n, err
+}
+
+func mtProtoOutboundFrameInfo(data []byte) (opcode int, payloadBytes int, frameBytes int, ok bool) {
+	if len(data) < 2 {
+		return 0, 0, 0, false
+	}
+
+	opcode = int(data[0] & 0x0F)
+	payloadLen := uint64(data[1] & 0x7F)
+	headerLen := 2
+
+	switch payloadLen {
+	case 126:
+		if len(data) < 4 {
+			return 0, 0, 0, false
+		}
+		payloadLen = uint64(binary.BigEndian.Uint16(data[2:4]))
+		headerLen = 4
+	case 127:
+		if len(data) < 10 {
+			return 0, 0, 0, false
+		}
+		payloadLen = binary.BigEndian.Uint64(data[2:10])
+		headerLen = 10
+	}
+
+	if data[1]&0x80 != 0 {
+		headerLen += 4
+	}
+	if payloadLen > uint64(^uint(0)>>1) {
+		return 0, 0, 0, false
+	}
+
+	payloadBytes = int(payloadLen)
+	frameBytes = headerLen + payloadBytes
+	if frameBytes > len(data) {
+		return 0, 0, 0, false
+	}
+	return opcode, payloadBytes, frameBytes, true
+}
+
+var _ net.Conn = (*mtProtoWorkerFrameTraceConn)(nil)

--- a/native/tgwsproxy/mtproto_worker_frame_trace_test.go
+++ b/native/tgwsproxy/mtproto_worker_frame_trace_test.go
@@ -9,7 +9,7 @@ import (
 	"tg-ws-proxy/mtproxyfrontend"
 )
 
-func TestMtProtoWorkerFrameTraceReportsFragmentedLargeMessage(t *testing.T) {
+func TestMtProtoWorkerFrameTraceReportsSingleLargeFrame(t *testing.T) {
 	previousLogInfo := logInfo
 	var logs bytes.Buffer
 	logInfo = log.New(&logs, "", 0)
@@ -21,33 +21,27 @@ func TestMtProtoWorkerFrameTraceReportsFragmentedLargeMessage(t *testing.T) {
 	request := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: 2, IsMedia: false}
 	installMtProtoWorkerFrameTrace(stream, request, "frame-session", "149.154.167.51")
 
-	payload := bytes.Repeat([]byte{0x5A}, mtProtoOutboundFragmentThreshold)
+	payload := bytes.Repeat([]byte{0x5A}, 65536)
 	if err := safeSocket.Send(payload); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 
 	text := logs.String()
-	if got := strings.Count(text, "MTProto Worker WS frame trace"); got != 4 {
-		t.Fatalf("frame traces=%d want=4\n%s", got, text)
+	if got := strings.Count(text, "MTProto Worker WS frame trace"); got != 1 {
+		t.Fatalf("frame traces=%d want=1\n%s", got, text)
 	}
 	for _, want := range []string{
 		"session_id=frame-session",
 		"signed_dc=2 dc=2 media=false",
 		"worker_dst=149.154.167.51",
-		"frame_index=1 opcode=2 frame_payload_bytes=16384 frame_bytes=16392",
-		"frame_index=2 opcode=0 frame_payload_bytes=16384 frame_bytes=16392",
-		"frame_index=3 opcode=0 frame_payload_bytes=16384 frame_bytes=16392",
-		"frame_index=4 opcode=0 frame_payload_bytes=16384 frame_bytes=16392",
-		"requested_bytes=16392 written_bytes=16392",
+		"frame_index=1 opcode=2 frame_payload_bytes=65536 frame_bytes=65550",
+		"requested_bytes=65550 written_bytes=65550",
 		"completed=true short_write=false",
 		"result=ok error=none",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("missing %q in trace:\n%s", want, text)
 		}
-	}
-	if strings.Contains(text, "frame_payload_bytes=65536") {
-		t.Fatalf("64 KiB payload must not be emitted as one WebSocket frame:\n%s", text)
 	}
 }
 

--- a/native/tgwsproxy/mtproto_worker_frame_trace_test.go
+++ b/native/tgwsproxy/mtproto_worker_frame_trace_test.go
@@ -9,7 +9,7 @@ import (
 	"tg-ws-proxy/mtproxyfrontend"
 )
 
-func TestMtProtoWorkerFrameTraceReportsSegmentedWrites(t *testing.T) {
+func TestMtProtoWorkerFrameTraceReportsSingleLargeFrame(t *testing.T) {
 	previousLogInfo := logInfo
 	var logs bytes.Buffer
 	logInfo = log.New(&logs, "", 0)
@@ -21,22 +21,21 @@ func TestMtProtoWorkerFrameTraceReportsSegmentedWrites(t *testing.T) {
 	request := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: 2, IsMedia: false}
 	installMtProtoWorkerFrameTrace(stream, request, "frame-session", "149.154.167.51")
 
-	payload := bytes.Repeat([]byte{0x5A}, 2*mtProtoMaxOutboundWebSocketPayloadLen+123)
+	payload := bytes.Repeat([]byte{0x5A}, 65536)
 	if err := safeSocket.Send(payload); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 
 	text := logs.String()
-	if got := strings.Count(text, "MTProto Worker WS frame trace"); got != 3 {
-		t.Fatalf("frame traces=%d want=3\n%s", got, text)
+	if got := strings.Count(text, "MTProto Worker WS frame trace"); got != 1 {
+		t.Fatalf("frame traces=%d want=1\n%s", got, text)
 	}
 	for _, want := range []string{
 		"session_id=frame-session",
 		"signed_dc=2 dc=2 media=false",
 		"worker_dst=149.154.167.51",
-		"frame_index=1 opcode=2 frame_payload_bytes=16384 frame_bytes=16392",
-		"frame_index=2 opcode=2 frame_payload_bytes=16384 frame_bytes=16392",
-		"frame_index=3 opcode=2 frame_payload_bytes=123 frame_bytes=129",
+		"frame_index=1 opcode=2 frame_payload_bytes=65536 frame_bytes=65550",
+		"requested_bytes=65550 written_bytes=65550",
 		"completed=true short_write=false",
 		"result=ok error=none",
 	} {

--- a/native/tgwsproxy/mtproto_worker_frame_trace_test.go
+++ b/native/tgwsproxy/mtproto_worker_frame_trace_test.go
@@ -9,7 +9,7 @@ import (
 	"tg-ws-proxy/mtproxyfrontend"
 )
 
-func TestMtProtoWorkerFrameTraceReportsSingleLargeFrame(t *testing.T) {
+func TestMtProtoWorkerFrameTraceReportsFragmentedLargeMessage(t *testing.T) {
 	previousLogInfo := logInfo
 	var logs bytes.Buffer
 	logInfo = log.New(&logs, "", 0)
@@ -21,27 +21,33 @@ func TestMtProtoWorkerFrameTraceReportsSingleLargeFrame(t *testing.T) {
 	request := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: 2, IsMedia: false}
 	installMtProtoWorkerFrameTrace(stream, request, "frame-session", "149.154.167.51")
 
-	payload := bytes.Repeat([]byte{0x5A}, 65536)
+	payload := bytes.Repeat([]byte{0x5A}, mtProtoOutboundFragmentThreshold)
 	if err := safeSocket.Send(payload); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 
 	text := logs.String()
-	if got := strings.Count(text, "MTProto Worker WS frame trace"); got != 1 {
-		t.Fatalf("frame traces=%d want=1\n%s", got, text)
+	if got := strings.Count(text, "MTProto Worker WS frame trace"); got != 4 {
+		t.Fatalf("frame traces=%d want=4\n%s", got, text)
 	}
 	for _, want := range []string{
 		"session_id=frame-session",
 		"signed_dc=2 dc=2 media=false",
 		"worker_dst=149.154.167.51",
-		"frame_index=1 opcode=2 frame_payload_bytes=65536 frame_bytes=65550",
-		"requested_bytes=65550 written_bytes=65550",
+		"frame_index=1 opcode=2 frame_payload_bytes=16384 frame_bytes=16392",
+		"frame_index=2 opcode=0 frame_payload_bytes=16384 frame_bytes=16392",
+		"frame_index=3 opcode=0 frame_payload_bytes=16384 frame_bytes=16392",
+		"frame_index=4 opcode=0 frame_payload_bytes=16384 frame_bytes=16392",
+		"requested_bytes=16392 written_bytes=16392",
 		"completed=true short_write=false",
 		"result=ok error=none",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("missing %q in trace:\n%s", want, text)
 		}
+	}
+	if strings.Contains(text, "frame_payload_bytes=65536") {
+		t.Fatalf("64 KiB payload must not be emitted as one WebSocket frame:\n%s", text)
 	}
 }
 

--- a/native/tgwsproxy/mtproto_worker_frame_trace_test.go
+++ b/native/tgwsproxy/mtproto_worker_frame_trace_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"tg-ws-proxy/mtproxyfrontend"
+)
+
+func TestMtProtoWorkerFrameTraceReportsSegmentedWrites(t *testing.T) {
+	previousLogInfo := logInfo
+	var logs bytes.Buffer
+	logInfo = log.New(&logs, "", 0)
+	t.Cleanup(func() { logInfo = previousLogInfo })
+
+	raw, _ := newFrameTestRaw(nil)
+	safeSocket := &mtProtoSafeFrameSocket{raw: raw}
+	stream := &mtProtoWebSocketStream{socket: safeSocket}
+	request := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: 2, IsMedia: false}
+	installMtProtoWorkerFrameTrace(stream, request, "frame-session", "149.154.167.51")
+
+	payload := bytes.Repeat([]byte{0x5A}, 2*mtProtoMaxOutboundWebSocketPayloadLen+123)
+	if err := safeSocket.Send(payload); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	text := logs.String()
+	if got := strings.Count(text, "MTProto Worker WS frame trace"); got != 3 {
+		t.Fatalf("frame traces=%d want=3\n%s", got, text)
+	}
+	for _, want := range []string{
+		"session_id=frame-session",
+		"signed_dc=2 dc=2 media=false",
+		"worker_dst=149.154.167.51",
+		"frame_index=1 opcode=2 frame_payload_bytes=16384 frame_bytes=16392",
+		"frame_index=2 opcode=2 frame_payload_bytes=16384 frame_bytes=16392",
+		"frame_index=3 opcode=2 frame_payload_bytes=123 frame_bytes=129",
+		"completed=true short_write=false",
+		"result=ok error=none",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in trace:\n%s", want, text)
+		}
+	}
+}
+
+func TestMtProtoWorkerFrameTraceExposesShortWrites(t *testing.T) {
+	previousLogInfo := logInfo
+	var logs bytes.Buffer
+	logInfo = log.New(&logs, "", 0)
+	t.Cleanup(func() { logInfo = previousLogInfo })
+
+	raw, conn := newFrameTestRaw(nil)
+	conn.maxWrite = 7
+	safeSocket := &mtProtoSafeFrameSocket{raw: raw}
+	stream := &mtProtoWebSocketStream{socket: safeSocket}
+	request := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: -2, IsMedia: true}
+	installMtProtoWorkerFrameTrace(stream, request, "short-write-session", "149.154.167.51")
+
+	if err := safeSocket.Send(bytes.Repeat([]byte{0xA5}, 256)); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	text := logs.String()
+	for _, want := range []string{
+		"session_id=short-write-session",
+		"signed_dc=-2 dc=2 media=true",
+		"frame_index=1 opcode=2 frame_payload_bytes=256 frame_bytes=264",
+		"short_write=true",
+		"completed=true",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in trace:\n%s", want, text)
+		}
+	}
+	if conn.writeCalls <= 1 {
+		t.Fatalf("write calls=%d want multiple", conn.writeCalls)
+	}
+}
+
+func TestMtProtoWorkerPayloadTraceInstallsFrameTrace(t *testing.T) {
+	raw, _ := newFrameTestRaw(nil)
+	safeSocket := &mtProtoSafeFrameSocket{raw: raw}
+	base := &mtProtoWebSocketStream{socket: safeSocket}
+	request := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: -2, IsMedia: true}
+
+	wrapped := wrapMtProtoWorkerPayloadTrace(base, request, "payload-session", "149.154.167.51")
+	if wrapped == nil {
+		t.Fatal("payload trace wrapper is nil")
+	}
+
+	frameTrace, ok := safeSocket.raw.conn.(*mtProtoWorkerFrameTraceConn)
+	if !ok {
+		t.Fatalf("raw conn type=%T want *mtProtoWorkerFrameTraceConn", safeSocket.raw.conn)
+	}
+	if frameTrace.sessionID != "payload-session" {
+		t.Fatalf("session id=%q", frameTrace.sessionID)
+	}
+	if frameTrace.signedDC != -2 || frameTrace.dc != 2 || !frameTrace.media {
+		t.Fatalf("metadata signed_dc=%d dc=%d media=%t", frameTrace.signedDC, frameTrace.dc, frameTrace.media)
+	}
+	if frameTrace.workerDst != "149.154.167.51" {
+		t.Fatalf("worker dst=%q", frameTrace.workerDst)
+	}
+}

--- a/native/tgwsproxy/mtproto_worker_payload_trace.go
+++ b/native/tgwsproxy/mtproto_worker_payload_trace.go
@@ -36,6 +36,11 @@ func wrapMtProtoWorkerPayloadTrace(
 		return conn
 	}
 
+	// Keep the WebSocket frame trace above the diagnostic transport pacing
+	// layer. That way the frame trace still observes one complete serialized
+	// WebSocket frame, while the transport layer can vary how that frame is
+	// handed to crypto/tls without changing WebSocket message boundaries.
+	installMtProtoWorkerTransportWrite(conn, request, sessionID, workerDst)
 	installMtProtoWorkerFrameTrace(conn, request, sessionID, workerDst)
 
 	return &mtProtoWorkerPayloadTraceConn{

--- a/native/tgwsproxy/mtproto_worker_payload_trace.go
+++ b/native/tgwsproxy/mtproto_worker_payload_trace.go
@@ -35,6 +35,9 @@ func wrapMtProtoWorkerPayloadTrace(
 	if conn == nil {
 		return conn
 	}
+
+	installMtProtoWorkerFrameTrace(conn, request, sessionID, workerDst)
+
 	return &mtProtoWorkerPayloadTraceConn{
 		Conn:      conn,
 		sessionID: strings.TrimSpace(sessionID),

--- a/native/tgwsproxy/mtproto_worker_transport_write.go
+++ b/native/tgwsproxy/mtproto_worker_transport_write.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"io"
+	"net"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"tg-ws-proxy/mtproxyfrontend"
+)
+
+const (
+	// This is a diagnostic transport granularity, not a WebSocket fragment
+	// size. The serialized WebSocket frame and its message boundary stay intact.
+	mtProtoWorkerTransportWriteChunk = 16 * 1024
+	mtProtoWorkerTransportTraceLimit = 32
+)
+
+// mtProtoWorkerTransportWriteConn tests whether #29 is sensitive to the
+// application-write cadence into crypto/tls. Flowseal successfully moves bulk
+// traffic through the same Worker while awaiting StreamWriter.drain() after
+// each WebSocket send. Go has no direct drain equivalent here, so this layer
+// hands one already-serialized WebSocket frame to the TLS connection in bounded
+// slices and yields between slices. It never creates extra WebSocket frames or
+// changes message boundaries.
+type mtProtoWorkerTransportWriteConn struct {
+	net.Conn
+
+	sessionID string
+	signedDC  int16
+	dc        int
+	media     bool
+	workerDst string
+	started   time.Time
+
+	mu         sync.Mutex
+	writeIndex int
+}
+
+func installMtProtoWorkerTransportWrite(
+	conn net.Conn,
+	request mtproxyfrontend.OutboundRequest,
+	sessionID string,
+	workerDst string,
+) {
+	stream, ok := conn.(*mtProtoWebSocketStream)
+	if !ok || stream == nil {
+		return
+	}
+	safeSocket, ok := stream.socket.(*mtProtoSafeFrameSocket)
+	if !ok || safeSocket == nil || safeSocket.raw == nil || safeSocket.raw.conn == nil {
+		return
+	}
+	if _, alreadyWrapped := safeSocket.raw.conn.(*mtProtoWorkerTransportWriteConn); alreadyWrapped {
+		return
+	}
+
+	safeSocket.raw.conn = &mtProtoWorkerTransportWriteConn{
+		Conn:      safeSocket.raw.conn,
+		sessionID: strings.TrimSpace(sessionID),
+		signedDC:  request.SignedDC,
+		dc:        request.DCID,
+		media:     request.IsMedia,
+		workerDst: strings.TrimSpace(workerDst),
+		started:   time.Now(),
+	}
+}
+
+func (c *mtProtoWorkerTransportWriteConn) Write(data []byte) (int, error) {
+	if len(data) == 0 {
+		return c.Conn.Write(data)
+	}
+
+	c.mu.Lock()
+	c.writeIndex++
+	writeIndex := c.writeIndex
+	c.mu.Unlock()
+
+	started := time.Now()
+	total := 0
+	transportWrites := 0
+	var writeErr error
+
+	for total < len(data) {
+		end := total + mtProtoWorkerTransportWriteChunk
+		if end > len(data) {
+			end = len(data)
+		}
+
+		for total < end {
+			n, err := c.Conn.Write(data[total:end])
+			transportWrites++
+			if n > 0 {
+				total += n
+			}
+			if err != nil {
+				writeErr = err
+				break
+			}
+			if n == 0 {
+				writeErr = io.ErrShortWrite
+				break
+			}
+		}
+		if writeErr != nil {
+			break
+		}
+
+		// Give the reader goroutine and the runtime network poller an explicit
+		// scheduling point between bounded TLS application writes. Unlike the
+		// rejected RFC6455 experiment, this does not alter bytes on the wire at
+		// the WebSocket protocol layer.
+		runtime.Gosched()
+	}
+
+	if logInfo != nil && (writeIndex <= mtProtoWorkerTransportTraceLimit || writeErr != nil) {
+		result := "ok"
+		errorField := "none"
+		if writeErr != nil {
+			result = "error"
+			errorField = mtProtoStatusField(writeErr.Error())
+		}
+		logInfo.Printf(
+			"MTProto Worker transport write trace session_id=%s signed_dc=%d dc=%d media=%t worker_dst=%s write_index=%d requested_bytes=%d written_bytes=%d transport_writes=%d max_transport_chunk=%d write_ms=%d elapsed_ms=%d result=%s error=%s",
+			mtProtoStatusField(c.sessionID),
+			c.signedDC,
+			c.dc,
+			c.media,
+			mtProtoStatusField(c.workerDst),
+			writeIndex,
+			len(data),
+			total,
+			transportWrites,
+			mtProtoWorkerTransportWriteChunk,
+			time.Since(started).Milliseconds(),
+			time.Since(c.started).Milliseconds(),
+			result,
+			errorField,
+		)
+	}
+
+	return total, writeErr
+}
+
+var _ net.Conn = (*mtProtoWorkerTransportWriteConn)(nil)

--- a/native/tgwsproxy/mtproto_worker_transport_write_test.go
+++ b/native/tgwsproxy/mtproto_worker_transport_write_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"tg-ws-proxy/mtproxyfrontend"
+)
+
+func TestMtProtoWorkerTransportWritePreservesSingleLargeWebSocketFrame(t *testing.T) {
+	previousLogInfo := logInfo
+	var logs bytes.Buffer
+	logInfo = log.New(&logs, "", 0)
+	t.Cleanup(func() { logInfo = previousLogInfo })
+
+	raw, underlying := newFrameTestRaw(nil)
+	safeSocket := &mtProtoSafeFrameSocket{raw: raw}
+	stream := &mtProtoWebSocketStream{socket: safeSocket}
+	request := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: -2, IsMedia: true}
+
+	installMtProtoWorkerTransportWrite(stream, request, "transport-session", "149.154.167.51")
+	installMtProtoWorkerFrameTrace(stream, request, "transport-session", "149.154.167.51")
+
+	frameTrace, ok := safeSocket.raw.conn.(*mtProtoWorkerFrameTraceConn)
+	if !ok {
+		t.Fatalf("raw conn type=%T want *mtProtoWorkerFrameTraceConn", safeSocket.raw.conn)
+	}
+	if _, ok := frameTrace.Conn.(*mtProtoWorkerTransportWriteConn); !ok {
+		t.Fatalf("frame trace inner conn type=%T want *mtProtoWorkerTransportWriteConn", frameTrace.Conn)
+	}
+
+	payload := bytes.Repeat([]byte{0x5A}, 65536)
+	if err := safeSocket.Send(payload); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	lengths := clientFramePayloadLengths(t, underlying.writes.Bytes())
+	if len(lengths) != 1 || lengths[0] != len(payload) {
+		t.Fatalf("frame lengths=%v want=[%d]", lengths, len(payload))
+	}
+	if underlying.writeCalls < 5 {
+		t.Fatalf("underlying TLS writes=%d want at least 5 for 65550 serialized bytes", underlying.writeCalls)
+	}
+
+	text := logs.String()
+	for _, want := range []string{
+		"MTProto Worker WS frame trace",
+		"frame_payload_bytes=65536 frame_bytes=65550",
+		"MTProto Worker transport write trace",
+		"session_id=transport-session",
+		"requested_bytes=65550 written_bytes=65550",
+		"transport_writes=5 max_transport_chunk=16384",
+		"result=ok error=none",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in trace:\n%s", want, text)
+		}
+	}
+}
+
+func TestMtProtoWorkerTransportWriteCompletesShortUnderlyingWrites(t *testing.T) {
+	previousLogInfo := logInfo
+	var logs bytes.Buffer
+	logInfo = log.New(&logs, "", 0)
+	t.Cleanup(func() { logInfo = previousLogInfo })
+
+	raw, underlying := newFrameTestRaw(nil)
+	underlying.maxWrite = 1024
+	safeSocket := &mtProtoSafeFrameSocket{raw: raw}
+	stream := &mtProtoWebSocketStream{socket: safeSocket}
+	request := mtproxyfrontend.OutboundRequest{DCID: 2, SignedDC: 2, IsMedia: false}
+
+	installMtProtoWorkerTransportWrite(stream, request, "short-transport", "149.154.167.51")
+
+	payload := bytes.Repeat([]byte{0xA5}, 65536)
+	if err := safeSocket.Send(payload); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	lengths := clientFramePayloadLengths(t, underlying.writes.Bytes())
+	if len(lengths) != 1 || lengths[0] != len(payload) {
+		t.Fatalf("frame lengths=%v want=[%d]", lengths, len(payload))
+	}
+	if underlying.writeCalls <= 5 {
+		t.Fatalf("underlying writes=%d want more than nominal 5 because of short writes", underlying.writeCalls)
+	}
+	if !strings.Contains(logs.String(), "result=ok error=none") {
+		t.Fatalf("transport trace did not report successful completion:\n%s", logs.String())
+	}
+}


### PR DESCRIPTION
## Зачем

Диагностика #29 локализовала зависание на больших исходящих Worker WebSocket writes.

Ручной Android-прогон показал воспроизводимый паттерн для нескольких DC2-сессий: первые семь WebSocket messages с payload ровно `65536` байт успевали уйти (`7 × 65536 = 458752` байт), `down_bytes` оставался `0`, а следующая запись затем зависала и завершалась `write: connection timed out`.

Два предыдущих framing-эксперимента не подходят:

- разбиение одного MTProto chunk на несколько **отдельных WebSocket messages** по 16 KiB ломало обычное подключение Telegram;
- RFC 6455 fragmentation одного 64-KiB message на четыре 16-KiB frames сохраняла message boundary, но bulk-сбой всё равно повторялся на той же границе `458752` байт.

## A/B с upstream Flowseal

Тот же Cloudflare Worker был проверен через неизменённый upstream Flowseal (`f200e33fd283143a9f101d62aaf9d8c1468a23fe`). В этом прогоне `tcp_fb=0`, а счётчик upstream-трафика Flowseal дошёл примерно до `20.2 MB`, то есть клиентский Flowseal transport смог протолкнуть существенно больше данных через тот же Worker, чем Android runtime.

При этом Cloudflare platform logs для Flowseal-сессий тоже содержат отдельные `loadShed` / `internal error`, поэтому этот A/B не доказывает, что Worker полностью исправен. Он показывает другое: Flowseal transport заметно устойчивее к тому же Worker path, поэтому следующий эксперимент должен менять клиентскую write/backpressure семантику, а не WebSocket protocol framing.

## Текущий эксперимент

Этот PR теперь снова сохраняет upstream-подобную WebSocket семантику:

- один MTProto bridge write -> **один WebSocket message / один FIN binary frame**;
- payload `65536` снова сериализуется как один frame (`frame_bytes=65550`);
- `writeFull` остаётся, поэтому законные short writes не могут молча обрезать frame;
- bounded receive/reassembly и low-level frame trace остаются.

Дополнительно только для диагностируемого Worker path устанавливается `mtProtoWorkerTransportWriteConn` **под frame trace**. Он не меняет WebSocket bytes и не создаёт дополнительные frames/messages. Уже сериализованный frame передаётся в `crypto/tls` порциями максимум по `16 KiB`, между порциями вызывается `runtime.Gosched()`.

Это не заявляется как точный эквивалент `asyncio.StreamWriter.drain()`. Это узкий A/B-тест гипотезы: чувствителен ли #29 к cadence/backpressure больших application writes в Go/TLS.

Добавлен отдельный transport trace:

```text
MTProto Worker transport write trace ... requested_bytes=65550 written_bytes=65550 transport_writes=5 max_transport_chunk=16384 ...
```

Frame trace при этом должен по-прежнему видеть **один** frame:

```text
MTProto Worker WS frame trace ... opcode=2 frame_payload_bytes=65536 frame_bytes=65550 ...
```

## Критерий ручной проверки

Отправить новый не кэшированный файл примерно 20 MiB через Worker и проверить:

1. Telegram после запуска остаётся подключённым;
2. для bulk-трафика видны цельные `65536`-байтные WS messages;
3. transport trace показывает несколько bounded TLS writes на один `65550`-байтный frame;
4. исчезает ли прежний паттерн `458752 up / 0 down / timeout`.

Если bulk начинает проходить, проблема чувствительна к Go/TLS write cadence. Если прежний предел повторяется, гипотеза transport granularity отвергается и следующий шаг — уже не очередное изменение WebSocket framing.

Base — PR #37.

Relates #29
Relates #33