### PR TITLE
[experiment][#29] A/B Worker transport with Chrome-like uTLS

### DIFF
--- a/app/src/main/java/com/amurcanov/tgwsproxy/NativeProxy.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/NativeProxy.kt
@@ -23,6 +23,7 @@ interface ProxyLibrary : Library {
     fun GetMtProtoProxyStatus(): Pointer?
     fun RunWorkerNetworkProbe(domain: String): Pointer?
     fun RunWorkerNetworkProbeWithFamily(domain: String, family: String): Pointer?
+    fun RunWorkerNetworkProbeWithFamilyAndTransport(domain: String, family: String, transport: String): Pointer?
     fun ResetAdaptiveRouteStats(all: Int)
     fun ResetAdaptiveNetworkRouteStats(profileId: String)
     fun FreeString(p: Pointer)
@@ -79,8 +80,8 @@ object NativeProxy {
         ProxyLibrary.INSTANCE.FreeString(ptr)
         return res
     }
-    fun runWorkerNetworkProbe(domain: String, family: String = "auto"): String? {
-        val ptr = ProxyLibrary.INSTANCE.RunWorkerNetworkProbeWithFamily(domain, family) ?: return null
+    fun runWorkerNetworkProbe(domain: String, family: String = "auto", transport: String = "go"): String? {
+        val ptr = ProxyLibrary.INSTANCE.RunWorkerNetworkProbeWithFamilyAndTransport(domain, family, transport) ?: return null
         val res = ptr.getString(0)
         ProxyLibrary.INSTANCE.FreeString(ptr)
         return res

--- a/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
@@ -21,7 +21,7 @@ class WorkerNetworkProbeActivity : Activity() {
                 Log.i(TAG, "PROBE_START domain=$domain ip_family=$family transport=$transport")
                 val report = when (transport) {
                     "okhttp" -> OkHttpWorkerNetworkProbe.run(domain, family)
-                    "go" -> NativeProxy.runWorkerNetworkProbe(domain, family).orEmpty()
+                    "go", "utls" -> NativeProxy.runWorkerNetworkProbe(domain, family, transport).orEmpty()
                     else -> throw IllegalArgumentException("unsupported_transport:$transport")
                 }
                 if (report.isEmpty()) {

--- a/native/tgwsproxy/flowseal_websocket_utls.go
+++ b/native/tgwsproxy/flowseal_websocket_utls.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	utls "github.com/refraction-networking/utls"
+)
+
+const workerProbeUTLSFingerprint = "chrome_auto_http1"
+
+func connectFlowsealRawWebSocketUTLSContext(ctx context.Context, host, domain, path string, timeout float64) (*flowsealRawWebSocket, error) {
+	if path == "" {
+		path = "/apiws"
+	}
+	if timeout <= 0 {
+		timeout = 10
+	}
+	dialTimeout := timeout
+	if dialTimeout > 10 {
+		dialTimeout = 10
+	}
+
+	dialer := &net.Dialer{Timeout: time.Duration(dialTimeout * float64(time.Second))}
+	rawConn, err := dialer.DialContext(ctx, "tcp", joinAddr(host, 443))
+	if err != nil {
+		return nil, &wsStageError{Stage: "tcp_dial", Err: err}
+	}
+	setSockOpts(rawConn)
+	stopCancel := context.AfterFunc(ctx, func() { _ = rawConn.Close() })
+	defer stopCancel()
+
+	config := &utls.Config{
+		InsecureSkipVerify:          true, // Preserve the existing Flowseal verification policy.
+		ServerName:                  domain,
+		NextProtos:                  []string{"http/1.1"},
+		DynamicRecordSizingDisabled: true,
+	}
+	utlsConn := utls.UClient(rawConn, config, utls.HelloChrome_Auto)
+	if err := prepareWorkerUTLSForHTTP1(utlsConn); err != nil {
+		_ = rawConn.Close()
+		return nil, &wsStageError{Stage: "tls_client_hello", Err: err}
+	}
+
+	deadline := time.Now().Add(time.Duration(timeout * float64(time.Second)))
+	_ = utlsConn.SetDeadline(deadline)
+	if err := utlsConn.HandshakeContext(ctx); err != nil {
+		_ = utlsConn.Close()
+		return nil, &wsStageError{Stage: "tls_handshake", Err: err}
+	}
+	_ = utlsConn.SetDeadline(time.Time{})
+
+	keyBytes := make([]byte, 16)
+	if _, err := rand.Read(keyBytes); err != nil {
+		_ = utlsConn.Close()
+		return nil, &wsStageError{Stage: "ws_upgrade_write", Err: err}
+	}
+	request := buildFlowsealUpgradeRequest(path, domain, base64.StdEncoding.EncodeToString(keyBytes))
+	_ = utlsConn.SetWriteDeadline(deadline)
+	if err := writeFlowsealFull(utlsConn, []byte(request)); err != nil {
+		_ = utlsConn.Close()
+		return nil, &wsStageError{Stage: "ws_upgrade_write", Err: err}
+	}
+	_ = utlsConn.SetWriteDeadline(time.Time{})
+
+	reader := bufio.NewReaderSize(utlsConn, 4096)
+	_ = utlsConn.SetReadDeadline(deadline)
+	responseLines := make([]string, 0, 16)
+	for {
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			_ = utlsConn.Close()
+			return nil, &wsStageError{Stage: "ws_upgrade_read", Err: readErr}
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		responseLines = append(responseLines, line)
+		if len(responseLines) > 100 {
+			_ = utlsConn.Close()
+			return nil, &wsStageError{Stage: "ws_upgrade_read", Err: fmt.Errorf("too many HTTP headers")}
+		}
+	}
+	_ = utlsConn.SetReadDeadline(time.Time{})
+
+	if len(responseLines) == 0 {
+		_ = utlsConn.Close()
+		return nil, &WsHandshakeError{StatusCode: 0, StatusLine: "empty response"}
+	}
+
+	firstLine := responseLines[0]
+	parts := strings.SplitN(firstLine, " ", 3)
+	statusCode := 0
+	if len(parts) >= 2 {
+		statusCode, _ = strconv.Atoi(parts[1])
+	}
+	if statusCode == 101 {
+		if logInfo != nil {
+			state := utlsConn.ConnectionState()
+			logInfo.Printf(
+				"MTProto Worker transport ready session_id=%s remote=%s tls_version=%x cipher=%x tls_record_sizing=fixed tls_fingerprint=%s alpn=%s worker_revision=%s",
+				flowsealSessionIDFromPath(path), rawConn.RemoteAddr(), state.Version, state.CipherSuite,
+				workerProbeUTLSFingerprint, mtProtoStatusField(state.NegotiatedProtocol),
+				flowsealResponseHeader(responseLines, "X-Tgws-Worker-Revision"),
+			)
+		}
+		return &flowsealRawWebSocket{
+			conn:      utlsConn,
+			reader:    reader,
+			sessionID: flowsealSessionIDFromPath(path),
+		}, nil
+	}
+
+	headers := make(map[string]string)
+	for _, headerLine := range responseLines[1:] {
+		if index := strings.IndexByte(headerLine, ':'); index >= 0 {
+			key := strings.TrimSpace(strings.ToLower(headerLine[:index]))
+			value := strings.TrimSpace(headerLine[index+1:])
+			headers[key] = value
+		}
+	}
+	_ = utlsConn.Close()
+	return nil, &WsHandshakeError{
+		StatusCode: statusCode,
+		StatusLine: firstLine,
+		Headers:    headers,
+		Location:   headers["location"],
+	}
+}
+
+// Chrome parrots normally advertise h2 as well. The existing probe speaks a
+// raw HTTP/1.1 WebSocket upgrade after TLS, so keep the browser-like ClientHello
+// while constraining ALPN to HTTP/1.1. This isolates ClientHello/fingerprint
+// effects without changing the WebSocket implementation under test.
+func prepareWorkerUTLSForHTTP1(conn *utls.UConn) error {
+	if err := conn.BuildHandshakeState(); err != nil {
+		return err
+	}
+	found := false
+	for _, extension := range conn.Extensions {
+		if alpn, ok := extension.(*utls.ALPNExtension); ok {
+			alpn.AlpnProtocols = []string{"http/1.1"}
+			found = true
+			break
+		}
+	}
+	if !found {
+		conn.Extensions = append(conn.Extensions, &utls.ALPNExtension{AlpnProtocols: []string{"http/1.1"}})
+	}
+	return conn.BuildHandshakeState()
+}

--- a/native/tgwsproxy/go.mod
+++ b/native/tgwsproxy/go.mod
@@ -2,6 +2,13 @@ module tg-ws-proxy
 
 go 1.25
 
+require github.com/refraction-networking/utls v1.8.2
+
 require (
-	golang.org/x/crypto v0.31.0
+	github.com/andybalholm/brotli v1.0.6 // indirect
+	github.com/klauspost/compress v1.17.4 // indirect
+	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
 )

--- a/native/tgwsproxy/go.sum
+++ b/native/tgwsproxy/go.sum
@@ -1,1 +1,14 @@
-golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
+github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
+github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEvV+S9iJ2IdQo=
+github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=

--- a/native/tgwsproxy/worker_network_probe.go
+++ b/native/tgwsproxy/worker_network_probe.go
@@ -23,6 +23,11 @@ const (
 	workerProbeIPv6   = "ipv6"
 )
 
+const (
+	workerProbeTransportGo   = "go"
+	workerProbeTransportUTLS = "utls"
+)
+
 var workerNetworkProbeSizes = []int{
 	1 * 1024,
 	4 * 1024,
@@ -49,11 +54,12 @@ type workerNetworkProbeCase struct {
 }
 
 type workerNetworkProbeReport struct {
-	Revision string                   `json:"revision"`
-	Domain   string                   `json:"domain"`
-	IPFamily string                   `json:"ip_family"`
-	Started  string                   `json:"started"`
-	Cases    []workerNetworkProbeCase `json:"cases"`
+	Revision  string                   `json:"revision"`
+	Domain    string                   `json:"domain"`
+	IPFamily  string                   `json:"ip_family"`
+	Transport string                   `json:"transport"`
+	Started   string                   `json:"started"`
+	Cases     []workerNetworkProbeCase `json:"cases"`
 }
 
 func normalizeWorkerProbeIPFamily(raw string) (string, bool) {
@@ -64,6 +70,17 @@ func normalizeWorkerProbeIPFamily(raw string) (string, bool) {
 		return workerProbeIPv4, true
 	case workerProbeIPv6, "6", "tcp6":
 		return workerProbeIPv6, true
+	default:
+		return "", false
+	}
+}
+
+func normalizeWorkerProbeTransport(raw string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", workerProbeTransportGo:
+		return workerProbeTransportGo, true
+	case workerProbeTransportUTLS, "chrome", "chrome_auto":
+		return workerProbeTransportUTLS, true
 	default:
 		return "", false
 	}
@@ -87,14 +104,20 @@ func resolveWorkerProbeHost(ctx context.Context, domain, family string) (string,
 	return ips[0].String(), nil
 }
 
-func workerProbeOpen(domain, path, family string) (*flowsealRawWebSocket, error) {
+func workerProbeOpen(domain, path, family, transport string) (*flowsealRawWebSocket, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	host, err := resolveWorkerProbeHost(ctx, domain, family)
 	if err != nil {
 		return nil, err
 	}
-	ws, err := connectFlowsealRawWebSocketContext(ctx, host, domain, path, 10)
+	var ws *flowsealRawWebSocket
+	switch transport {
+	case workerProbeTransportUTLS:
+		ws, err = connectFlowsealRawWebSocketUTLSContext(ctx, host, domain, path, 10)
+	default:
+		ws, err = connectFlowsealRawWebSocketContext(ctx, host, domain, path, 10)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -102,12 +125,13 @@ func workerProbeOpen(domain, path, family string) (*flowsealRawWebSocket, error)
 	return ws, nil
 }
 
-func workerProbeCaseLog(c workerNetworkProbeCase) {
+func workerProbeCaseLog(c workerNetworkProbeCase, transport string) {
 	if logInfo == nil {
 		return
 	}
 	logInfo.Printf(
-		"Worker network probe mode=%s size_bytes=%d cumulative_bytes=%d ok=%t duration_ms=%d error=%s %s",
+		"Worker network probe transport=%s mode=%s size_bytes=%d cumulative_bytes=%d ok=%t duration_ms=%d error=%s %s",
+		transport,
 		c.Mode,
 		c.SizeBytes,
 		c.CumulativeBytes,
@@ -118,12 +142,12 @@ func workerProbeCaseLog(c workerNetworkProbeCase) {
 	)
 }
 
-func runEchoStaircase(domain, family string) []workerNetworkProbeCase {
-	path := "/diag/ws-echo?sid=probe-echo"
-	ws, err := workerProbeOpen(domain, path, family)
+func runEchoStaircase(domain, family, transport string) []workerNetworkProbeCase {
+	path := "/diag/ws-echo?sid=probe-" + transport + "-echo"
+	ws, err := workerProbeOpen(domain, path, family, transport)
 	if err != nil {
 		c := workerNetworkProbeCase{Mode: "echo_staircase_connect", Error: err.Error()}
-		workerProbeCaseLog(c)
+		workerProbeCaseLog(c, transport)
 		return []workerNetworkProbeCase{c}
 	}
 	defer ws.Close()
@@ -147,7 +171,7 @@ func runEchoStaircase(domain, family string) []workerNetworkProbeCase {
 				TransportState:  tcpTransportState(ws.conn),
 				Error:           sendErr.Error(),
 			}
-			workerProbeCaseLog(c)
+			workerProbeCaseLog(c, transport)
 			cases = append(cases, c)
 			break
 		}
@@ -167,7 +191,7 @@ func runEchoStaircase(domain, family string) []workerNetworkProbeCase {
 		} else {
 			c.OK = true
 		}
-		workerProbeCaseLog(c)
+		workerProbeCaseLog(c, transport)
 		cases = append(cases, c)
 		if !c.OK {
 			break
@@ -176,12 +200,12 @@ func runEchoStaircase(domain, family string) []workerNetworkProbeCase {
 	return cases
 }
 
-func runUpload4KStream(domain, family string) []workerNetworkProbeCase {
-	path := "/diag/upload?sid=probe-upload-4k"
-	ws, err := workerProbeOpen(domain, path, family)
+func runUpload4KStream(domain, family, transport string) []workerNetworkProbeCase {
+	path := "/diag/upload?sid=probe-" + transport + "-upload-4k"
+	ws, err := workerProbeOpen(domain, path, family, transport)
 	if err != nil {
 		c := workerNetworkProbeCase{Mode: "upload_4k_connect", Error: err.Error()}
-		workerProbeCaseLog(c)
+		workerProbeCaseLog(c, transport)
 		return []workerNetworkProbeCase{c}
 	}
 	defer ws.Close()
@@ -206,7 +230,7 @@ func runUpload4KStream(domain, family string) []workerNetworkProbeCase {
 				TransportState:  tcpTransportState(ws.conn),
 				Error:           err.Error(),
 			}
-			workerProbeCaseLog(c)
+			workerProbeCaseLog(c, transport)
 			cases = append(cases, c)
 			break
 		}
@@ -220,7 +244,7 @@ func runUpload4KStream(domain, family string) []workerNetworkProbeCase {
 				TransportState:  tcpTransportState(ws.conn),
 				Error:           err.Error(),
 			}
-			workerProbeCaseLog(c)
+			workerProbeCaseLog(c, transport)
 			cases = append(cases, c)
 			break
 		}
@@ -235,7 +259,7 @@ func runUpload4KStream(domain, family string) []workerNetworkProbeCase {
 				TransportState:  tcpTransportState(ws.conn),
 				Error:           "unexpected_ack",
 			}
-			workerProbeCaseLog(c)
+			workerProbeCaseLog(c, transport)
 			cases = append(cases, c)
 			break
 		}
@@ -248,22 +272,22 @@ func runUpload4KStream(domain, family string) []workerNetworkProbeCase {
 				DurationMS:      time.Since(started).Milliseconds(),
 				TransportState:  tcpTransportState(ws.conn),
 			}
-			workerProbeCaseLog(c)
+			workerProbeCaseLog(c, transport)
 			cases = append(cases, c)
 		}
 	}
 	return cases
 }
 
-func runDownloadSizes(domain, family string) []workerNetworkProbeCase {
+func runDownloadSizes(domain, family, transport string) []workerNetworkProbeCase {
 	cases := make([]workerNetworkProbeCase, 0, len(workerNetworkProbeSizes))
 	for _, size := range workerNetworkProbeSizes {
-		path := "/diag/download?size=" + fmt.Sprint(size) + "&sid=" + url.QueryEscape(fmt.Sprintf("probe-download-%d", size))
+		path := "/diag/download?size=" + fmt.Sprint(size) + "&sid=" + url.QueryEscape(fmt.Sprintf("probe-%s-download-%d", transport, size))
 		started := time.Now()
-		ws, err := workerProbeOpen(domain, path, family)
+		ws, err := workerProbeOpen(domain, path, family, transport)
 		if err != nil {
 			c := workerNetworkProbeCase{Mode: "download_single", SizeBytes: size, DurationMS: time.Since(started).Milliseconds(), Error: err.Error()}
-			workerProbeCaseLog(c)
+			workerProbeCaseLog(c, transport)
 			cases = append(cases, c)
 			break
 		}
@@ -282,7 +306,7 @@ func runDownloadSizes(domain, family string) []workerNetworkProbeCase {
 		} else {
 			c.OK = true
 		}
-		workerProbeCaseLog(c)
+		workerProbeCaseLog(c, transport)
 		cases = append(cases, c)
 		ws.Close()
 		if !c.OK {
@@ -292,14 +316,16 @@ func runDownloadSizes(domain, family string) []workerNetworkProbeCase {
 	return cases
 }
 
-func runWorkerNetworkProbe(domain, familyRaw string) workerNetworkProbeReport {
+func runWorkerNetworkProbe(domain, familyRaw, transportRaw string) workerNetworkProbeReport {
 	domain = NormalizeWorkerDomain(strings.TrimSpace(domain))
 	family, familyOK := normalizeWorkerProbeIPFamily(familyRaw)
+	transport, transportOK := normalizeWorkerProbeTransport(transportRaw)
 	report := workerNetworkProbeReport{
-		Revision: "worker-network-probe-v2",
-		Domain:   domain,
-		IPFamily: family,
-		Started:  time.Now().UTC().Format(time.RFC3339),
+		Revision:  "worker-network-probe-v3",
+		Domain:    domain,
+		IPFamily:  family,
+		Transport: transport,
+		Started:   time.Now().UTC().Format(time.RFC3339),
 	}
 	if domain == "" {
 		report.Cases = []workerNetworkProbeCase{{Mode: "validation", Error: "invalid_worker_domain"}}
@@ -310,14 +336,19 @@ func runWorkerNetworkProbe(domain, familyRaw string) workerNetworkProbeReport {
 		report.Cases = []workerNetworkProbeCase{{Mode: "validation", Error: "invalid_ip_family"}}
 		return report
 	}
-	if logInfo != nil {
-		logInfo.Printf("Worker network probe start domain=%s ip_family=%s revision=%s", domain, family, report.Revision)
+	if !transportOK {
+		report.Transport = strings.TrimSpace(transportRaw)
+		report.Cases = []workerNetworkProbeCase{{Mode: "validation", Error: "invalid_transport"}}
+		return report
 	}
-	report.Cases = append(report.Cases, runEchoStaircase(domain, family)...)
-	report.Cases = append(report.Cases, runUpload4KStream(domain, family)...)
-	report.Cases = append(report.Cases, runDownloadSizes(domain, family)...)
 	if logInfo != nil {
-		logInfo.Printf("Worker network probe complete domain=%s ip_family=%s cases=%d", domain, family, len(report.Cases))
+		logInfo.Printf("Worker network probe start domain=%s ip_family=%s transport=%s revision=%s", domain, family, transport, report.Revision)
+	}
+	report.Cases = append(report.Cases, runEchoStaircase(domain, family, transport)...)
+	report.Cases = append(report.Cases, runUpload4KStream(domain, family, transport)...)
+	report.Cases = append(report.Cases, runDownloadSizes(domain, family, transport)...)
+	if logInfo != nil {
+		logInfo.Printf("Worker network probe complete domain=%s ip_family=%s transport=%s cases=%d", domain, family, transport, len(report.Cases))
 	}
 	return report
 }
@@ -325,7 +356,7 @@ func runWorkerNetworkProbe(domain, familyRaw string) workerNetworkProbeReport {
 func encodeWorkerNetworkProbeReport(report workerNetworkProbeReport) *C.char {
 	encoded, err := json.Marshal(report)
 	if err != nil {
-		return C.CString(`{"revision":"worker-network-probe-v2","error":"json_encode_failed"}`)
+		return C.CString(`{"revision":"worker-network-probe-v3","error":"json_encode_failed"}`)
 	}
 	return C.CString(string(encoded))
 }
@@ -333,11 +364,17 @@ func encodeWorkerNetworkProbeReport(report workerNetworkProbeReport) *C.char {
 //export RunWorkerNetworkProbe
 func RunWorkerNetworkProbe(cDomain *C.char) *C.char {
 	initLogging(true)
-	return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain), workerProbeIPAuto))
+	return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain), workerProbeIPAuto, workerProbeTransportGo))
 }
 
 //export RunWorkerNetworkProbeWithFamily
 func RunWorkerNetworkProbeWithFamily(cDomain *C.char, cFamily *C.char) *C.char {
 	initLogging(true)
-	return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain), C.GoString(cFamily)))
+	return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain), C.GoString(cFamily), workerProbeTransportGo))
+}
+
+//export RunWorkerNetworkProbeWithFamilyAndTransport
+func RunWorkerNetworkProbeWithFamilyAndTransport(cDomain *C.char, cFamily *C.char, cTransport *C.char) *C.char {
+	initLogging(true)
+	return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain), C.GoString(cFamily), C.GoString(cTransport)))
 }

--- a/native/tgwsproxy/worker_network_probe_test.go
+++ b/native/tgwsproxy/worker_network_probe_test.go
@@ -29,3 +29,29 @@ func TestNormalizeWorkerProbeIPFamily(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeWorkerProbeTransport(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+		ok    bool
+	}{
+		{"", workerProbeTransportGo, true},
+		{"go", workerProbeTransportGo, true},
+		{"GO", workerProbeTransportGo, true},
+		{"utls", workerProbeTransportUTLS, true},
+		{"chrome", workerProbeTransportUTLS, true},
+		{"chrome_auto", workerProbeTransportUTLS, true},
+		{"okhttp", "", false},
+		{"bogus", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, ok := normalizeWorkerProbeTransport(tt.input)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("normalizeWorkerProbeTransport(%q) = (%q, %t), want (%q, %t)", tt.input, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/scripts/test-worker-network-probe.ps1
+++ b/scripts/test-worker-network-probe.ps1
@@ -4,7 +4,7 @@ param(
     [string]$WorkerDomain,
     [ValidateSet("Auto", "IPv4", "IPv6")]
     [string]$IPFamily = "Auto",
-    [ValidateSet("Go", "OkHttp")]
+    [ValidateSet("Go", "OkHttp", "UTLS")]
     [string]$Transport = "Go",
     [switch]$SkipBuild,
     [string]$DeviceSerial = "",
@@ -108,7 +108,7 @@ $finalDump | Set-Content -Encoding UTF8 $runtimeLog
 
 Write-Host ""
 Write-Host "=== Probe summary ==="
-$finalDump | Select-String "Worker network probe|PROBE_" | ForEach-Object { $_.Line }
+$finalDump | Select-String "Worker network probe|MTProto Worker transport ready|PROBE_" | ForEach-Object { $_.Line }
 Write-Host ""
 Write-Host "Runtime log: $runtimeLog"
 Write-Host "Metadata:    $metaLog"


### PR DESCRIPTION
## Цель

Проверить, объясняется ли улучшение OkHttp в #42 различием TLS ClientHello / fingerprint, не перенося production Worker transport из Go в Kotlin.

PR основан на #42 и не меняет production proxy routing. Используются те же диагностические `/diag/*` endpoints на том же `*.workers.dev`.

## Что добавлено

- `github.com/refraction-networking/utls v1.8.2`;
- отдельный диагностический Go connector на uTLS `HelloChrome_Auto`;
- ALPN принудительно ограничен `http/1.1`, потому что существующий raw WebSocket probe после TLS отправляет HTTP/1.1 Upgrade;
- WebSocket framing остаётся тем же Go/Flowseal raw implementation;
- `DynamicRecordSizingDisabled=true`, как у текущего Go baseline, чтобы A/B менял прежде всего ClientHello/fingerprint, а не TLS record sizing;
- transport selector `go | utls` в native probe;
- Android/JNA и `test-worker-network-probe.ps1` принимают `-Transport UTLS`;
- Android `OkHttp` transport из #42 сохранён для сравнения;
- report revision `worker-network-probe-v3`, transport записывается в JSON/logcat;
- unit test для transport selector.

## Device A/B — direct IPv4, без AWG/VPN

### Go baseline

Повторно подтверждён прежний профиль отказа:

- `echo_staircase`: 1 KiB и 4 KiB проходят, 8-KiB step (`13312` cumulative) зависает на 12 s;
- около точки отказа `bytes_acked=15236`;
- `upload_4k_stream`: timeout на `20480` cumulative; перед закрытием `cwnd=1`, `total_retrans=6`, `bytes_acked=18342`;
- `download_single`: 16 KiB проходит, 24 KiB зависает.

### uTLS `HelloChrome_Auto`

Chrome-like ClientHello сам по себе картину не изменил:

- `echo_staircase`: 8-KiB step (`13312` cumulative) зависает так же; перед закрытием `bytes_acked=15521`;
- `upload_4k_stream`: timeout на `20480` cumulative; `cwnd=1`, `total_retrans=6`, `bytes_acked=18595`;
- `download_single`: 16 KiB проходит, 24 KiB зависает;
- handshake действительно использует `tls_fingerprint=chrome_auto_http1`, TLS 1.3 / AES-128-GCM / ALPN `http/1.1`.

Иными словами, uTLS практически совпадает с Go baseline. Гипотеза «достаточно заменить только ClientHello/fingerprint» отвергнута.

### OkHttp control

На той же direct IPv4 сети Android OkHttp снова показывает существенно иной профиль:

- `echo_staircase`: проходит до 128-KiB message / `295936` cumulative, timeout только на 256-KiB step;
- `upload_4k_stream`: доходит примерно до `40960` cumulative;
- `download_single`: проходит все размеры вплоть до 1 MiB;
- TLS 1.3 / AES-128-GCM / HTTP/1.1.

Это значит, что преимущество OkHttp связано не только с ClientHello. Наиболее вероятные различия для следующего A/B: TLS record sizing / record boundaries / write packetization и поведение Android TLS socket.

## Вывод

- Chrome-like ClientHello через uTLS **не помогает** и не приближает Go transport к OkHttp.
- Простая подмена TLS fingerprint не является production fix для #29.
- OkHttp по-прежнему заметно лучше direct Go/uTLS, особенно в downstream: 1 MiB против 16 KiB.
- Следующий диагностический шаг — изолировать TLS record shaping/packetization при неизменных Worker, WebSocket message boundaries и direct IPv4 path.

Worker заново деплоить не нужно: `/diag/*` не менялись.

CI #105: Worker transport regression passed; Windows CI ещё выполняется на момент фиксации результата.

Draft: не сливать как production fix.

Relates #29
Depends on #42