### PR TITLE
[experiment][#29] Relay Worker traffic over Telegram WSS

### DIFF
--- a/.github/workflows/trusted-ci.yml
+++ b/.github/workflows/trusted-ci.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: native/tgwsproxy
         run: go test -race ./...
       - name: Deployed Worker handler tests
-        run: node --test scripts/cloudflare-worker/worker.test.mjs
+        run: node --test scripts/cloudflare-worker/*.test.mjs
 
   ci:
     name: Windows CI

--- a/native/tgwsproxy/flowseal_websocket_connect.go
+++ b/native/tgwsproxy/flowseal_websocket_connect.go
@@ -28,7 +28,7 @@ func dialFlowsealWorkerCandidateContext(ctx context.Context, domain, path, logPr
 	if logInfo != nil {
 		logInfo.Printf("%s Flowseal parity transport connected host=%s path=%s worker_transport=wss_relay_v3 pool=false preconnect=false", logPrefix, domain, v3Path)
 	}
-	return ws, nil
+	return newWorkerWSSRelayV3FrameSocket(ws), nil
 }
 
 // flowsealWorkerWSSRelayPath moves only the Flowseal-parity MTProto Worker dial

--- a/native/tgwsproxy/flowseal_websocket_connect.go
+++ b/native/tgwsproxy/flowseal_websocket_connect.go
@@ -19,15 +19,28 @@ func dialFlowsealWorkerCandidate(domain, path, logPrefix string) (mtProtoFrameSo
 }
 
 func dialFlowsealWorkerCandidateContext(ctx context.Context, domain, path, logPrefix string) (mtProtoFrameSocket, error) {
-	ws, err := connectFlowsealRawWebSocketContext(ctx, domain, domain, path, 10)
+	v3Path := flowsealWorkerWSSRelayPath(path)
+	ws, err := connectFlowsealRawWebSocketContext(ctx, domain, domain, v3Path, 10)
 	if err != nil {
 		logDomainConnectFailure(logPrefix, domain, domain, err)
 		return nil, err
 	}
 	if logInfo != nil {
-		logInfo.Printf("%s Flowseal parity transport connected host=%s path=%s pool=false preconnect=false", logPrefix, domain, path)
+		logInfo.Printf("%s Flowseal parity transport connected host=%s path=%s worker_transport=wss_relay_v3 pool=false preconnect=false", logPrefix, domain, v3Path)
 	}
 	return ws, nil
+}
+
+// flowsealWorkerWSSRelayPath moves only the Flowseal-parity MTProto Worker dial
+// to the experimental v3 endpoint. The shared /apiws builder and legacy Worker
+// routes remain unchanged so v2 stays available for A/B testing.
+func flowsealWorkerWSSRelayPath(path string) string {
+	parsed, err := url.ParseRequestURI(path)
+	if err != nil || parsed.Path != "/apiws" {
+		return path
+	}
+	parsed.Path = "/apiws-ws"
+	return parsed.RequestURI()
 }
 
 func connectFlowsealRawWebSocket(host, domain, path string, timeout float64) (*flowsealRawWebSocket, error) {

--- a/native/tgwsproxy/worker_wss_relay_v3.go
+++ b/native/tgwsproxy/worker_wss_relay_v3.go
@@ -1,0 +1,52 @@
+package main
+
+import "fmt"
+
+// workerWSSRelayV3FrameSocket adapts the existing raw Worker stream to the
+// message semantics expected by Telegram's /apiws endpoint. The first Send is
+// the 64-byte MTProto relay_init. Subsequent transformed TCP writes are fed to
+// MsgSplitter and emitted only as complete MTProto packet WebSocket messages.
+//
+// This wrapper is installed only by the experimental Flowseal-parity Worker
+// dial. Legacy /apiws -> raw TCP Worker paths retain their v2 chunk semantics.
+type workerWSSRelayV3FrameSocket struct {
+	inner       mtProtoFrameSocket
+	splitter    *MsgSplitter
+	initialized bool
+}
+
+func newWorkerWSSRelayV3FrameSocket(inner mtProtoFrameSocket) mtProtoFrameSocket {
+	return &workerWSSRelayV3FrameSocket{inner: inner}
+}
+
+func (s *workerWSSRelayV3FrameSocket) Send(data []byte) error {
+	if !s.initialized {
+		splitter, err := newMsgSplitter(data)
+		if err != nil {
+			return fmt.Errorf("initialize Worker v3 MTProto packet splitter: %w", err)
+		}
+		s.splitter = splitter
+		s.initialized = true
+		return s.inner.Send(data)
+	}
+
+	parts := s.splitter.Split(data)
+	if len(parts) == 0 {
+		return nil
+	}
+	return s.inner.SendBatch(parts)
+}
+
+func (s *workerWSSRelayV3FrameSocket) SendBatch(parts [][]byte) error {
+	return s.inner.SendBatch(parts)
+}
+
+func (s *workerWSSRelayV3FrameSocket) Recv() ([]byte, error) {
+	return s.inner.Recv()
+}
+
+func (s *workerWSSRelayV3FrameSocket) Close() {
+	s.inner.Close()
+}
+
+var _ mtProtoFrameSocket = (*workerWSSRelayV3FrameSocket)(nil)

--- a/native/tgwsproxy/worker_wss_relay_v3_test.go
+++ b/native/tgwsproxy/worker_wss_relay_v3_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestFlowsealWorkerWSSRelayPathPreservesWorkerQuery(t *testing.T) {
+	got := flowsealWorkerWSSRelayPath("/apiws?dc=2&dst=149.154.167.51&media=1&sid=abc123")
+	if !strings.HasPrefix(got, "/apiws-ws?") {
+		t.Fatalf("path=%s", got)
+	}
+	for _, want := range []string{"dc=2", "dst=149.154.167.51", "media=1", "sid=abc123"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("path=%s missing %s", got, want)
+		}
+	}
+}
+
+func TestFlowsealWorkerWSSRelayPathDoesNotRewriteOtherEndpoints(t *testing.T) {
+	for _, input := range []string{"/apiws_test?dc=2", "/other?dc=2", "not a uri"} {
+		if got := flowsealWorkerWSSRelayPath(input); got != input {
+			t.Fatalf("input=%q got=%q", input, got)
+		}
+	}
+}
+
+func TestWorkerWSSRelayV3FrameSocketPacketizesSplitWrites(t *testing.T) {
+	relayInit := buildTestInitWithSignedDC(t, 2)
+	inner := &fakeMtProtoFrameSocket{}
+	socket := newWorkerWSSRelayV3FrameSocket(inner)
+
+	if err := socket.Send(relayInit); err != nil {
+		t.Fatalf("relay init: %v", err)
+	}
+	if len(inner.sent) != 1 || !bytes.Equal(inner.sent[0], relayInit) {
+		t.Fatalf("relay init was not forwarded intact: sent=%x", inner.sent)
+	}
+
+	plainPacket := []byte{1, 9, 8, 7, 6}
+	cipherPacket := encryptRelayPayloadForFramingTest(t, relayInit, plainPacket)
+	cut := 2
+	if err := socket.Send(cipherPacket[:cut]); err != nil {
+		t.Fatalf("first partial send: %v", err)
+	}
+	if len(inner.sent) != 1 || len(inner.batches) != 0 {
+		t.Fatalf("partial packet escaped before completion: sent=%d batches=%d", len(inner.sent), len(inner.batches))
+	}
+
+	if err := socket.Send(cipherPacket[cut:]); err != nil {
+		t.Fatalf("second partial send: %v", err)
+	}
+	if len(inner.batches) != 1 || len(inner.batches[0]) != 1 {
+		t.Fatalf("batches=%x", inner.batches)
+	}
+	if !bytes.Equal(inner.batches[0][0], cipherPacket) {
+		t.Fatalf("packet changed: got=%x want=%x", inner.batches[0][0], cipherPacket)
+	}
+}
+
+func TestWorkerWSSRelayV3FrameSocketRejectsInvalidRelayInit(t *testing.T) {
+	inner := &fakeMtProtoFrameSocket{}
+	socket := newWorkerWSSRelayV3FrameSocket(inner)
+	if err := socket.Send([]byte{1, 2, 3}); err == nil {
+		t.Fatal("expected invalid relay_init to fail before any Worker message is sent")
+	}
+	if len(inner.sent) != 0 || len(inner.batches) != 0 {
+		t.Fatalf("invalid relay_init leaked to Worker: sent=%d batches=%d", len(inner.sent), len(inner.batches))
+	}
+}

--- a/scripts/cloudflare-worker/worker.js
+++ b/scripts/cloudflare-worker/worker.js
@@ -1,7 +1,9 @@
 import { connect } from "cloudflare:sockets";
 
-const REVISION = "worker-stream-v2";
+const TCP_REVISION = "worker-stream-v2";
+const WSS_REVISION = "worker-wss-relay-v3";
 const MAX_PENDING_BYTES = 32 * 1024 * 1024;
+const VALID_TELEGRAM_DCS = new Set([1, 2, 3, 4, 5, 203]);
 
 async function toBytes(data) {
   if (data instanceof ArrayBuffer) return new Uint8Array(data);
@@ -21,143 +23,353 @@ function dataSize(data) {
   return data?.byteLength ?? data?.size ?? data?.length ?? 0;
 }
 
-// The injected connector lets tests exercise this handler without contacting
-// Telegram. Production always uses cloudflare:sockets below.
-export function createWorkerHandler(connectTCP) {
+function responseHeaders(request, revision) {
+  const headers = { "X-Tgws-Worker-Revision": revision };
+  const protocols = (request.headers.get("Sec-WebSocket-Protocol") || "")
+    .split(",").map((value) => value.trim());
+  if (protocols.includes("binary")) headers["Sec-WebSocket-Protocol"] = "binary";
+  return headers;
+}
+
+function telegramWebSocketCandidates(dc, media) {
+  // Android direct-WS routing aliases DC203 to the DC2 WebSocket host.
+  const effectiveDC = dc === 203 ? 2 : dc;
+  const primary = media
+    ? `kws${effectiveDC}-1.web.telegram.org`
+    : `kws${effectiveDC}.web.telegram.org`;
+  const secondary = media
+    ? `kws${effectiveDC}.web.telegram.org`
+    : `kws${effectiveDC}-1.web.telegram.org`;
+  return [primary, secondary];
+}
+
+function parseTelegramDC(url) {
+  const raw = url.searchParams.get("dc");
+  const dc = Number(raw);
+  if (!Number.isInteger(dc) || !VALID_TELEGRAM_DCS.has(dc)) return null;
+  return dc;
+}
+
+function createLogger(url, env, revision, transport) {
+  const meta = {
+    sid: url.searchParams.get("sid") || "?",
+    dst: url.searchParams.get("dst") || "?",
+    dc: url.searchParams.get("dc"),
+    media: url.searchParams.get("media"),
+    revision,
+    transport,
+  };
+  const started = Date.now();
+  const diagnostic = env.WORKER_DIAGNOSTICS === "1";
+  const log = (event, fields = {}) =>
+    console.log(event, { ...meta, elapsed_ms: Date.now() - started, ...fields });
+  const trace = (event, fields = {}) => {
+    if (diagnostic) log(event, fields);
+  };
+  return { log, trace, diagnostic };
+}
+
+function createOuterWebSocket() {
+  const pair = new WebSocketPair();
+  const client = pair[0];
+  const server = pair[1];
+  server.accept();
+  return { client, server };
+}
+
+async function handleTcpRelay(request, env, url, connectTCP) {
+  const dst = url.searchParams.get("dst");
+  if (!dst) return new Response("Missing dst", { status: 400 });
+
+  const { log, trace, diagnostic } = createLogger(url, env, TCP_REVISION, "tcp_v2");
+  const { client, server } = createOuterWebSocket();
+
+  let socket;
+  let writer;
+  let closed = false;
+  let chain = Promise.resolve();
+  let sequence = 0;
+  let receivedBytes = 0;
+  let writtenBytes = 0;
+  let downstreamBytes = 0;
+  let pendingBytes = 0;
+
+  function closeRelay(reason, code = 1000) {
+    if (closed) return;
+    closed = true;
+    log("relay close", {
+      reason,
+      received_bytes: receivedBytes,
+      tcp_written_bytes: writtenBytes,
+      downstream_bytes: downstreamBytes,
+      pending_bytes: pendingBytes,
+    });
+    // writer.close() queues behind a pending write and cannot cancel it.
+    // Close the socket directly so both directions stop even under pressure.
+    try { Promise.resolve(socket?.close()).catch(() => {}); } catch {}
+    try { server.close(code, reason); } catch {}
+  }
+
+  function startTCP() {
+    if (socket) return;
+    socket = connectTCP(
+      { hostname: dst, port: 443 },
+      { secureTransport: "off", allowHalfOpen: true },
+    );
+    writer = socket.writable.getWriter();
+    trace("tcp connect start", {});
+    socket.opened.then(() => trace("tcp opened", {}))
+      .catch(() => closeRelay("tcp_open_failed", 1011));
+    socket.closed.catch(() => closeRelay("tcp_failed", 1011));
+
+    const reader = socket.readable.getReader();
+    (async () => {
+      let reason = "tcp_eof";
+      try {
+        while (!closed) {
+          const { value, done } = await reader.read();
+          if (done || closed) break;
+          if (!value?.byteLength) continue;
+          downstreamBytes += value.byteLength;
+          trace("tcp read", {
+            bytes: value.byteLength,
+            downstream_bytes: downstreamBytes,
+          });
+          server.send(value);
+        }
+      } catch {
+        reason = "tcp_read_failed";
+      } finally {
+        try { reader.releaseLock(); } catch {}
+        closeRelay(reason, reason === "tcp_eof" ? 1000 : 1011);
+      }
+    })();
+  }
+
+  server.addEventListener("message", (event) => {
+    if (closed) return;
+    const seq = ++sequence;
+    const size = dataSize(event.data);
+    receivedBytes += size;
+    trace("ws message received", { seq, bytes: size, received_bytes: receivedBytes });
+    if (pendingBytes + size > MAX_PENDING_BYTES) {
+      closeRelay("tcp_backlog_limit", 1011);
+      return;
+    }
+    pendingBytes += size;
+    // Enqueue before asynchronous conversion: a later ArrayBuffer must not
+    // overtake an earlier Blob. Exactly one TCP write runs at a time.
+    chain = chain.then(async () => {
+      if (closed) return;
+      const chunk = await toBytes(event.data);
+      if (closed || !chunk.byteLength) return;
+      startTCP(); // The first nonempty message, including relay_init.
+      const writeStarted = Date.now();
+      trace("tcp write start", { seq, bytes: chunk.byteLength, pending_bytes: pendingBytes });
+      await writer.write(chunk);
+      writtenBytes += chunk.byteLength;
+      trace("tcp write end", {
+        seq,
+        bytes: chunk.byteLength,
+        duration_ms: Date.now() - writeStarted,
+        tcp_written_bytes: writtenBytes,
+      });
+    }).catch(() => closeRelay("ws_to_tcp_failed", 1011))
+      .finally(() => { pendingBytes -= size; });
+  });
+  server.addEventListener("close", () => closeRelay("ws_closed"));
+  server.addEventListener("error", () => closeRelay("ws_error", 1011));
+
+  log("apiws accepted", { tcp_connect: "lazy", diagnostics: diagnostic });
+  return new Response(null, {
+    status: 101,
+    webSocket: client,
+    headers: responseHeaders(request, TCP_REVISION),
+  });
+}
+
+async function handleWssRelay(request, env, url, fetchWebSocket) {
+  const dc = parseTelegramDC(url);
+  if (dc === null) return new Response("Invalid dc", { status: 400 });
+  const media = url.searchParams.get("media") === "1";
+  const candidates = telegramWebSocketCandidates(dc, media);
+  const { log, trace, diagnostic } = createLogger(url, env, WSS_REVISION, "wss_relay_v3");
+  const { client, server } = createOuterWebSocket();
+
+  let upstream;
+  let upstreamPromise;
+  let closed = false;
+  let upstreamHost = "";
+  let upstreamChain = Promise.resolve();
+  let downstreamChain = Promise.resolve();
+  let sequence = 0;
+  let downstreamSequence = 0;
+  let receivedBytes = 0;
+  let upstreamBytes = 0;
+  let downstreamBytes = 0;
+  let pendingBytes = 0;
+
+  function closeRelay(reason, code = 1000) {
+    if (closed) return;
+    closed = true;
+    log("relay close", {
+      reason,
+      upstream_host: upstreamHost || null,
+      received_bytes: receivedBytes,
+      upstream_ws_bytes: upstreamBytes,
+      downstream_bytes: downstreamBytes,
+      pending_bytes: pendingBytes,
+    });
+    try { upstream?.close(1000, reason); } catch {}
+    try { server.close(code, reason); } catch {}
+  }
+
+  function attachUpstream(ws, host) {
+    upstream = ws;
+    upstreamHost = host;
+    if (typeof ws.accept === "function") ws.accept();
+    ws.addEventListener("message", (event) => {
+      if (closed) return;
+      const seq = ++downstreamSequence;
+      downstreamChain = downstreamChain.then(async () => {
+        if (closed) return;
+        const chunk = await toBytes(event.data);
+        if (closed || !chunk.byteLength) return;
+        downstreamBytes += chunk.byteLength;
+        trace("upstream ws message received", {
+          seq,
+          bytes: chunk.byteLength,
+          downstream_bytes: downstreamBytes,
+          upstream_host: host,
+        });
+        server.send(chunk);
+      }).catch(() => closeRelay("upstream_ws_to_client_failed", 1011));
+    });
+    ws.addEventListener("close", () => closeRelay("upstream_ws_closed"));
+    ws.addEventListener("error", () => closeRelay("upstream_ws_error", 1011));
+  }
+
+  async function openUpstream() {
+    if (upstream) return upstream;
+    if (upstreamPromise) return upstreamPromise;
+    upstreamPromise = (async () => {
+      let lastStatus = 0;
+      for (const host of candidates) {
+        if (closed) throw new Error("relay closed");
+        trace("upstream ws connect start", { upstream_host: host });
+        try {
+          const response = await fetchWebSocket(`https://${host}/apiws`, {
+            headers: {
+              Upgrade: "websocket",
+              "Sec-WebSocket-Protocol": "binary",
+            },
+          });
+          lastStatus = response?.status ?? 0;
+          if (response?.status !== 101 || !response.webSocket) {
+            trace("upstream ws connect rejected", {
+              upstream_host: host,
+              status: lastStatus,
+            });
+            continue;
+          }
+          attachUpstream(response.webSocket, host);
+          trace("upstream ws connected", { upstream_host: host });
+          return response.webSocket;
+        } catch (error) {
+          trace("upstream ws connect failed", {
+            upstream_host: host,
+            error: String(error),
+          });
+        }
+      }
+      throw new Error(`Telegram WebSocket unavailable (last status ${lastStatus})`);
+    })();
+    try {
+      return await upstreamPromise;
+    } catch (error) {
+      upstreamPromise = undefined;
+      throw error;
+    }
+  }
+
+  server.addEventListener("message", (event) => {
+    if (closed) return;
+    const seq = ++sequence;
+    const size = dataSize(event.data);
+    receivedBytes += size;
+    trace("ws message received", {
+      seq,
+      bytes: size,
+      received_bytes: receivedBytes,
+      transport: "wss_relay_v3",
+    });
+    if (pendingBytes + size > MAX_PENDING_BYTES) {
+      closeRelay("upstream_ws_backlog_limit", 1011);
+      return;
+    }
+    pendingBytes += size;
+    // The Android v3 client packet-splits before this point. Preserve each
+    // outer binary message as exactly one Telegram /apiws message.
+    upstreamChain = upstreamChain.then(async () => {
+      if (closed) return;
+      const chunk = await toBytes(event.data);
+      if (closed || !chunk.byteLength) return;
+      const ws = await openUpstream(); // Lazy: relay_init is the first message.
+      if (closed) return;
+      const writeStarted = Date.now();
+      trace("upstream ws send start", {
+        seq,
+        bytes: chunk.byteLength,
+        pending_bytes: pendingBytes,
+        upstream_host: upstreamHost,
+      });
+      ws.send(chunk);
+      upstreamBytes += chunk.byteLength;
+      trace("upstream ws send end", {
+        seq,
+        bytes: chunk.byteLength,
+        duration_ms: Date.now() - writeStarted,
+        upstream_ws_bytes: upstreamBytes,
+        upstream_host: upstreamHost,
+      });
+    }).catch(() => closeRelay("client_to_upstream_ws_failed", 1011))
+      .finally(() => { pendingBytes -= size; });
+  });
+  server.addEventListener("close", () => closeRelay("ws_closed"));
+  server.addEventListener("error", () => closeRelay("ws_error", 1011));
+
+  log("apiws-ws accepted", {
+    upstream_connect: "lazy",
+    upstream_candidates: candidates.join(","),
+    diagnostics: diagnostic,
+  });
+  return new Response(null, {
+    status: 101,
+    webSocket: client,
+    headers: responseHeaders(request, WSS_REVISION),
+  });
+}
+
+// The injected transports let tests exercise both relay implementations without
+// contacting Telegram. Production uses cloudflare:sockets for v2 and fetch()
+// WebSocket upgrades for v3.
+export function createWorkerHandler(connectTCP, fetchWebSocket = globalThis.fetch) {
   return {
     async fetch(request, env = {}) {
       if ((request.headers.get("Upgrade") || "").toLowerCase() !== "websocket") {
         return new Response("WebSocket upgrade required", { status: 426 });
       }
       const url = new URL(request.url);
-      if (url.pathname !== "/apiws") {
-        return new Response("Not found", { status: 404 });
+      if (url.pathname === "/apiws") {
+        return handleTcpRelay(request, env, url, connectTCP);
       }
-      const dst = url.searchParams.get("dst");
-      if (!dst) return new Response("Missing dst", { status: 400 });
-
-      const meta = {
-        sid: url.searchParams.get("sid") || "?",
-        dst,
-        dc: url.searchParams.get("dc"),
-        media: url.searchParams.get("media"),
-        revision: REVISION,
-      };
-      const started = Date.now();
-      const diagnostic = env.WORKER_DIAGNOSTICS === "1";
-      const log = (event, fields = {}) =>
-        console.log(event, { ...meta, elapsed_ms: Date.now() - started, ...fields });
-      const trace = (event, fields) => {
-        if (diagnostic) log(event, fields);
-      };
-
-      const pair = new WebSocketPair();
-      const client = pair[0];
-      const server = pair[1];
-      server.accept();
-
-      let socket;
-      let writer;
-      let closed = false;
-      let chain = Promise.resolve();
-      let sequence = 0;
-      let receivedBytes = 0;
-      let writtenBytes = 0;
-      let downstreamBytes = 0;
-      let pendingBytes = 0;
-
-      function closeRelay(reason, code = 1000) {
-        if (closed) return;
-        closed = true;
-        log("relay close", {
-          reason,
-          received_bytes: receivedBytes,
-          tcp_written_bytes: writtenBytes,
-          downstream_bytes: downstreamBytes,
-          pending_bytes: pendingBytes,
-        });
-        // writer.close() queues behind a pending write and cannot cancel it.
-        // Close the socket directly so both directions stop even under pressure.
-        try { Promise.resolve(socket?.close()).catch(() => {}); } catch {}
-        try { server.close(code, reason); } catch {}
-      }
-
-      function startTCP() {
-        if (socket) return;
-        socket = connectTCP(
-          { hostname: dst, port: 443 },
-          { secureTransport: "off", allowHalfOpen: true },
-        );
-        writer = socket.writable.getWriter();
-        trace("tcp connect start", {});
-        socket.opened.then(() => trace("tcp opened", {}))
-          .catch(() => closeRelay("tcp_open_failed", 1011));
-        socket.closed.catch(() => closeRelay("tcp_failed", 1011));
-
-        const reader = socket.readable.getReader();
-        (async () => {
-          let reason = "tcp_eof";
-          try {
-            while (!closed) {
-              const { value, done } = await reader.read();
-              if (done || closed) break;
-              if (!value?.byteLength) continue;
-              downstreamBytes += value.byteLength;
-              trace("tcp read", {
-                bytes: value.byteLength,
-                downstream_bytes: downstreamBytes,
-              });
-              server.send(value);
-            }
-          } catch {
-            reason = "tcp_read_failed";
-          } finally {
-            try { reader.releaseLock(); } catch {}
-            closeRelay(reason, reason === "tcp_eof" ? 1000 : 1011);
-          }
-        })();
-      }
-
-      server.addEventListener("message", (event) => {
-        if (closed) return;
-        const seq = ++sequence;
-        const size = dataSize(event.data);
-        receivedBytes += size;
-        trace("ws message received", { seq, bytes: size, received_bytes: receivedBytes });
-        if (pendingBytes + size > MAX_PENDING_BYTES) {
-          closeRelay("tcp_backlog_limit", 1011);
-          return;
+      if (url.pathname === "/apiws-ws") {
+        if (typeof fetchWebSocket !== "function") {
+          return new Response("Outbound WebSocket unavailable", { status: 503 });
         }
-        pendingBytes += size;
-        // Enqueue before asynchronous conversion: a later ArrayBuffer must not
-        // overtake an earlier Blob. Exactly one TCP write runs at a time.
-        chain = chain.then(async () => {
-          if (closed) return;
-          const chunk = await toBytes(event.data);
-          if (closed || !chunk.byteLength) return;
-          startTCP(); // The first nonempty message, including relay_init.
-          const writeStarted = Date.now();
-          trace("tcp write start", { seq, bytes: chunk.byteLength, pending_bytes: pendingBytes });
-          await writer.write(chunk);
-          writtenBytes += chunk.byteLength;
-          trace("tcp write end", {
-            seq,
-            bytes: chunk.byteLength,
-            duration_ms: Date.now() - writeStarted,
-            tcp_written_bytes: writtenBytes,
-          });
-        }).catch(() => closeRelay("ws_to_tcp_failed", 1011))
-          .finally(() => { pendingBytes -= size; });
-      });
-      server.addEventListener("close", () => closeRelay("ws_closed"));
-      server.addEventListener("error", () => closeRelay("ws_error", 1011));
-
-      log("apiws accepted", { tcp_connect: "lazy", diagnostics: diagnostic });
-      const headers = { "X-Tgws-Worker-Revision": REVISION };
-      const protocols = (request.headers.get("Sec-WebSocket-Protocol") || "")
-        .split(",").map((value) => value.trim());
-      if (protocols.includes("binary")) headers["Sec-WebSocket-Protocol"] = "binary";
-      return new Response(null, { status: 101, webSocket: client, headers });
+        return handleWssRelay(request, env, url, fetchWebSocket);
+      }
+      return new Response("Not found", { status: 404 });
     },
   };
 }

--- a/scripts/cloudflare-worker/worker.wss.test.mjs
+++ b/scripts/cloudflare-worker/worker.wss.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = (await readFile(new URL("./worker.js", import.meta.url), "utf8"))
+  .replace('import { connect } from "cloudflare:sockets";',
+    'const connect = () => { throw new Error("unexpected production connect"); };');
+const { createWorkerHandler } = await import(
+  "data:text/javascript;base64," + Buffer.from(source).toString("base64")
+);
+
+const nextTurn = () => new Promise((resolve) => setImmediate(resolve));
+async function until(predicate) {
+  for (let i = 0; i < 2000; i++) {
+    if (predicate()) return;
+    await nextTurn();
+  }
+  assert.fail("relay did not reach the expected state");
+}
+
+class Endpoint {
+  listeners = new Map();
+  sent = [];
+  closes = [];
+  accepted = false;
+
+  accept() { this.accepted = true; }
+  addEventListener(name, handler) { this.listeners.set(name, handler); }
+  emit(name, data) { this.listeners.get(name)?.({ data }); }
+  send(data) { this.sent.push(new Uint8Array(data).slice()); }
+  close(code, reason) { this.closes.push({ code, reason }); }
+}
+
+function setup(t, fetchImpl) {
+  const oldPair = globalThis.WebSocketPair;
+  const oldResponse = globalThis.Response;
+  const pairs = [];
+  const logs = [];
+  t.mock.method(console, "log", (event, fields) => logs.push({ event, ...fields }));
+
+  globalThis.WebSocketPair = class {
+    constructor() {
+      this[0] = new Endpoint();
+      this[1] = new Endpoint();
+      pairs.push(this);
+    }
+  };
+  globalThis.Response = class {
+    constructor(body, options = {}) {
+      this.body = body;
+      Object.assign(this, options);
+      this.headers = new Headers(options.headers);
+    }
+  };
+  t.after(() => {
+    globalThis.WebSocketPair = oldPair;
+    globalThis.Response = oldResponse;
+  });
+
+  const tcpConnect = () => { throw new Error("v3 must not use cloudflare:sockets"); };
+  const handler = createWorkerHandler(tcpConnect, fetchImpl);
+  return {
+    pairs,
+    logs,
+    async open(path = "/apiws-ws?dst=149.154.167.51&dc=2&media=0&sid=v3-test") {
+      const response = await handler.fetch(new Request(
+        `https://example.workers.dev${path}`,
+        { headers: { Upgrade: "websocket", "Sec-WebSocket-Protocol": "binary" } },
+      ), { WORKER_DIAGNOSTICS: "1" });
+      return { response, server: pairs.at(-1)?.[1] };
+    },
+  };
+}
+
+function upgraded(upstream) {
+  return { status: 101, webSocket: upstream };
+}
+
+test("v3 opens Telegram WSS lazily and preserves outer message boundaries", async (t) => {
+  const upstream = new Endpoint();
+  const calls = [];
+  const harness = setup(t, async (url, options) => {
+    calls.push({ url, options });
+    return upgraded(upstream);
+  });
+  const { response, server } = await harness.open();
+
+  assert.equal(response.status, 101);
+  assert.equal(response.headers.get("X-Tgws-Worker-Revision"), "worker-wss-relay-v3");
+  assert.equal(calls.length, 0, "Telegram WSS must stay lazy until relay_init");
+
+  server.emit("message", new Uint8Array([1, 2, 3]));
+  server.emit("message", new Uint8Array([4, 5]));
+  await until(() => upstream.sent.length === 2);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://kws2.web.telegram.org/apiws");
+  assert.equal(calls[0].options.headers.Upgrade, "websocket");
+  assert.equal(calls[0].options.headers["Sec-WebSocket-Protocol"], "binary");
+  assert.deepEqual(upstream.sent.map((value) => [...value]), [[1, 2, 3], [4, 5]]);
+});
+
+test("v3 keeps asynchronous client payload conversion ordered and relays downstream", async (t) => {
+  const upstream = new Endpoint();
+  const harness = setup(t, async () => upgraded(upstream));
+  const { server } = await harness.open();
+
+  let release;
+  server.emit("message", {
+    size: 3,
+    arrayBuffer: () => new Promise((resolve) => { release = resolve; }),
+  });
+  server.emit("message", new Uint8Array([4, 5]));
+  await until(() => release);
+  assert.equal(upstream.sent.length, 0);
+  release(new Uint8Array([1, 2, 3]).buffer);
+  await until(() => upstream.sent.length === 2);
+  assert.deepEqual(upstream.sent.map((value) => [...value]), [[1, 2, 3], [4, 5]]);
+
+  upstream.emit("message", new Uint8Array([9, 8, 7]));
+  await until(() => server.sent.length === 1);
+  assert.deepEqual([...server.sent[0]], [9, 8, 7]);
+});
+
+test("v3 media route prefers kws*-1 and fails over to the secondary Telegram WSS host", async (t) => {
+  const upstream = new Endpoint();
+  const calls = [];
+  const harness = setup(t, async (url) => {
+    calls.push(url);
+    if (calls.length === 1) return { status: 503, webSocket: null };
+    return upgraded(upstream);
+  });
+  const { server } = await harness.open(
+    "/apiws-ws?dst=149.154.167.51&dc=2&media=1&sid=media-v3",
+  );
+
+  server.emit("message", new Uint8Array([1]));
+  await until(() => upstream.sent.length === 1);
+  assert.deepEqual(calls, [
+    "https://kws2-1.web.telegram.org/apiws",
+    "https://kws2.web.telegram.org/apiws",
+  ]);
+});
+
+test("v3 validates DC and aliases DC203 to Telegram DC2 WebSocket hosts", async (t) => {
+  const upstream = new Endpoint();
+  const calls = [];
+  const harness = setup(t, async (url) => {
+    calls.push(url);
+    return upgraded(upstream);
+  });
+
+  const invalid = await harness.open("/apiws-ws?dc=999&media=0");
+  assert.equal(invalid.response.status, 400);
+
+  const valid = await harness.open("/apiws-ws?dc=203&media=0&sid=dc203");
+  assert.equal(valid.response.status, 101);
+  valid.server.emit("message", new Uint8Array([7]));
+  await until(() => upstream.sent.length === 1);
+  assert.equal(calls[0], "https://kws2.web.telegram.org/apiws");
+});


### PR DESCRIPTION
## Цель

Экспериментально заменить внутренний участок Worker `cloudflare:sockets -> Telegram TCP :443` на `Worker -> WSS -> kws*.web.telegram.org/apiws`, сохранив текущий Worker v2 для A/B.

## Что меняется

- `/apiws` остаётся `worker-stream-v2` и продолжает использовать `cloudflare:sockets` raw TCP.
- Добавлен отдельный `/apiws-ws` с revision `worker-wss-relay-v3`.
- v3 лениво открывает исходящий Telegram WebSocket только после первого outer WS message (`relay_init`).
- Для обычного DC сначала используется `kws{dc}.web.telegram.org`, для media — `kws{dc}-1.web.telegram.org`; второй hostname остаётся fallback.
- DC203 следует текущей Android direct-WS семантике и использует хосты DC2.
- Production Flowseal-parity Worker dial переписывается только с `/apiws` на `/apiws-ws`; общий builder и legacy Worker path не изменены.
- Перед v3 Worker transport добавлена packet-aware обёртка на `MsgSplitter`: relay_init идёт первым отдельным WS message, последующие transformed TCP writes выдаются только полными MTProto packet messages, как в direct Telegram WS.
- Добавлены JS-тесты WSS relay и Go-тесты path rewrite/packetization.

## Зачем

На Android Worker v2 стабильно зависает после ~458752 байт локально принятого upstream, при этом Cloudflare Worker часто видит только 64-byte init. Изменения framing/TLS record sizing это не исправили. Этот эксперимент убирает `cloudflare:sockets` raw-TCP leg внутри Worker и проверяет принципиально другой backend transport.

## Проверка на устройстве

Для реального A/B требуется сначала развернуть `scripts/cloudflare-worker/worker.js` из этой ветки на тестовом Worker, затем установить APK этой ветки и проверить обычное подключение + загрузку media. В логах ожидаются `/apiws-ws`, `worker_revision=worker-wss-relay-v3` и Worker diagnostics `transport=wss_relay_v3`.

Draft: не сливать до real-device проверки #29.