### PR TITLE
[diag][#29] Add direct Worker network probe

### DIFF
--- a/.github/workflows/trusted-ci.yml
+++ b/.github/workflows/trusted-ci.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: native/tgwsproxy
         run: go test -race ./...
       - name: Deployed Worker handler tests
-        run: node --test scripts/cloudflare-worker/worker.test.mjs
+        run: node --test scripts/cloudflare-worker/*.test.mjs
 
   ci:
     name: Windows CI

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
             android:exported="true"
             android:excludeFromRecents="true"
             android:noHistory="true"
-            android:theme="@android:style/Theme.NoDisplay" />
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
         <activity
             android:name="com.amurcanov.tgwsproxy.FeedbackActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:supportsRtl="true"
         android:theme="@android:style/Theme.NoTitleBar"
         tools:targetApi="33">
-        
+
         <activity
             android:name="com.amurcanov.tgwsproxy.MainActivity"
             android:exported="true"
@@ -31,6 +31,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.amurcanov.tgwsproxy.WorkerNetworkProbeActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay" />
 
         <activity
             android:name="com.amurcanov.tgwsproxy.FeedbackActivity"

--- a/app/src/main/java/com/amurcanov/tgwsproxy/NativeProxy.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/NativeProxy.kt
@@ -22,6 +22,7 @@ interface ProxyLibrary : Library {
     fun StopMtProtoProxy(): Int
     fun GetMtProtoProxyStatus(): Pointer?
     fun RunWorkerNetworkProbe(domain: String): Pointer?
+    fun RunWorkerNetworkProbeWithFamily(domain: String, family: String): Pointer?
     fun ResetAdaptiveRouteStats(all: Int)
     fun ResetAdaptiveNetworkRouteStats(profileId: String)
     fun FreeString(p: Pointer)
@@ -78,8 +79,8 @@ object NativeProxy {
         ProxyLibrary.INSTANCE.FreeString(ptr)
         return res
     }
-    fun runWorkerNetworkProbe(domain: String): String? {
-        val ptr = ProxyLibrary.INSTANCE.RunWorkerNetworkProbe(domain) ?: return null
+    fun runWorkerNetworkProbe(domain: String, family: String = "auto"): String? {
+        val ptr = ProxyLibrary.INSTANCE.RunWorkerNetworkProbeWithFamily(domain, family) ?: return null
         val res = ptr.getString(0)
         ProxyLibrary.INSTANCE.FreeString(ptr)
         return res

--- a/app/src/main/java/com/amurcanov/tgwsproxy/NativeProxy.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/NativeProxy.kt
@@ -8,7 +8,7 @@ interface ProxyLibrary : Library {
     companion object {
         val INSTANCE = Native.load("tgwsproxy", ProxyLibrary::class.java) as ProxyLibrary
     }
-    
+
     fun StartProxy(host: String, port: Int, dcIps: String, verbose: Int): Int
     fun StopProxy(): Int
     fun SetPoolSize(size: Int)
@@ -21,6 +21,7 @@ interface ProxyLibrary : Library {
     fun StartMtProtoProxy(host: String, port: Int, secret: String, runtimeConfig: String, verbose: Int): Int
     fun StopMtProtoProxy(): Int
     fun GetMtProtoProxyStatus(): Pointer?
+    fun RunWorkerNetworkProbe(domain: String): Pointer?
     fun ResetAdaptiveRouteStats(all: Int)
     fun ResetAdaptiveNetworkRouteStats(profileId: String)
     fun FreeString(p: Pointer)
@@ -73,6 +74,12 @@ object NativeProxy {
     }
     fun getMtProtoProxyStatus(): String? {
         val ptr = ProxyLibrary.INSTANCE.GetMtProtoProxyStatus() ?: return null
+        val res = ptr.getString(0)
+        ProxyLibrary.INSTANCE.FreeString(ptr)
+        return res
+    }
+    fun runWorkerNetworkProbe(domain: String): String? {
+        val ptr = ProxyLibrary.INSTANCE.RunWorkerNetworkProbe(domain) ?: return null
         val res = ptr.getString(0)
         ProxyLibrary.INSTANCE.FreeString(ptr)
         return res

--- a/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
@@ -1,0 +1,42 @@
+package com.amurcanov.tgwsproxy
+
+import android.app.Activity
+import android.os.Bundle
+import android.util.Log
+
+class WorkerNetworkProbeActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val domain = intent?.getStringExtra(EXTRA_DOMAIN).orEmpty().trim()
+        if (domain.isEmpty()) {
+            Log.e(TAG, "PROBE_DONE error=missing_domain")
+            finish()
+            return
+        }
+
+        Thread {
+            try {
+                Log.i(TAG, "PROBE_START domain=$domain")
+                val report = NativeProxy.runWorkerNetworkProbe(domain).orEmpty()
+                if (report.isEmpty()) {
+                    Log.e(TAG, "PROBE_RESULT empty")
+                } else {
+                    report.chunked(LOG_CHUNK_SIZE).forEachIndexed { index, chunk ->
+                        Log.i(TAG, "PROBE_RESULT part=${index + 1} $chunk")
+                    }
+                }
+                Log.i(TAG, "PROBE_DONE domain=$domain")
+            } catch (t: Throwable) {
+                Log.e(TAG, "PROBE_DONE error=${t.javaClass.simpleName}:${t.message}", t)
+            } finally {
+                runOnUiThread { finish() }
+            }
+        }.start()
+    }
+
+    companion object {
+        const val EXTRA_DOMAIN = "domain"
+        private const val TAG = "TgWsProxyProbe"
+        private const val LOG_CHUNK_SIZE = 3000
+    }
+}

--- a/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
@@ -8,6 +8,7 @@ class WorkerNetworkProbeActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val domain = intent?.getStringExtra(EXTRA_DOMAIN).orEmpty().trim()
+        val family = intent?.getStringExtra(EXTRA_FAMILY).orEmpty().trim().ifEmpty { "auto" }
         if (domain.isEmpty()) {
             Log.e(TAG, "PROBE_DONE error=missing_domain")
             finish()
@@ -16,8 +17,8 @@ class WorkerNetworkProbeActivity : Activity() {
 
         Thread {
             try {
-                Log.i(TAG, "PROBE_START domain=$domain")
-                val report = NativeProxy.runWorkerNetworkProbe(domain).orEmpty()
+                Log.i(TAG, "PROBE_START domain=$domain ip_family=$family")
+                val report = NativeProxy.runWorkerNetworkProbe(domain, family).orEmpty()
                 if (report.isEmpty()) {
                     Log.e(TAG, "PROBE_RESULT empty")
                 } else {
@@ -25,7 +26,7 @@ class WorkerNetworkProbeActivity : Activity() {
                         Log.i(TAG, "PROBE_RESULT part=${index + 1} $chunk")
                     }
                 }
-                Log.i(TAG, "PROBE_DONE domain=$domain")
+                Log.i(TAG, "PROBE_DONE domain=$domain ip_family=$family")
             } catch (t: Throwable) {
                 Log.e(TAG, "PROBE_DONE error=${t.javaClass.simpleName}:${t.message}", t)
             } finally {
@@ -36,6 +37,7 @@ class WorkerNetworkProbeActivity : Activity() {
 
     companion object {
         const val EXTRA_DOMAIN = "domain"
+        const val EXTRA_FAMILY = "family"
         private const val TAG = "TgWsProxyProbe"
         private const val LOG_CHUNK_SIZE = 3000
     }

--- a/native/tgwsproxy/worker_network_probe.go
+++ b/native/tgwsproxy/worker_network_probe.go
@@ -9,12 +9,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 	"time"
 )
 
 const workerNetworkProbeDeadline = 12 * time.Second
+
+const (
+	workerProbeIPAuto = "auto"
+	workerProbeIPv4   = "ipv4"
+	workerProbeIPv6   = "ipv6"
+)
 
 var workerNetworkProbeSizes = []int{
 	1 * 1024,
@@ -44,14 +51,50 @@ type workerNetworkProbeCase struct {
 type workerNetworkProbeReport struct {
 	Revision string                   `json:"revision"`
 	Domain   string                   `json:"domain"`
+	IPFamily string                   `json:"ip_family"`
 	Started  string                   `json:"started"`
 	Cases    []workerNetworkProbeCase `json:"cases"`
 }
 
-func workerProbeOpen(domain, path string) (*flowsealRawWebSocket, error) {
+func normalizeWorkerProbeIPFamily(raw string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", workerProbeIPAuto:
+		return workerProbeIPAuto, true
+	case workerProbeIPv4, "4", "tcp4":
+		return workerProbeIPv4, true
+	case workerProbeIPv6, "6", "tcp6":
+		return workerProbeIPv6, true
+	default:
+		return "", false
+	}
+}
+
+func resolveWorkerProbeHost(ctx context.Context, domain, family string) (string, error) {
+	if family == workerProbeIPAuto {
+		return domain, nil
+	}
+	network := "ip4"
+	if family == workerProbeIPv6 {
+		network = "ip6"
+	}
+	ips, err := net.DefaultResolver.LookupIP(ctx, network, domain)
+	if err != nil {
+		return "", fmt.Errorf("resolve_%s: %w", family, err)
+	}
+	if len(ips) == 0 {
+		return "", fmt.Errorf("resolve_%s: no addresses", family)
+	}
+	return ips[0].String(), nil
+}
+
+func workerProbeOpen(domain, path, family string) (*flowsealRawWebSocket, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	ws, err := connectFlowsealRawWebSocketContext(ctx, domain, domain, path, 10)
+	host, err := resolveWorkerProbeHost(ctx, domain, family)
+	if err != nil {
+		return nil, err
+	}
+	ws, err := connectFlowsealRawWebSocketContext(ctx, host, domain, path, 10)
 	if err != nil {
 		return nil, err
 	}
@@ -75,9 +118,9 @@ func workerProbeCaseLog(c workerNetworkProbeCase) {
 	)
 }
 
-func runEchoStaircase(domain string) []workerNetworkProbeCase {
+func runEchoStaircase(domain, family string) []workerNetworkProbeCase {
 	path := "/diag/ws-echo?sid=probe-echo"
-	ws, err := workerProbeOpen(domain, path)
+	ws, err := workerProbeOpen(domain, path, family)
 	if err != nil {
 		c := workerNetworkProbeCase{Mode: "echo_staircase_connect", Error: err.Error()}
 		workerProbeCaseLog(c)
@@ -133,9 +176,9 @@ func runEchoStaircase(domain string) []workerNetworkProbeCase {
 	return cases
 }
 
-func runUpload4KStream(domain string) []workerNetworkProbeCase {
+func runUpload4KStream(domain, family string) []workerNetworkProbeCase {
 	path := "/diag/upload?sid=probe-upload-4k"
-	ws, err := workerProbeOpen(domain, path)
+	ws, err := workerProbeOpen(domain, path, family)
 	if err != nil {
 		c := workerNetworkProbeCase{Mode: "upload_4k_connect", Error: err.Error()}
 		workerProbeCaseLog(c)
@@ -212,12 +255,12 @@ func runUpload4KStream(domain string) []workerNetworkProbeCase {
 	return cases
 }
 
-func runDownloadSizes(domain string) []workerNetworkProbeCase {
+func runDownloadSizes(domain, family string) []workerNetworkProbeCase {
 	cases := make([]workerNetworkProbeCase, 0, len(workerNetworkProbeSizes))
 	for _, size := range workerNetworkProbeSizes {
 		path := "/diag/download?size=" + fmt.Sprint(size) + "&sid=" + url.QueryEscape(fmt.Sprintf("probe-download-%d", size))
 		started := time.Now()
-		ws, err := workerProbeOpen(domain, path)
+		ws, err := workerProbeOpen(domain, path, family)
 		if err != nil {
 			c := workerNetworkProbeCase{Mode: "download_single", SizeBytes: size, DurationMS: time.Since(started).Milliseconds(), Error: err.Error()}
 			workerProbeCaseLog(c)
@@ -249,36 +292,52 @@ func runDownloadSizes(domain string) []workerNetworkProbeCase {
 	return cases
 }
 
-func runWorkerNetworkProbe(domain string) workerNetworkProbeReport {
+func runWorkerNetworkProbe(domain, familyRaw string) workerNetworkProbeReport {
 	domain = NormalizeWorkerDomain(strings.TrimSpace(domain))
+	family, familyOK := normalizeWorkerProbeIPFamily(familyRaw)
 	report := workerNetworkProbeReport{
-		Revision: "worker-network-probe-v1",
+		Revision: "worker-network-probe-v2",
 		Domain:   domain,
+		IPFamily: family,
 		Started:  time.Now().UTC().Format(time.RFC3339),
 	}
 	if domain == "" {
 		report.Cases = []workerNetworkProbeCase{{Mode: "validation", Error: "invalid_worker_domain"}}
 		return report
 	}
-	if logInfo != nil {
-		logInfo.Printf("Worker network probe start domain=%s revision=%s", domain, report.Revision)
+	if !familyOK {
+		report.IPFamily = strings.TrimSpace(familyRaw)
+		report.Cases = []workerNetworkProbeCase{{Mode: "validation", Error: "invalid_ip_family"}}
+		return report
 	}
-	report.Cases = append(report.Cases, runEchoStaircase(domain)...)
-	report.Cases = append(report.Cases, runUpload4KStream(domain)...)
-	report.Cases = append(report.Cases, runDownloadSizes(domain)...)
 	if logInfo != nil {
-		logInfo.Printf("Worker network probe complete domain=%s cases=%d", domain, len(report.Cases))
+		logInfo.Printf("Worker network probe start domain=%s ip_family=%s revision=%s", domain, family, report.Revision)
+	}
+	report.Cases = append(report.Cases, runEchoStaircase(domain, family)...)
+	report.Cases = append(report.Cases, runUpload4KStream(domain, family)...)
+	report.Cases = append(report.Cases, runDownloadSizes(domain, family)...)
+	if logInfo != nil {
+		logInfo.Printf("Worker network probe complete domain=%s ip_family=%s cases=%d", domain, family, len(report.Cases))
 	}
 	return report
+}
+
+func encodeWorkerNetworkProbeReport(report workerNetworkProbeReport) *C.char {
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		return C.CString(`{"revision":"worker-network-probe-v2","error":"json_encode_failed"}`)
+	}
+	return C.CString(string(encoded))
 }
 
 //export RunWorkerNetworkProbe
 func RunWorkerNetworkProbe(cDomain *C.char) *C.char {
 	initLogging(true)
-	report := runWorkerNetworkProbe(C.GoString(cDomain))
-	encoded, err := json.Marshal(report)
-	if err != nil {
-		return C.CString(`{"revision":"worker-network-probe-v1","error":"json_encode_failed"}`)
-	}
-	return C.CString(string(encoded))
+	return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain), workerProbeIPAuto))
+}
+
+//export RunWorkerNetworkProbeWithFamily
+func RunWorkerNetworkProbeWithFamily(cDomain *C.char, cFamily *C.char) *C.char {
+	initLogging(true)
+	return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain), C.GoString(cFamily)))
 }

--- a/native/tgwsproxy/worker_network_probe.go
+++ b/native/tgwsproxy/worker_network_probe.go
@@ -1,0 +1,284 @@
+package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const workerNetworkProbeDeadline = 12 * time.Second
+
+var workerNetworkProbeSizes = []int{
+	1 * 1024,
+	4 * 1024,
+	8 * 1024,
+	12 * 1024,
+	16 * 1024,
+	24 * 1024,
+	32 * 1024,
+	64 * 1024,
+	128 * 1024,
+	256 * 1024,
+	512 * 1024,
+	1024 * 1024,
+}
+
+type workerNetworkProbeCase struct {
+	Mode            string `json:"mode"`
+	SizeBytes       int    `json:"size_bytes,omitempty"`
+	CumulativeBytes int    `json:"cumulative_bytes,omitempty"`
+	OK              bool   `json:"ok"`
+	DurationMS      int64  `json:"duration_ms"`
+	TransportState  string `json:"transport_state,omitempty"`
+	Error           string `json:"error,omitempty"`
+}
+
+type workerNetworkProbeReport struct {
+	Revision string                   `json:"revision"`
+	Domain   string                   `json:"domain"`
+	Started  string                   `json:"started"`
+	Cases    []workerNetworkProbeCase `json:"cases"`
+}
+
+func workerProbeOpen(domain, path string) (*flowsealRawWebSocket, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ws, err := connectFlowsealRawWebSocketContext(ctx, domain, domain, path, 10)
+	if err != nil {
+		return nil, err
+	}
+	_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline))
+	return ws, nil
+}
+
+func workerProbeCaseLog(c workerNetworkProbeCase) {
+	if logInfo == nil {
+		return
+	}
+	logInfo.Printf(
+		"Worker network probe mode=%s size_bytes=%d cumulative_bytes=%d ok=%t duration_ms=%d error=%s %s",
+		c.Mode,
+		c.SizeBytes,
+		c.CumulativeBytes,
+		c.OK,
+		c.DurationMS,
+		mtProtoStatusField(c.Error),
+		c.TransportState,
+	)
+}
+
+func runEchoStaircase(domain string) []workerNetworkProbeCase {
+	path := "/diag/ws-echo?sid=probe-echo"
+	ws, err := workerProbeOpen(domain, path)
+	if err != nil {
+		c := workerNetworkProbeCase{Mode: "echo_staircase_connect", Error: err.Error()}
+		workerProbeCaseLog(c)
+		return []workerNetworkProbeCase{c}
+	}
+	defer ws.Close()
+
+	cases := make([]workerNetworkProbeCase, 0, len(workerNetworkProbeSizes))
+	cumulative := 0
+	for index, size := range workerNetworkProbeSizes {
+		payload := make([]byte, size)
+		for i := range payload {
+			payload[i] = byte((i + index) & 0xff)
+		}
+		_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline))
+		started := time.Now()
+		sendErr := ws.Send(payload)
+		if sendErr != nil {
+			c := workerNetworkProbeCase{
+				Mode:            "echo_staircase",
+				SizeBytes:       size,
+				CumulativeBytes: cumulative,
+				DurationMS:      time.Since(started).Milliseconds(),
+				TransportState:  tcpTransportState(ws.conn),
+				Error:           sendErr.Error(),
+			}
+			workerProbeCaseLog(c)
+			cases = append(cases, c)
+			break
+		}
+		received, recvErr := ws.Recv()
+		cumulative += size
+		c := workerNetworkProbeCase{
+			Mode:            "echo_staircase",
+			SizeBytes:       size,
+			CumulativeBytes: cumulative,
+			DurationMS:      time.Since(started).Milliseconds(),
+			TransportState:  tcpTransportState(ws.conn),
+		}
+		if recvErr != nil {
+			c.Error = recvErr.Error()
+		} else if len(received) != len(payload) {
+			c.Error = fmt.Sprintf("echo_size_mismatch:%d", len(received))
+		} else {
+			c.OK = true
+		}
+		workerProbeCaseLog(c)
+		cases = append(cases, c)
+		if !c.OK {
+			break
+		}
+	}
+	return cases
+}
+
+func runUpload4KStream(domain string) []workerNetworkProbeCase {
+	path := "/diag/upload?sid=probe-upload-4k"
+	ws, err := workerProbeOpen(domain, path)
+	if err != nil {
+		c := workerNetworkProbeCase{Mode: "upload_4k_connect", Error: err.Error()}
+		workerProbeCaseLog(c)
+		return []workerNetworkProbeCase{c}
+	}
+	defer ws.Close()
+
+	const chunkSize = 4 * 1024
+	const target = 1024 * 1024
+	payload := make([]byte, chunkSize)
+	cases := make([]workerNetworkProbeCase, 0, target/(64*1024))
+	cumulative := 0
+	for cumulative < target {
+		for i := range payload {
+			payload[i] = byte((i + cumulative/chunkSize) & 0xff)
+		}
+		_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline))
+		started := time.Now()
+		if err := ws.Send(payload); err != nil {
+			c := workerNetworkProbeCase{
+				Mode:            "upload_4k_stream",
+				SizeBytes:       chunkSize,
+				CumulativeBytes: cumulative,
+				DurationMS:      time.Since(started).Milliseconds(),
+				TransportState:  tcpTransportState(ws.conn),
+				Error:           err.Error(),
+			}
+			workerProbeCaseLog(c)
+			cases = append(cases, c)
+			break
+		}
+		ack, err := ws.Recv()
+		if err != nil {
+			c := workerNetworkProbeCase{
+				Mode:            "upload_4k_stream",
+				SizeBytes:       chunkSize,
+				CumulativeBytes: cumulative + chunkSize,
+				DurationMS:      time.Since(started).Milliseconds(),
+				TransportState:  tcpTransportState(ws.conn),
+				Error:           err.Error(),
+			}
+			workerProbeCaseLog(c)
+			cases = append(cases, c)
+			break
+		}
+		cumulative += chunkSize
+		expected := fmt.Sprintf("ack:%d", cumulative)
+		if string(ack) != expected {
+			c := workerNetworkProbeCase{
+				Mode:            "upload_4k_stream",
+				SizeBytes:       chunkSize,
+				CumulativeBytes: cumulative,
+				DurationMS:      time.Since(started).Milliseconds(),
+				TransportState:  tcpTransportState(ws.conn),
+				Error:           "unexpected_ack",
+			}
+			workerProbeCaseLog(c)
+			cases = append(cases, c)
+			break
+		}
+		if cumulative == chunkSize || cumulative%(64*1024) == 0 || cumulative == target {
+			c := workerNetworkProbeCase{
+				Mode:            "upload_4k_stream",
+				SizeBytes:       chunkSize,
+				CumulativeBytes: cumulative,
+				OK:              true,
+				DurationMS:      time.Since(started).Milliseconds(),
+				TransportState:  tcpTransportState(ws.conn),
+			}
+			workerProbeCaseLog(c)
+			cases = append(cases, c)
+		}
+	}
+	return cases
+}
+
+func runDownloadSizes(domain string) []workerNetworkProbeCase {
+	cases := make([]workerNetworkProbeCase, 0, len(workerNetworkProbeSizes))
+	for _, size := range workerNetworkProbeSizes {
+		path := "/diag/download?size=" + fmt.Sprint(size) + "&sid=" + url.QueryEscape(fmt.Sprintf("probe-download-%d", size))
+		started := time.Now()
+		ws, err := workerProbeOpen(domain, path)
+		if err != nil {
+			c := workerNetworkProbeCase{Mode: "download_single", SizeBytes: size, DurationMS: time.Since(started).Milliseconds(), Error: err.Error()}
+			workerProbeCaseLog(c)
+			cases = append(cases, c)
+			break
+		}
+		_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline))
+		payload, recvErr := ws.Recv()
+		c := workerNetworkProbeCase{
+			Mode:           "download_single",
+			SizeBytes:      size,
+			DurationMS:     time.Since(started).Milliseconds(),
+			TransportState: tcpTransportState(ws.conn),
+		}
+		if recvErr != nil {
+			c.Error = recvErr.Error()
+		} else if len(payload) != size {
+			c.Error = fmt.Sprintf("download_size_mismatch:%d", len(payload))
+		} else {
+			c.OK = true
+		}
+		workerProbeCaseLog(c)
+		cases = append(cases, c)
+		ws.Close()
+		if !c.OK {
+			break
+		}
+	}
+	return cases
+}
+
+func runWorkerNetworkProbe(domain string) workerNetworkProbeReport {
+	domain = NormalizeWorkerDomain(strings.TrimSpace(domain))
+	report := workerNetworkProbeReport{
+		Revision: "worker-network-probe-v1",
+		Domain:   domain,
+		Started:  time.Now().UTC().Format(time.RFC3339),
+	}
+	if domain == "" {
+		report.Cases = []workerNetworkProbeCase{{Mode: "validation", Error: "invalid_worker_domain"}}
+		return report
+	}
+	if logInfo != nil {
+		logInfo.Printf("Worker network probe start domain=%s revision=%s", domain, report.Revision)
+	}
+	report.Cases = append(report.Cases, runEchoStaircase(domain)...)
+	report.Cases = append(report.Cases, runUpload4KStream(domain)...)
+	report.Cases = append(report.Cases, runDownloadSizes(domain)...)
+	if logInfo != nil {
+		logInfo.Printf("Worker network probe complete domain=%s cases=%d", domain, len(report.Cases))
+	}
+	return report
+}
+
+//export RunWorkerNetworkProbe
+func RunWorkerNetworkProbe(cDomain *C.char) *C.char {
+	initLogging(true)
+	report := runWorkerNetworkProbe(C.GoString(cDomain))
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		return C.CString(`{"revision":"worker-network-probe-v1","error":"json_encode_failed"}`)
+	}
+	return C.CString(string(encoded))
+}

--- a/native/tgwsproxy/worker_network_probe_test.go
+++ b/native/tgwsproxy/worker_network_probe_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestNormalizeWorkerProbeIPFamily(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+		ok    bool
+	}{
+		{"", workerProbeIPAuto, true},
+		{"auto", workerProbeIPAuto, true},
+		{"AUTO", workerProbeIPAuto, true},
+		{"ipv4", workerProbeIPv4, true},
+		{"4", workerProbeIPv4, true},
+		{"tcp4", workerProbeIPv4, true},
+		{"IPv6", workerProbeIPv6, true},
+		{"6", workerProbeIPv6, true},
+		{"tcp6", workerProbeIPv6, true},
+		{"bogus", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, ok := normalizeWorkerProbeIPFamily(tt.input)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("normalizeWorkerProbeIPFamily(%q) = (%q, %t), want (%q, %t)", tt.input, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/scripts/cloudflare-worker/worker.diag.test.mjs
+++ b/scripts/cloudflare-worker/worker.diag.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = (await readFile(new URL("./worker.js", import.meta.url), "utf8"))
+  .replace('import { connect } from "cloudflare:sockets";',
+    'const connect = () => { throw new Error("unexpected production connect"); };');
+const { createWorkerHandler } = await import(
+  "data:text/javascript;base64," + Buffer.from(source).toString("base64")
+);
+
+function setup(t) {
+  const oldPair = globalThis.WebSocketPair;
+  const oldResponse = globalThis.Response;
+  const pairs = [];
+  class Endpoint {
+    listeners = new Map();
+    sent = [];
+    closes = [];
+    accept() {}
+    addEventListener(name, handler) { this.listeners.set(name, handler); }
+    emit(name, data) { return this.listeners.get(name)?.({ data }); }
+    send(data) { this.sent.push(data); }
+    close(code, reason) { this.closes.push({ code, reason }); }
+  }
+  globalThis.WebSocketPair = class {
+    constructor() {
+      this[0] = new Endpoint();
+      this[1] = new Endpoint();
+      pairs.push(this);
+    }
+  };
+  globalThis.Response = class {
+    constructor(body, options = {}) {
+      this.body = body;
+      Object.assign(this, options);
+      this.headers = new Headers(options.headers);
+    }
+  };
+  t.after(() => {
+    globalThis.WebSocketPair = oldPair;
+    globalThis.Response = oldResponse;
+  });
+  const handler = createWorkerHandler(() => {
+    throw new Error("diagnostic route must not open cloudflare:sockets");
+  });
+  return { handler, pairs };
+}
+
+async function open(harness, path) {
+  const response = await harness.handler.fetch(new Request(
+    `https://example.workers.dev${path}`,
+    { headers: { Upgrade: "websocket", "Sec-WebSocket-Protocol": "binary" } },
+  ));
+  assert.equal(response.status, 101);
+  assert.equal(response.headers.get("X-Tgws-Worker-Revision"), "worker-network-probe-v1");
+  return harness.pairs.at(-1)[1];
+}
+
+test("diagnostic echo returns the exact binary message", async (t) => {
+  const harness = setup(t);
+  const server = await open(harness, "/diag/ws-echo?sid=test-echo");
+  const payload = new Uint8Array([1, 2, 3, 4, 5]);
+  await server.emit("message", payload);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(server.sent.length, 1);
+  assert.deepEqual([...server.sent[0]], [...payload]);
+});
+
+test("diagnostic upload acknowledges cumulative bytes", async (t) => {
+  const harness = setup(t);
+  const server = await open(harness, "/diag/upload?sid=test-upload");
+  server.emit("message", new Uint8Array(4096));
+  server.emit("message", new Uint8Array(4096));
+  assert.deepEqual(server.sent, ["ack:4096", "ack:8192"]);
+});
+
+test("diagnostic download emits requested payload without TCP backend", async (t) => {
+  const harness = setup(t);
+  const server = await open(harness, "/diag/download?size=65536&sid=test-download");
+  assert.equal(server.sent.length, 1);
+  assert.equal(server.sent[0].byteLength, 65536);
+});

--- a/scripts/cloudflare-worker/worker.js
+++ b/scripts/cloudflare-worker/worker.js
@@ -1,7 +1,9 @@
 import { connect } from "cloudflare:sockets";
 
 const REVISION = "worker-stream-v2";
+const DIAG_REVISION = "worker-network-probe-v1";
 const MAX_PENDING_BYTES = 32 * 1024 * 1024;
+const MAX_DIAG_BYTES = 2 * 1024 * 1024;
 
 async function toBytes(data) {
   if (data instanceof ArrayBuffer) return new Uint8Array(data);
@@ -21,6 +23,93 @@ function dataSize(data) {
   return data?.byteLength ?? data?.size ?? data?.length ?? 0;
 }
 
+function websocketResponse(client, request, revision = REVISION) {
+  const headers = { "X-Tgws-Worker-Revision": revision };
+  const protocols = (request.headers.get("Sec-WebSocket-Protocol") || "")
+    .split(",").map((value) => value.trim());
+  if (protocols.includes("binary")) headers["Sec-WebSocket-Protocol"] = "binary";
+  return new Response(null, { status: 101, webSocket: client, headers });
+}
+
+function diagnosticWebSocket(request, url) {
+  const pair = new WebSocketPair();
+  const client = pair[0];
+  const server = pair[1];
+  server.accept();
+  const sid = url.searchParams.get("sid") || "?";
+  const started = Date.now();
+  const log = (event, fields = {}) => console.log(event, {
+    sid,
+    path: url.pathname,
+    revision: DIAG_REVISION,
+    elapsed_ms: Date.now() - started,
+    ...fields,
+  });
+
+  if (url.pathname === "/diag/ws-echo") {
+    let receivedBytes = 0;
+    let messages = 0;
+    server.addEventListener("message", async (event) => {
+      try {
+        const size = dataSize(event.data);
+        if (size > MAX_DIAG_BYTES) {
+          server.close(1009, "diag_message_too_large");
+          return;
+        }
+        const bytes = await toBytes(event.data);
+        receivedBytes += bytes.byteLength;
+        messages++;
+        server.send(bytes);
+        if (messages <= 2 || receivedBytes % (64 * 1024) < bytes.byteLength) {
+          log("diag echo", { messages, bytes: bytes.byteLength, received_bytes: receivedBytes });
+        }
+      } catch {
+        server.close(1011, "diag_echo_failed");
+      }
+    });
+    server.addEventListener("close", () => log("diag echo close", { messages, received_bytes: receivedBytes }));
+    log("diag echo accepted");
+    return websocketResponse(client, request, DIAG_REVISION);
+  }
+
+  if (url.pathname === "/diag/upload") {
+    let receivedBytes = 0;
+    let messages = 0;
+    server.addEventListener("message", (event) => {
+      const size = dataSize(event.data);
+      if (size > MAX_DIAG_BYTES || receivedBytes + size > 64 * MAX_DIAG_BYTES) {
+        server.close(1009, "diag_upload_too_large");
+        return;
+      }
+      receivedBytes += size;
+      messages++;
+      server.send(`ack:${receivedBytes}`);
+      if (messages <= 2 || receivedBytes % (64 * 1024) < size) {
+        log("diag upload", { messages, bytes: size, received_bytes: receivedBytes });
+      }
+    });
+    server.addEventListener("close", () => log("diag upload close", { messages, received_bytes: receivedBytes }));
+    log("diag upload accepted");
+    return websocketResponse(client, request, DIAG_REVISION);
+  }
+
+  if (url.pathname === "/diag/download") {
+    const size = Number.parseInt(url.searchParams.get("size") || "0", 10);
+    if (!Number.isFinite(size) || size < 0 || size > MAX_DIAG_BYTES) {
+      try { server.close(1008, "invalid_diag_size"); } catch {}
+      return new Response("Invalid size", { status: 400 });
+    }
+    const payload = new Uint8Array(size);
+    for (let i = 0; i < payload.length; i += 4096) payload[i] = (i / 4096) & 0xff;
+    server.send(payload);
+    log("diag download sent", { bytes: size });
+    server.addEventListener("close", () => log("diag download close", { bytes: size }));
+    return websocketResponse(client, request, DIAG_REVISION);
+  }
+
+  return null;
+}
+
 // The injected connector lets tests exercise this handler without contacting
 // Telegram. Production always uses cloudflare:sockets below.
 export function createWorkerHandler(connectTCP) {
@@ -30,6 +119,11 @@ export function createWorkerHandler(connectTCP) {
         return new Response("WebSocket upgrade required", { status: 426 });
       }
       const url = new URL(request.url);
+      if (url.pathname.startsWith("/diag/")) {
+        const response = diagnosticWebSocket(request, url);
+        if (response) return response;
+        return new Response("Not found", { status: 404 });
+      }
       if (url.pathname !== "/apiws") {
         return new Response("Not found", { status: 404 });
       }
@@ -76,8 +170,6 @@ export function createWorkerHandler(connectTCP) {
           downstream_bytes: downstreamBytes,
           pending_bytes: pendingBytes,
         });
-        // writer.close() queues behind a pending write and cannot cancel it.
-        // Close the socket directly so both directions stop even under pressure.
         try { Promise.resolve(socket?.close()).catch(() => {}); } catch {}
         try { server.close(code, reason); } catch {}
       }
@@ -129,13 +221,11 @@ export function createWorkerHandler(connectTCP) {
           return;
         }
         pendingBytes += size;
-        // Enqueue before asynchronous conversion: a later ArrayBuffer must not
-        // overtake an earlier Blob. Exactly one TCP write runs at a time.
         chain = chain.then(async () => {
           if (closed) return;
           const chunk = await toBytes(event.data);
           if (closed || !chunk.byteLength) return;
-          startTCP(); // The first nonempty message, including relay_init.
+          startTCP();
           const writeStarted = Date.now();
           trace("tcp write start", { seq, bytes: chunk.byteLength, pending_bytes: pendingBytes });
           await writer.write(chunk);
@@ -153,11 +243,7 @@ export function createWorkerHandler(connectTCP) {
       server.addEventListener("error", () => closeRelay("ws_error", 1011));
 
       log("apiws accepted", { tcp_connect: "lazy", diagnostics: diagnostic });
-      const headers = { "X-Tgws-Worker-Revision": REVISION };
-      const protocols = (request.headers.get("Sec-WebSocket-Protocol") || "")
-        .split(",").map((value) => value.trim());
-      if (protocols.includes("binary")) headers["Sec-WebSocket-Protocol"] = "binary";
-      return new Response(null, { status: 101, webSocket: client, headers });
+      return websocketResponse(client, request, REVISION);
     },
   };
 }

--- a/scripts/test-worker-network-probe.ps1
+++ b/scripts/test-worker-network-probe.ps1
@@ -2,6 +2,8 @@
 param(
     [Parameter(Mandatory = $true)]
     [string]$WorkerDomain,
+    [ValidateSet("Auto", "IPv4", "IPv6")]
+    [string]$IPFamily = "Auto",
     [switch]$SkipBuild,
     [string]$DeviceSerial = "",
     [int]$TimeoutSeconds = 240
@@ -14,6 +16,7 @@ Set-Location $repoRoot
 
 $WorkerDomain = $WorkerDomain.Trim()
 if (-not $WorkerDomain) { throw "WorkerDomain is required." }
+$familyArg = $IPFamily.ToLowerInvariant()
 
 $sdkCandidates = @(
     $env:ANDROID_SDK_ROOT,
@@ -58,14 +61,15 @@ if ($LASTEXITCODE -ne 0) { throw "APK installation failed." }
 $logDir = Join-Path $repoRoot "artifacts\worker-tests"
 New-Item -ItemType Directory -Force -Path $logDir | Out-Null
 $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
-$runtimeLog = Join-Path $logDir "worker-network-probe-$stamp.txt"
-$metaLog = Join-Path $logDir "worker-network-probe-$stamp.meta.txt"
+$runtimeLog = Join-Path $logDir "worker-network-probe-$familyArg-$stamp.txt"
+$metaLog = Join-Path $logDir "worker-network-probe-$familyArg-$stamp.meta.txt"
 $commit = (& git rev-parse HEAD).Trim()
 $model = (& $adb -s $DeviceSerial shell getprop ro.product.model).Trim()
 $androidVersion = (& $adb -s $DeviceSerial shell getprop ro.build.version.release).Trim()
 @(
     "commit=$commit",
     "worker_domain=$WorkerDomain",
+    "ip_family=$familyArg",
     "apk=$apk",
     "apk_sha256=$((Get-FileHash $apk -Algorithm SHA256).Hash)",
     "device=$model",
@@ -75,10 +79,11 @@ $androidVersion = (& $adb -s $DeviceSerial shell getprop ro.build.version.releas
 
 Write-Host "IMPORTANT: deploy scripts/cloudflare-worker/worker.js from this branch to the same Worker first."
 Write-Host "Running probe against: $WorkerDomain"
+Write-Host "IP family: $familyArg"
 
 & $adb -s $DeviceSerial logcat -c
 & $adb -s $DeviceSerial shell am force-stop com.amurcanov.tgwsproxy
-& $adb -s $DeviceSerial shell am start -n "com.amurcanov.tgwsproxy/.WorkerNetworkProbeActivity" --es domain $WorkerDomain
+& $adb -s $DeviceSerial shell am start -n "com.amurcanov.tgwsproxy/.WorkerNetworkProbeActivity" --es domain $WorkerDomain --es family $familyArg
 if ($LASTEXITCODE -ne 0) { throw "Could not start WorkerNetworkProbeActivity." }
 
 $deadline = (Get-Date).AddSeconds($TimeoutSeconds)

--- a/scripts/test-worker-network-probe.ps1
+++ b/scripts/test-worker-network-probe.ps1
@@ -1,0 +1,108 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$WorkerDomain,
+    [switch]$SkipBuild,
+    [string]$DeviceSerial = "",
+    [int]$TimeoutSeconds = 240
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+$WorkerDomain = $WorkerDomain.Trim()
+if (-not $WorkerDomain) { throw "WorkerDomain is required." }
+
+$sdkCandidates = @(
+    $env:ANDROID_SDK_ROOT,
+    $env:ANDROID_HOME,
+    "C:\Android\SDK"
+)
+if ($env:LOCALAPPDATA) {
+    $sdkCandidates += (Join-Path $env:LOCALAPPDATA "Android\Sdk")
+}
+$adb = $null
+foreach ($candidate in $sdkCandidates) {
+    if ($candidate -and (Test-Path (Join-Path $candidate "platform-tools\adb.exe"))) {
+        $env:ANDROID_SDK_ROOT = $candidate
+        $env:ANDROID_HOME = $candidate
+        $adb = Join-Path $candidate "platform-tools\adb.exe"
+        break
+    }
+}
+if (-not $adb) { throw "adb.exe not found. Set ANDROID_SDK_ROOT to your Android SDK." }
+
+if (-not $SkipBuild) {
+    & (Join-Path $PSScriptRoot "build-apk.ps1") -Configuration Debug
+    if ($LASTEXITCODE -ne 0) { throw "Debug APK build failed." }
+}
+$apk = Join-Path $repoRoot "app\build\outputs\apk\debug\app-debug.apk"
+if (-not (Test-Path $apk)) { throw "Debug APK not found: $apk" }
+
+$deviceLines = & $adb devices
+if ($LASTEXITCODE -ne 0) { throw "adb devices failed." }
+$devices = @($deviceLines | Where-Object { $_ -match '^\S+\s+device$' } |
+    ForEach-Object { ($_ -split '\s+')[0] })
+if ($DeviceSerial) {
+    if ($DeviceSerial -notin $devices) { throw "Device is not connected/authorized: $DeviceSerial" }
+} else {
+    if ($devices.Count -ne 1) { throw "Connect one authorized device or pass -DeviceSerial." }
+    $DeviceSerial = $devices[0]
+}
+
+& $adb -s $DeviceSerial install -r $apk
+if ($LASTEXITCODE -ne 0) { throw "APK installation failed." }
+
+$logDir = Join-Path $repoRoot "artifacts\worker-tests"
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$runtimeLog = Join-Path $logDir "worker-network-probe-$stamp.txt"
+$metaLog = Join-Path $logDir "worker-network-probe-$stamp.meta.txt"
+$commit = (& git rev-parse HEAD).Trim()
+$model = (& $adb -s $DeviceSerial shell getprop ro.product.model).Trim()
+$androidVersion = (& $adb -s $DeviceSerial shell getprop ro.build.version.release).Trim()
+@(
+    "commit=$commit",
+    "worker_domain=$WorkerDomain",
+    "apk=$apk",
+    "apk_sha256=$((Get-FileHash $apk -Algorithm SHA256).Hash)",
+    "device=$model",
+    "android=$androidVersion",
+    "skip_build=$SkipBuild"
+) | Set-Content -Encoding UTF8 $metaLog
+
+Write-Host "IMPORTANT: deploy scripts/cloudflare-worker/worker.js from this branch to the same Worker first."
+Write-Host "Running probe against: $WorkerDomain"
+
+& $adb -s $DeviceSerial logcat -c
+& $adb -s $DeviceSerial shell am force-stop com.amurcanov.tgwsproxy
+& $adb -s $DeviceSerial shell am start -n "com.amurcanov.tgwsproxy/.WorkerNetworkProbeActivity" --es domain $WorkerDomain
+if ($LASTEXITCODE -ne 0) { throw "Could not start WorkerNetworkProbeActivity." }
+
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+$complete = $false
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 2
+    $dump = & $adb -s $DeviceSerial logcat -d -v threadtime "TgWsProxy:V" "TgWsProxyProbe:V" "AndroidRuntime:E" "*:S"
+    $dump | Set-Content -Encoding UTF8 $runtimeLog
+    if ($dump -match 'PROBE_DONE') {
+        $complete = $true
+        break
+    }
+}
+
+$finalDump = & $adb -s $DeviceSerial logcat -d -v threadtime "TgWsProxy:V" "TgWsProxyProbe:V" "AndroidRuntime:E" "*:S"
+$finalDump | Set-Content -Encoding UTF8 $runtimeLog
+
+Write-Host ""
+Write-Host "=== Probe summary ==="
+$finalDump | Select-String "Worker network probe|PROBE_" | ForEach-Object { $_.Line }
+Write-Host ""
+Write-Host "Runtime log: $runtimeLog"
+Write-Host "Metadata:    $metaLog"
+
+if (-not $complete) {
+    throw "Probe did not finish within $TimeoutSeconds seconds. Inspect $runtimeLog for the last successful size and TCP stall diagnostics."
+}


### PR DESCRIPTION
## Цель

Изолировать участок `Android -> *.workers.dev` от Telegram backend и проверить, воспроизводится ли #29 на самом внешнем Cloudflare Worker transport.

Этот PR намеренно не меняет production `/apiws` route и не использует custom domain / Cloudflare Proxy. Тест идёт к тому же Worker `*.workers.dev` тем же Go `net.Dial -> crypto/tls -> raw WebSocket` transport, который используется в текущем Flowseal-parity Worker path.

## Что добавлено

### Worker diagnostics

В `scripts/cloudflare-worker/worker.js` добавлены отдельные диагностические WebSocket endpoints, не открывающие `cloudflare:sockets` и не подключающиеся к Telegram:

- `/diag/ws-echo` — возвращает каждый binary WS message без изменений;
- `/diag/upload` — принимает сообщения и отвечает `ack:<cumulative bytes>`;
- `/diag/download?size=N` — отправляет binary payload заданного размера, до 2 MiB.

Диагностическая Worker revision: `worker-network-probe-v1`.

Production `/apiws` остаётся `worker-stream-v2` без изменения семантики.

### Android/native probe

Добавлены `RunWorkerNetworkProbe` и `RunWorkerNetworkProbeWithFamily` в native Go core и JNA wrapper. Probe использует тот же `connectFlowsealRawWebSocketContext()` и логирует существующий `tcpTransportState()` / TCP_INFO.

Проверки:

1. `echo_staircase` на одном соединении: 1, 4, 8, 12, 16, 24, 32, 64, 128, 256, 512 KiB, 1 MiB;
2. `upload_4k_stream`: 4-KiB messages с ACK до суммарного 1 MiB;
3. `download_single`: отдельное соединение на каждый размер из той же лестницы.

На каждом шаге фиксируются размер, cumulative bytes, duration, success/error и TCP transport state. Deadline операции — 12 секунд.

Probe revision `worker-network-probe-v2` поддерживает выбор address family:

- `auto` — системный выбор адреса;
- `ipv4` — DNS resolve только A / принудительный IPv4 dial;
- `ipv6` — DNS resolve только AAAA / принудительный IPv6 dial.

SNI/Host остаются исходным `*.workers.dev`; меняется только IP family TCP-подключения.

### Запуск через ADB

```powershell
.\scripts\test-worker-network-probe.ps1 -WorkerDomain "tgproxy.carkov195.workers.dev" -IPFamily IPv4
.\scripts\test-worker-network-probe.ps1 -WorkerDomain "tgproxy.carkov195.workers.dev" -IPFamily IPv6 -SkipBuild
```

Скрипт собирает Debug APK, устанавливает его, запускает probe, ждёт `PROBE_DONE` и сохраняет logcat + metadata в `artifacts/worker-tests/`. IP family включается в имя файла и metadata.

## Результаты A/B

### Direct, без VPN

Внешний Worker transport воспроизводит проблему без Telegram backend:

- `echo_staircase`: timeout после небольшого объёма; около точки отказа `bytes_acked ~= 15 KiB`;
- `upload_4k_stream`: retransmissions, collapse до `cwnd=1`, timeout;
- `download_single`: 16 KiB проходит, 24 KiB уже зависает.

### AmneziaWG/WARP + forced IPv4

Принудительный IPv4 (`104.21.9.191:443`) проходит полностью:

- echo: до 1 MiB message / 2.13 MiB cumulative;
- upload: 1 MiB;
- download: до 1 MiB;
- очереди дренируются, `cwnd` растёт нормально; встречаются только единичные retransmissions без деградации.

Это исключает гипотезу, что успех предыдущего AWG-прогона объяснялся переходом с IPv4 на IPv6.

### AmneziaWG/WARP + forced IPv6

Также проходит полностью до 1 MiB во всех режимах, без деградации транспорта.

### Direct + forced IPv6

Не является доступным обходом на тестовой сети: `connect: network is unreachable` уже на dial.

## Вывод

Критический фактор — именно изменение внешнего сетевого пути через AWG/WARP, а не address family.

Практически исключены как первичная причина #29:

- Telegram / MTProto payload semantics;
- `cloudflare:sockets`;
- Worker v2/v3 inner backend;
- WebSocket message boundaries;
- IPv4 как таковой.

Проблема воспроизводится на прямом `Android -> ISP -> Cloudflare edge` TCP/TLS/WSS пути к `*.workers.dev` и исчезает при туннелировании того же IPv4-трафика через AWG/WARP.

Следующий этап исследования: проверить, можно ли обойти фильтрацию без отдельного VPN transport — в первую очередь Android-native/Cronet/OkHttp против текущего Go TLS/WS, затем TLS fingerprint/record-shaping, QUIC/WebTransport; userspace AWG остаётся гарантированным fallback.

## Проверки

CI #103: success.

Draft оставлен открытым как диагностический PR; не сливать как production fix #29.

Relates #29
Relates #33