### PR TITLE
[experiment][#29] A/B Worker TLS record shaping and write packetization

### DIFF
--- a/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
@@ -21,8 +21,7 @@ class WorkerNetworkProbeActivity : Activity() {
                 Log.i(TAG, "PROBE_START domain=$domain ip_family=$family transport=$transport")
                 val report = when (transport) {
                     "okhttp" -> OkHttpWorkerNetworkProbe.run(domain, family)
-                    "go", "utls" -> NativeProxy.runWorkerNetworkProbe(domain, family, transport).orEmpty()
-                    else -> throw IllegalArgumentException("unsupported_transport:$transport")
+                    else -> NativeProxy.runWorkerNetworkProbe(domain, family, transport).orEmpty()
                 }
                 if (report.isEmpty()) {
                     Log.e(TAG, "PROBE_RESULT empty")

--- a/native/tgwsproxy/flowseal_tls_write_profiles_test.go
+++ b/native/tgwsproxy/flowseal_tls_write_profiles_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+type flowsealWriteCapture struct {
+	writes []int
+	data   bytes.Buffer
+}
+
+func (w *flowsealWriteCapture) Write(p []byte) (int, error) {
+	w.writes = append(w.writes, len(p))
+	return w.data.Write(p)
+}
+
+func TestWriteFlowsealShapedFullCount(t *testing.T) {
+	payload := bytes.Repeat([]byte{0x5a}, 2500)
+	capture := &flowsealWriteCapture{}
+
+	n, err := writeFlowsealShapedFullCount(capture, payload, 1200, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(payload) {
+		t.Fatalf("written=%d want=%d", n, len(payload))
+	}
+	wantWrites := []int{1200, 1200, 100}
+	if len(capture.writes) != len(wantWrites) {
+		t.Fatalf("writes=%v want=%v", capture.writes, wantWrites)
+	}
+	for i, want := range wantWrites {
+		if capture.writes[i] != want {
+			t.Fatalf("writes=%v want=%v", capture.writes, wantWrites)
+		}
+	}
+	if !bytes.Equal(capture.data.Bytes(), payload) {
+		t.Fatal("shaping changed payload bytes")
+	}
+}
+
+func TestWorkerProbeTLSProfileForTransport(t *testing.T) {
+	tests := []struct {
+		transport string
+		chunk     int
+		dynamic   bool
+	}{
+		{workerProbeTransportGoDynamic, 0, true},
+		{workerProbeTransportGoSplit1200, 1200, false},
+		{workerProbeTransportGoSplit4K, 4 * 1024, false},
+		{workerProbeTransportGoSplit16K, 16 * 1024, false},
+		{workerProbeTransportGoPaced4K, 4 * 1024, false},
+	}
+	for _, tt := range tests {
+		profile, ok := workerProbeTLSProfileForTransport(tt.transport)
+		if !ok {
+			t.Fatalf("missing profile for %s", tt.transport)
+		}
+		if profile.WriteChunkBytes != tt.chunk {
+			t.Fatalf("%s chunk=%d want=%d", tt.transport, profile.WriteChunkBytes, tt.chunk)
+		}
+		if gotDynamic := !profile.DynamicRecordSizingDisabled; gotDynamic != tt.dynamic {
+			t.Fatalf("%s dynamic=%t want=%t", tt.transport, gotDynamic, tt.dynamic)
+		}
+	}
+	if workerProbeTLSProfilePaced4K.WritePace <= 0 {
+		t.Fatal("paced profile must have a positive delay")
+	}
+}

--- a/native/tgwsproxy/flowseal_websocket_frames.go
+++ b/native/tgwsproxy/flowseal_websocket_frames.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -69,13 +70,9 @@ func (ws *flowsealRawWebSocket) sendFrame(frame []byte, payloadBytes int) error 
 		return ws.failureOr(net.ErrClosed)
 	}
 
-	// Keep application messages ordered; writeMu serializes data and control
-	// frames. Close must never wait for either lock.
 	ws.sendMu.Lock()
 	defer ws.sendMu.Unlock()
 
-	// Allocate the sequence before entering the potentially blocking transport
-	// write. This keeps the exact blocked attempt visible in #29 diagnostics.
 	sequence := ws.sendCount.Add(1)
 	trace := payloadBytes >= 64*1024 || sequence <= 2
 
@@ -110,7 +107,6 @@ func (ws *flowsealRawWebSocket) sendFrame(frame []byte, payloadBytes int) error 
 	ws.writeMu.Unlock()
 
 	if err != nil {
-		// A partial TLS/WebSocket write cannot be replayed on this stream.
 		ws.fail(err)
 		if logInfo != nil {
 			logInfo.Printf(
@@ -180,8 +176,6 @@ func (ws *flowsealRawWebSocket) Close() {
 		logInfo.Printf("MTProto Worker transport closed session_id=%s sent_bytes=%d recv_bytes=%d %s",
 			ws.logSessionID(), ws.sentBytes.Load(), ws.recvBytes.Load(), tcpTransportState(ws.conn))
 	}
-	// tls.Conn.Close can try to write close_notify for another five seconds
-	// after a failed Write. Cancellation must close the underlying transport.
 	conn := ws.conn
 	if wrapped, ok := conn.(interface{ NetConn() net.Conn }); ok {
 		conn = wrapped.NetConn()
@@ -249,7 +243,6 @@ func (ws *flowsealRawWebSocket) readFrame() (int, []byte, bool, error) {
 	return opcode, payload, fin, nil
 }
 
-// buildFlowsealFrame preserves one application message per frame, like Flowseal.
 func buildFlowsealFrame(opcode int, payload []byte, mask bool) []byte {
 	return buildFlowsealSingleFrame(opcode, payload, mask, true)
 }

--- a/native/tgwsproxy/flowseal_websocket_frames.go
+++ b/native/tgwsproxy/flowseal_websocket_frames.go
@@ -20,22 +20,25 @@ const (
 // flowsealRawWebSocket mirrors Flowseal's RawWebSocket message semantics and
 // intentionally stays separate from the Android RawWebSocket abstraction.
 type flowsealRawWebSocket struct {
-	conn          net.Conn
-	reader        *bufio.Reader
-	sessionID     string
-	sendMu        sync.Mutex
-	writeMu       sync.Mutex
-	deadlineMu    sync.Mutex
-	writeDeadline time.Time
-	frameDeadline time.Time
-	closed        atomic.Bool
-	errorMu       sync.Mutex
-	terminalErr   error
-	frag          []byte
-	sendCount     atomic.Uint64
-	recvCount     atomic.Uint64
-	sentBytes     atomic.Uint64
-	recvBytes     atomic.Uint64
+	conn                net.Conn
+	reader              *bufio.Reader
+	sessionID           string
+	tlsWriteChunkBytes  int
+	tlsWritePace        time.Duration
+	tlsWriteProfileName string
+	sendMu              sync.Mutex
+	writeMu             sync.Mutex
+	deadlineMu          sync.Mutex
+	writeDeadline       time.Time
+	frameDeadline       time.Time
+	closed              atomic.Bool
+	errorMu             sync.Mutex
+	terminalErr         error
+	frag                []byte
+	sendCount           atomic.Uint64
+	recvCount           atomic.Uint64
+	sentBytes           atomic.Uint64
+	recvBytes           atomic.Uint64
 }
 
 func (ws *flowsealRawWebSocket) Send(data []byte) error {
@@ -92,13 +95,13 @@ func (ws *flowsealRawWebSocket) sendFrame(frame []byte, payloadBytes int) error 
 	started := time.Now()
 	if logInfo != nil && trace {
 		logInfo.Printf(
-			"MTProto Worker Flowseal parity WS write start session_id=%s seq=%d payload_bytes=%d frame_bytes=%d tcp_send_queue_before=%d tcp_not_sent_before=%d tcp_send_buffer_bytes=%d",
-			ws.logSessionID(), sequence, payloadBytes, len(frame), queueBefore, notSentBefore, sendBufferBytes,
+			"MTProto Worker Flowseal parity WS write start session_id=%s seq=%d payload_bytes=%d frame_bytes=%d tls_write_profile=%s tls_write_chunk_bytes=%d tls_write_pace_us=%d tcp_send_queue_before=%d tcp_not_sent_before=%d tcp_send_buffer_bytes=%d",
+			ws.logSessionID(), sequence, payloadBytes, len(frame), ws.logTLSWriteProfile(), ws.tlsWriteChunkBytes, ws.tlsWritePace.Microseconds(), queueBefore, notSentBefore, sendBufferBytes,
 		)
 	}
 
 	stopTrace := ws.traceBlockedWrite(sequence, trace)
-	writtenFrameBytes, err := writeFlowsealFullCount(ws.conn, frame)
+	writtenFrameBytes, err := writeFlowsealShapedFullCount(ws.conn, frame, ws.tlsWriteChunkBytes, ws.tlsWritePace)
 	stopTrace()
 	ws.endFrameWrite()
 	duration := time.Since(started)
@@ -111,8 +114,8 @@ func (ws *flowsealRawWebSocket) sendFrame(frame []byte, payloadBytes int) error 
 		ws.fail(err)
 		if logInfo != nil {
 			logInfo.Printf(
-				"MTProto Worker Flowseal parity WS write failed session_id=%s seq=%d payload_bytes=%d frame_bytes=%d written_frame_bytes=%d duration_ms=%d tcp_send_queue_before=%d tcp_send_queue_after=%d tcp_not_sent_before=%d tcp_not_sent_after=%d tcp_send_buffer_bytes=%d error=%v",
-				ws.logSessionID(), sequence, payloadBytes, len(frame), writtenFrameBytes, duration.Milliseconds(), queueBefore, queueAfter, notSentBefore, notSentAfter, sendBufferBytes, err,
+				"MTProto Worker Flowseal parity WS write failed session_id=%s seq=%d payload_bytes=%d frame_bytes=%d written_frame_bytes=%d duration_ms=%d tls_write_profile=%s tls_write_chunk_bytes=%d tls_write_pace_us=%d tcp_send_queue_before=%d tcp_send_queue_after=%d tcp_not_sent_before=%d tcp_not_sent_after=%d tcp_send_buffer_bytes=%d error=%v",
+				ws.logSessionID(), sequence, payloadBytes, len(frame), writtenFrameBytes, duration.Milliseconds(), ws.logTLSWriteProfile(), ws.tlsWriteChunkBytes, ws.tlsWritePace.Microseconds(), queueBefore, queueAfter, notSentBefore, notSentAfter, sendBufferBytes, err,
 			)
 		}
 		return err
@@ -121,8 +124,8 @@ func (ws *flowsealRawWebSocket) sendFrame(frame []byte, payloadBytes int) error 
 	cumulative := ws.sentBytes.Add(uint64(payloadBytes))
 	if logInfo != nil && trace {
 		logInfo.Printf(
-			"MTProto Worker Flowseal parity WS send session_id=%s seq=%d payload_bytes=%d frame_bytes=%d written_frame_bytes=%d cumulative_payload_bytes=%d duration_ms=%d tcp_send_queue_before=%d tcp_send_queue_after=%d tcp_not_sent_before=%d tcp_not_sent_after=%d tcp_send_buffer_bytes=%d",
-			ws.logSessionID(), sequence, payloadBytes, len(frame), writtenFrameBytes, cumulative, duration.Milliseconds(), queueBefore, queueAfter, notSentBefore, notSentAfter, sendBufferBytes,
+			"MTProto Worker Flowseal parity WS send session_id=%s seq=%d payload_bytes=%d frame_bytes=%d written_frame_bytes=%d cumulative_payload_bytes=%d duration_ms=%d tls_write_profile=%s tls_write_chunk_bytes=%d tls_write_pace_us=%d tcp_send_queue_before=%d tcp_send_queue_after=%d tcp_not_sent_before=%d tcp_not_sent_after=%d tcp_send_buffer_bytes=%d",
+			ws.logSessionID(), sequence, payloadBytes, len(frame), writtenFrameBytes, cumulative, duration.Milliseconds(), ws.logTLSWriteProfile(), ws.tlsWriteChunkBytes, ws.tlsWritePace.Microseconds(), queueBefore, queueAfter, notSentBefore, notSentAfter, sendBufferBytes,
 		)
 	}
 	return nil
@@ -198,7 +201,7 @@ func (ws *flowsealRawWebSocket) writeControl(opcode int, payload []byte) error {
 		return err
 	}
 	defer ws.endFrameWrite()
-	err := writeFlowsealFull(ws.conn, frame)
+	err := writeFlowsealShapedFull(ws.conn, frame, ws.tlsWriteChunkBytes, ws.tlsWritePace)
 	if err != nil {
 		ws.fail(err)
 	}
@@ -324,6 +327,33 @@ func writeFlowsealFullCount(writer io.Writer, data []byte) (int, error) {
 	return total, nil
 }
 
+func writeFlowsealShapedFull(writer io.Writer, data []byte, chunkBytes int, pace time.Duration) error {
+	_, err := writeFlowsealShapedFullCount(writer, data, chunkBytes, pace)
+	return err
+}
+
+func writeFlowsealShapedFullCount(writer io.Writer, data []byte, chunkBytes int, pace time.Duration) (int, error) {
+	if chunkBytes <= 0 || chunkBytes >= len(data) {
+		return writeFlowsealFullCount(writer, data)
+	}
+	total := 0
+	for total < len(data) {
+		end := total + chunkBytes
+		if end > len(data) {
+			end = len(data)
+		}
+		written, err := writeFlowsealFullCount(writer, data[total:end])
+		total += written
+		if err != nil {
+			return total, err
+		}
+		if total < len(data) && pace > 0 {
+			time.Sleep(pace)
+		}
+	}
+	return total, nil
+}
+
 func (ws *flowsealRawWebSocket) noteRecv(payloadBytes int) {
 	sequence := ws.recvCount.Add(1)
 	cumulative := ws.recvBytes.Add(uint64(payloadBytes))
@@ -340,6 +370,13 @@ func (ws *flowsealRawWebSocket) logSessionID() string {
 		return "none"
 	}
 	return mtProtoStatusField(ws.sessionID)
+}
+
+func (ws *flowsealRawWebSocket) logTLSWriteProfile() string {
+	if ws == nil || strings.TrimSpace(ws.tlsWriteProfileName) == "" {
+		return "default"
+	}
+	return mtProtoStatusField(ws.tlsWriteProfileName)
 }
 
 func underlyingTCPConn(conn net.Conn) *net.TCPConn {

--- a/native/tgwsproxy/flowseal_websocket_tls_profiles.go
+++ b/native/tgwsproxy/flowseal_websocket_tls_profiles.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type workerProbeTLSProfile struct {
+	Name                        string
+	DynamicRecordSizingDisabled bool
+	WriteChunkBytes             int
+	WritePace                   time.Duration
+}
+
+var (
+	workerProbeTLSProfileDynamic = workerProbeTLSProfile{
+		Name:                        "go_dynamic",
+		DynamicRecordSizingDisabled: false,
+	}
+	workerProbeTLSProfileSplit1200 = workerProbeTLSProfile{
+		Name:                        "go_split_1200",
+		DynamicRecordSizingDisabled: true,
+		WriteChunkBytes:             1200,
+	}
+	workerProbeTLSProfileSplit4K = workerProbeTLSProfile{
+		Name:                        "go_split_4k",
+		DynamicRecordSizingDisabled: true,
+		WriteChunkBytes:             4 * 1024,
+	}
+	workerProbeTLSProfileSplit16K = workerProbeTLSProfile{
+		Name:                        "go_split_16k",
+		DynamicRecordSizingDisabled: true,
+		WriteChunkBytes:             16 * 1024,
+	}
+	workerProbeTLSProfilePaced4K = workerProbeTLSProfile{
+		Name:                        "go_paced_4k",
+		DynamicRecordSizingDisabled: true,
+		WriteChunkBytes:             4 * 1024,
+		WritePace:                   2 * time.Millisecond,
+	}
+)
+
+// connectFlowsealRawWebSocketTLSProfileContext is diagnostic-only. It keeps the
+// same Go TCP/TLS/raw-WebSocket implementation as the production Flowseal path
+// while changing only TLS record sizing and/or the size/timing of application
+// writes handed to crypto/tls.
+func connectFlowsealRawWebSocketTLSProfileContext(
+	ctx context.Context,
+	host, domain, path string,
+	timeout float64,
+	profile workerProbeTLSProfile,
+) (*flowsealRawWebSocket, error) {
+	if path == "" {
+		path = "/apiws"
+	}
+	if timeout <= 0 {
+		timeout = 10
+	}
+	dialTimeout := timeout
+	if dialTimeout > 10 {
+		dialTimeout = 10
+	}
+
+	dialer := &net.Dialer{Timeout: time.Duration(dialTimeout * float64(time.Second))}
+	rawConn, err := dialer.DialContext(ctx, "tcp", joinAddr(host, 443))
+	if err != nil {
+		return nil, &wsStageError{Stage: "tcp_dial", Err: err}
+	}
+	setSockOpts(rawConn)
+	stopCancel := context.AfterFunc(ctx, func() { _ = rawConn.Close() })
+	defer stopCancel()
+
+	config := flowsealWorkerTLSConfig(domain)
+	config.DynamicRecordSizingDisabled = profile.DynamicRecordSizingDisabled
+	tlsConn := tls.Client(rawConn, config)
+	deadline := time.Now().Add(time.Duration(timeout * float64(time.Second)))
+	_ = tlsConn.SetDeadline(deadline)
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		_ = tlsConn.Close()
+		return nil, &wsStageError{Stage: "tls_handshake", Err: err}
+	}
+	_ = tlsConn.SetDeadline(time.Time{})
+
+	keyBytes := make([]byte, 16)
+	if _, err := rand.Read(keyBytes); err != nil {
+		_ = tlsConn.Close()
+		return nil, &wsStageError{Stage: "ws_upgrade_write", Err: err}
+	}
+	request := buildFlowsealUpgradeRequest(path, domain, base64.StdEncoding.EncodeToString(keyBytes))
+	_ = tlsConn.SetWriteDeadline(deadline)
+	if err := writeFlowsealShapedFull(tlsConn, []byte(request), profile.WriteChunkBytes, profile.WritePace); err != nil {
+		_ = tlsConn.Close()
+		return nil, &wsStageError{Stage: "ws_upgrade_write", Err: err}
+	}
+	_ = tlsConn.SetWriteDeadline(time.Time{})
+
+	reader := bufio.NewReaderSize(tlsConn, 4096)
+	_ = tlsConn.SetReadDeadline(deadline)
+	responseLines := make([]string, 0, 16)
+	for {
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			_ = tlsConn.Close()
+			return nil, &wsStageError{Stage: "ws_upgrade_read", Err: readErr}
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		responseLines = append(responseLines, line)
+		if len(responseLines) > 100 {
+			_ = tlsConn.Close()
+			return nil, &wsStageError{Stage: "ws_upgrade_read", Err: fmt.Errorf("too many HTTP headers")}
+		}
+	}
+	_ = tlsConn.SetReadDeadline(time.Time{})
+
+	if len(responseLines) == 0 {
+		_ = tlsConn.Close()
+		return nil, &WsHandshakeError{StatusCode: 0, StatusLine: "empty response"}
+	}
+
+	firstLine := responseLines[0]
+	parts := strings.SplitN(firstLine, " ", 3)
+	statusCode := 0
+	if len(parts) >= 2 {
+		statusCode, _ = strconv.Atoi(parts[1])
+	}
+	if statusCode == 101 {
+		if logInfo != nil {
+			state := tlsConn.ConnectionState()
+			recordSizing := "dynamic"
+			if profile.DynamicRecordSizingDisabled {
+				recordSizing = "fixed"
+			}
+			logInfo.Printf(
+				"MTProto Worker transport ready session_id=%s remote=%s tls_version=%x cipher=%x tls_record_sizing=%s tls_write_profile=%s tls_write_chunk_bytes=%d tls_write_pace_us=%d worker_revision=%s",
+				flowsealSessionIDFromPath(path), rawConn.RemoteAddr(), state.Version, state.CipherSuite,
+				recordSizing, mtProtoStatusField(profile.Name), profile.WriteChunkBytes, profile.WritePace.Microseconds(),
+				flowsealResponseHeader(responseLines, "X-Tgws-Worker-Revision"),
+			)
+		}
+		return &flowsealRawWebSocket{
+			conn:                tlsConn,
+			reader:              reader,
+			sessionID:           flowsealSessionIDFromPath(path),
+			tlsWriteChunkBytes:  profile.WriteChunkBytes,
+			tlsWritePace:        profile.WritePace,
+			tlsWriteProfileName: profile.Name,
+		}, nil
+	}
+
+	headers := make(map[string]string)
+	for _, headerLine := range responseLines[1:] {
+		if index := strings.IndexByte(headerLine, ':'); index >= 0 {
+			key := strings.TrimSpace(strings.ToLower(headerLine[:index]))
+			value := strings.TrimSpace(headerLine[index+1:])
+			headers[key] = value
+		}
+	}
+	_ = tlsConn.Close()
+	return nil, &WsHandshakeError{
+		StatusCode: statusCode,
+		StatusLine: firstLine,
+		Headers:    headers,
+		Location:   headers["location"],
+	}
+}

--- a/native/tgwsproxy/worker_network_probe.go
+++ b/native/tgwsproxy/worker_network_probe.go
@@ -24,357 +24,169 @@ const (
 )
 
 const (
-	workerProbeTransportGo   = "go"
-	workerProbeTransportUTLS = "utls"
+	workerProbeTransportGo          = "go"
+	workerProbeTransportUTLS        = "utls"
+	workerProbeTransportGoDynamic   = "go_dynamic"
+	workerProbeTransportGoSplit1200 = "go_split_1200"
+	workerProbeTransportGoSplit4K   = "go_split_4k"
+	workerProbeTransportGoSplit16K  = "go_split_16k"
+	workerProbeTransportGoPaced4K   = "go_paced_4k"
 )
 
-var workerNetworkProbeSizes = []int{
-	1 * 1024,
-	4 * 1024,
-	8 * 1024,
-	12 * 1024,
-	16 * 1024,
-	24 * 1024,
-	32 * 1024,
-	64 * 1024,
-	128 * 1024,
-	256 * 1024,
-	512 * 1024,
-	1024 * 1024,
-}
+var workerNetworkProbeSizes = []int{1024, 4 * 1024, 8 * 1024, 12 * 1024, 16 * 1024, 24 * 1024, 32 * 1024, 64 * 1024, 128 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024}
 
 type workerNetworkProbeCase struct {
-	Mode            string `json:"mode"`
-	SizeBytes       int    `json:"size_bytes,omitempty"`
-	CumulativeBytes int    `json:"cumulative_bytes,omitempty"`
-	OK              bool   `json:"ok"`
-	DurationMS      int64  `json:"duration_ms"`
-	TransportState  string `json:"transport_state,omitempty"`
-	Error           string `json:"error,omitempty"`
+	Mode string `json:"mode"`
+	SizeBytes int `json:"size_bytes,omitempty"`
+	CumulativeBytes int `json:"cumulative_bytes,omitempty"`
+	OK bool `json:"ok"`
+	DurationMS int64 `json:"duration_ms"`
+	TransportState string `json:"transport_state,omitempty"`
+	Error string `json:"error,omitempty"`
 }
 
 type workerNetworkProbeReport struct {
-	Revision  string                   `json:"revision"`
-	Domain    string                   `json:"domain"`
-	IPFamily  string                   `json:"ip_family"`
-	Transport string                   `json:"transport"`
-	Started   string                   `json:"started"`
-	Cases     []workerNetworkProbeCase `json:"cases"`
+	Revision string `json:"revision"`
+	Domain string `json:"domain"`
+	IPFamily string `json:"ip_family"`
+	Transport string `json:"transport"`
+	Started string `json:"started"`
+	Cases []workerNetworkProbeCase `json:"cases"`
 }
 
 func normalizeWorkerProbeIPFamily(raw string) (string, bool) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "", workerProbeIPAuto:
-		return workerProbeIPAuto, true
-	case workerProbeIPv4, "4", "tcp4":
-		return workerProbeIPv4, true
-	case workerProbeIPv6, "6", "tcp6":
-		return workerProbeIPv6, true
-	default:
-		return "", false
+	case "", workerProbeIPAuto: return workerProbeIPAuto, true
+	case workerProbeIPv4, "4", "tcp4": return workerProbeIPv4, true
+	case workerProbeIPv6, "6", "tcp6": return workerProbeIPv6, true
+	default: return "", false
 	}
 }
 
 func normalizeWorkerProbeTransport(raw string) (string, bool) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "", workerProbeTransportGo:
-		return workerProbeTransportGo, true
-	case workerProbeTransportUTLS, "chrome", "chrome_auto":
-		return workerProbeTransportUTLS, true
-	default:
-		return "", false
+	case "", workerProbeTransportGo: return workerProbeTransportGo, true
+	case workerProbeTransportUTLS, "chrome", "chrome_auto": return workerProbeTransportUTLS, true
+	case workerProbeTransportGoDynamic, "godynamic", "dynamic": return workerProbeTransportGoDynamic, true
+	case workerProbeTransportGoSplit1200, "gosplit1200", "split1200": return workerProbeTransportGoSplit1200, true
+	case workerProbeTransportGoSplit4K, "gosplit4k", "split4k": return workerProbeTransportGoSplit4K, true
+	case workerProbeTransportGoSplit16K, "gosplit16k", "split16k": return workerProbeTransportGoSplit16K, true
+	case workerProbeTransportGoPaced4K, "gopaced4k", "paced4k": return workerProbeTransportGoPaced4K, true
+	default: return "", false
 	}
 }
 
 func resolveWorkerProbeHost(ctx context.Context, domain, family string) (string, error) {
-	if family == workerProbeIPAuto {
-		return domain, nil
-	}
+	if family == workerProbeIPAuto { return domain, nil }
 	network := "ip4"
-	if family == workerProbeIPv6 {
-		network = "ip6"
-	}
+	if family == workerProbeIPv6 { network = "ip6" }
 	ips, err := net.DefaultResolver.LookupIP(ctx, network, domain)
-	if err != nil {
-		return "", fmt.Errorf("resolve_%s: %w", family, err)
-	}
-	if len(ips) == 0 {
-		return "", fmt.Errorf("resolve_%s: no addresses", family)
-	}
+	if err != nil { return "", fmt.Errorf("resolve_%s: %w", family, err) }
+	if len(ips) == 0 { return "", fmt.Errorf("resolve_%s: no addresses", family) }
 	return ips[0].String(), nil
+}
+
+func workerProbeTLSProfileForTransport(transport string) (workerProbeTLSProfile, bool) {
+	switch transport {
+	case workerProbeTransportGoDynamic: return workerProbeTLSProfileDynamic, true
+	case workerProbeTransportGoSplit1200: return workerProbeTLSProfileSplit1200, true
+	case workerProbeTransportGoSplit4K: return workerProbeTLSProfileSplit4K, true
+	case workerProbeTransportGoSplit16K: return workerProbeTLSProfileSplit16K, true
+	case workerProbeTransportGoPaced4K: return workerProbeTLSProfilePaced4K, true
+	default: return workerProbeTLSProfile{}, false
+	}
 }
 
 func workerProbeOpen(domain, path, family, transport string) (*flowsealRawWebSocket, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	host, err := resolveWorkerProbeHost(ctx, domain, family)
-	if err != nil {
-		return nil, err
-	}
+	if err != nil { return nil, err }
 	var ws *flowsealRawWebSocket
 	switch transport {
 	case workerProbeTransportUTLS:
 		ws, err = connectFlowsealRawWebSocketUTLSContext(ctx, host, domain, path, 10)
+	case workerProbeTransportGoDynamic, workerProbeTransportGoSplit1200, workerProbeTransportGoSplit4K, workerProbeTransportGoSplit16K, workerProbeTransportGoPaced4K:
+		profile, _ := workerProbeTLSProfileForTransport(transport)
+		ws, err = connectFlowsealRawWebSocketTLSProfileContext(ctx, host, domain, path, 10, profile)
 	default:
 		ws, err = connectFlowsealRawWebSocketContext(ctx, host, domain, path, 10)
 	}
-	if err != nil {
-		return nil, err
-	}
+	if err != nil { return nil, err }
 	_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline))
 	return ws, nil
 }
 
 func workerProbeCaseLog(c workerNetworkProbeCase, transport string) {
-	if logInfo == nil {
-		return
-	}
-	logInfo.Printf(
-		"Worker network probe transport=%s mode=%s size_bytes=%d cumulative_bytes=%d ok=%t duration_ms=%d error=%s %s",
-		transport,
-		c.Mode,
-		c.SizeBytes,
-		c.CumulativeBytes,
-		c.OK,
-		c.DurationMS,
-		mtProtoStatusField(c.Error),
-		c.TransportState,
-	)
+	if logInfo == nil { return }
+	logInfo.Printf("Worker network probe transport=%s mode=%s size_bytes=%d cumulative_bytes=%d ok=%t duration_ms=%d error=%s %s", transport, c.Mode, c.SizeBytes, c.CumulativeBytes, c.OK, c.DurationMS, mtProtoStatusField(c.Error), c.TransportState)
 }
 
 func runEchoStaircase(domain, family, transport string) []workerNetworkProbeCase {
 	path := "/diag/ws-echo?sid=probe-" + transport + "-echo"
 	ws, err := workerProbeOpen(domain, path, family, transport)
-	if err != nil {
-		c := workerNetworkProbeCase{Mode: "echo_staircase_connect", Error: err.Error()}
-		workerProbeCaseLog(c, transport)
-		return []workerNetworkProbeCase{c}
-	}
+	if err != nil { c := workerNetworkProbeCase{Mode:"echo_staircase_connect", Error:err.Error()}; workerProbeCaseLog(c, transport); return []workerNetworkProbeCase{c} }
 	defer ws.Close()
-
-	cases := make([]workerNetworkProbeCase, 0, len(workerNetworkProbeSizes))
-	cumulative := 0
+	cases := make([]workerNetworkProbeCase, 0, len(workerNetworkProbeSizes)); cumulative := 0
 	for index, size := range workerNetworkProbeSizes {
-		payload := make([]byte, size)
-		for i := range payload {
-			payload[i] = byte((i + index) & 0xff)
-		}
-		_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline))
-		started := time.Now()
-		sendErr := ws.Send(payload)
-		if sendErr != nil {
-			c := workerNetworkProbeCase{
-				Mode:            "echo_staircase",
-				SizeBytes:       size,
-				CumulativeBytes: cumulative,
-				DurationMS:      time.Since(started).Milliseconds(),
-				TransportState:  tcpTransportState(ws.conn),
-				Error:           sendErr.Error(),
-			}
-			workerProbeCaseLog(c, transport)
-			cases = append(cases, c)
-			break
-		}
-		received, recvErr := ws.Recv()
-		cumulative += size
-		c := workerNetworkProbeCase{
-			Mode:            "echo_staircase",
-			SizeBytes:       size,
-			CumulativeBytes: cumulative,
-			DurationMS:      time.Since(started).Milliseconds(),
-			TransportState:  tcpTransportState(ws.conn),
-		}
-		if recvErr != nil {
-			c.Error = recvErr.Error()
-		} else if len(received) != len(payload) {
-			c.Error = fmt.Sprintf("echo_size_mismatch:%d", len(received))
-		} else {
-			c.OK = true
-		}
-		workerProbeCaseLog(c, transport)
-		cases = append(cases, c)
-		if !c.OK {
-			break
-		}
+		payload := make([]byte, size); for i := range payload { payload[i] = byte((i+index)&0xff) }
+		_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline)); started := time.Now()
+		if sendErr := ws.Send(payload); sendErr != nil { c:=workerNetworkProbeCase{Mode:"echo_staircase",SizeBytes:size,CumulativeBytes:cumulative,DurationMS:time.Since(started).Milliseconds(),TransportState:tcpTransportState(ws.conn),Error:sendErr.Error()}; workerProbeCaseLog(c,transport); cases=append(cases,c); break }
+		received, recvErr := ws.Recv(); cumulative += size
+		c := workerNetworkProbeCase{Mode:"echo_staircase",SizeBytes:size,CumulativeBytes:cumulative,DurationMS:time.Since(started).Milliseconds(),TransportState:tcpTransportState(ws.conn)}
+		if recvErr != nil { c.Error=recvErr.Error() } else if len(received)!=len(payload) { c.Error=fmt.Sprintf("echo_size_mismatch:%d",len(received)) } else { c.OK=true }
+		workerProbeCaseLog(c,transport); cases=append(cases,c); if !c.OK { break }
 	}
 	return cases
 }
 
 func runUpload4KStream(domain, family, transport string) []workerNetworkProbeCase {
 	path := "/diag/upload?sid=probe-" + transport + "-upload-4k"
-	ws, err := workerProbeOpen(domain, path, family, transport)
-	if err != nil {
-		c := workerNetworkProbeCase{Mode: "upload_4k_connect", Error: err.Error()}
-		workerProbeCaseLog(c, transport)
-		return []workerNetworkProbeCase{c}
-	}
-	defer ws.Close()
-
-	const chunkSize = 4 * 1024
-	const target = 1024 * 1024
-	payload := make([]byte, chunkSize)
-	cases := make([]workerNetworkProbeCase, 0, target/(64*1024))
-	cumulative := 0
-	for cumulative < target {
-		for i := range payload {
-			payload[i] = byte((i + cumulative/chunkSize) & 0xff)
-		}
-		_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline))
-		started := time.Now()
-		if err := ws.Send(payload); err != nil {
-			c := workerNetworkProbeCase{
-				Mode:            "upload_4k_stream",
-				SizeBytes:       chunkSize,
-				CumulativeBytes: cumulative,
-				DurationMS:      time.Since(started).Milliseconds(),
-				TransportState:  tcpTransportState(ws.conn),
-				Error:           err.Error(),
-			}
-			workerProbeCaseLog(c, transport)
-			cases = append(cases, c)
-			break
-		}
-		ack, err := ws.Recv()
-		if err != nil {
-			c := workerNetworkProbeCase{
-				Mode:            "upload_4k_stream",
-				SizeBytes:       chunkSize,
-				CumulativeBytes: cumulative + chunkSize,
-				DurationMS:      time.Since(started).Milliseconds(),
-				TransportState:  tcpTransportState(ws.conn),
-				Error:           err.Error(),
-			}
-			workerProbeCaseLog(c, transport)
-			cases = append(cases, c)
-			break
-		}
-		cumulative += chunkSize
-		expected := fmt.Sprintf("ack:%d", cumulative)
-		if string(ack) != expected {
-			c := workerNetworkProbeCase{
-				Mode:            "upload_4k_stream",
-				SizeBytes:       chunkSize,
-				CumulativeBytes: cumulative,
-				DurationMS:      time.Since(started).Milliseconds(),
-				TransportState:  tcpTransportState(ws.conn),
-				Error:           "unexpected_ack",
-			}
-			workerProbeCaseLog(c, transport)
-			cases = append(cases, c)
-			break
-		}
-		if cumulative == chunkSize || cumulative%(64*1024) == 0 || cumulative == target {
-			c := workerNetworkProbeCase{
-				Mode:            "upload_4k_stream",
-				SizeBytes:       chunkSize,
-				CumulativeBytes: cumulative,
-				OK:              true,
-				DurationMS:      time.Since(started).Milliseconds(),
-				TransportState:  tcpTransportState(ws.conn),
-			}
-			workerProbeCaseLog(c, transport)
-			cases = append(cases, c)
-		}
+	ws, err := workerProbeOpen(domain,path,family,transport)
+	if err != nil { c:=workerNetworkProbeCase{Mode:"upload_4k_connect",Error:err.Error()}; workerProbeCaseLog(c,transport); return []workerNetworkProbeCase{c} }
+	defer ws.Close(); const chunkSize=4*1024; const target=1024*1024
+	payload:=make([]byte,chunkSize); cases:=make([]workerNetworkProbeCase,0,target/(64*1024)); cumulative:=0
+	for cumulative<target {
+		for i:=range payload { payload[i]=byte((i+cumulative/chunkSize)&0xff) }
+		_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline)); started:=time.Now()
+		if err:=ws.Send(payload); err!=nil { c:=workerNetworkProbeCase{Mode:"upload_4k_stream",SizeBytes:chunkSize,CumulativeBytes:cumulative,DurationMS:time.Since(started).Milliseconds(),TransportState:tcpTransportState(ws.conn),Error:err.Error()}; workerProbeCaseLog(c,transport); cases=append(cases,c); break }
+		ack,err:=ws.Recv(); if err!=nil { c:=workerNetworkProbeCase{Mode:"upload_4k_stream",SizeBytes:chunkSize,CumulativeBytes:cumulative+chunkSize,DurationMS:time.Since(started).Milliseconds(),TransportState:tcpTransportState(ws.conn),Error:err.Error()}; workerProbeCaseLog(c,transport); cases=append(cases,c); break }
+		cumulative += chunkSize; expected:=fmt.Sprintf("ack:%d",cumulative)
+		if string(ack)!=expected { c:=workerNetworkProbeCase{Mode:"upload_4k_stream",SizeBytes:chunkSize,CumulativeBytes:cumulative,DurationMS:time.Since(started).Milliseconds(),TransportState:tcpTransportState(ws.conn),Error:"unexpected_ack"}; workerProbeCaseLog(c,transport); cases=append(cases,c); break }
+		if cumulative==chunkSize || cumulative%(64*1024)==0 || cumulative==target { c:=workerNetworkProbeCase{Mode:"upload_4k_stream",SizeBytes:chunkSize,CumulativeBytes:cumulative,OK:true,DurationMS:time.Since(started).Milliseconds(),TransportState:tcpTransportState(ws.conn)}; workerProbeCaseLog(c,transport); cases=append(cases,c) }
 	}
 	return cases
 }
 
 func runDownloadSizes(domain, family, transport string) []workerNetworkProbeCase {
-	cases := make([]workerNetworkProbeCase, 0, len(workerNetworkProbeSizes))
-	for _, size := range workerNetworkProbeSizes {
-		path := "/diag/download?size=" + fmt.Sprint(size) + "&sid=" + url.QueryEscape(fmt.Sprintf("probe-%s-download-%d", transport, size))
-		started := time.Now()
-		ws, err := workerProbeOpen(domain, path, family, transport)
-		if err != nil {
-			c := workerNetworkProbeCase{Mode: "download_single", SizeBytes: size, DurationMS: time.Since(started).Milliseconds(), Error: err.Error()}
-			workerProbeCaseLog(c, transport)
-			cases = append(cases, c)
-			break
-		}
-		_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline))
-		payload, recvErr := ws.Recv()
-		c := workerNetworkProbeCase{
-			Mode:           "download_single",
-			SizeBytes:      size,
-			DurationMS:     time.Since(started).Milliseconds(),
-			TransportState: tcpTransportState(ws.conn),
-		}
-		if recvErr != nil {
-			c.Error = recvErr.Error()
-		} else if len(payload) != size {
-			c.Error = fmt.Sprintf("download_size_mismatch:%d", len(payload))
-		} else {
-			c.OK = true
-		}
-		workerProbeCaseLog(c, transport)
-		cases = append(cases, c)
-		ws.Close()
-		if !c.OK {
-			break
-		}
+	cases:=make([]workerNetworkProbeCase,0,len(workerNetworkProbeSizes))
+	for _,size:=range workerNetworkProbeSizes {
+		path:="/diag/download?size="+fmt.Sprint(size)+"&sid="+url.QueryEscape(fmt.Sprintf("probe-%s-download-%d",transport,size)); started:=time.Now(); ws,err:=workerProbeOpen(domain,path,family,transport)
+		if err!=nil { c:=workerNetworkProbeCase{Mode:"download_single",SizeBytes:size,DurationMS:time.Since(started).Milliseconds(),Error:err.Error()}; workerProbeCaseLog(c,transport); cases=append(cases,c); break }
+		_ = ws.SetDeadline(time.Now().Add(workerNetworkProbeDeadline)); payload,recvErr:=ws.Recv(); c:=workerNetworkProbeCase{Mode:"download_single",SizeBytes:size,DurationMS:time.Since(started).Milliseconds(),TransportState:tcpTransportState(ws.conn)}
+		if recvErr!=nil { c.Error=recvErr.Error() } else if len(payload)!=size { c.Error=fmt.Sprintf("download_size_mismatch:%d",len(payload)) } else { c.OK=true }
+		workerProbeCaseLog(c,transport); cases=append(cases,c); ws.Close(); if !c.OK { break }
 	}
 	return cases
 }
 
-func runWorkerNetworkProbe(domain, familyRaw, transportRaw string) workerNetworkProbeReport {
-	domain = NormalizeWorkerDomain(strings.TrimSpace(domain))
-	family, familyOK := normalizeWorkerProbeIPFamily(familyRaw)
-	transport, transportOK := normalizeWorkerProbeTransport(transportRaw)
-	report := workerNetworkProbeReport{
-		Revision:  "worker-network-probe-v3",
-		Domain:    domain,
-		IPFamily:  family,
-		Transport: transport,
-		Started:   time.Now().UTC().Format(time.RFC3339),
-	}
-	if domain == "" {
-		report.Cases = []workerNetworkProbeCase{{Mode: "validation", Error: "invalid_worker_domain"}}
-		return report
-	}
-	if !familyOK {
-		report.IPFamily = strings.TrimSpace(familyRaw)
-		report.Cases = []workerNetworkProbeCase{{Mode: "validation", Error: "invalid_ip_family"}}
-		return report
-	}
-	if !transportOK {
-		report.Transport = strings.TrimSpace(transportRaw)
-		report.Cases = []workerNetworkProbeCase{{Mode: "validation", Error: "invalid_transport"}}
-		return report
-	}
-	if logInfo != nil {
-		logInfo.Printf("Worker network probe start domain=%s ip_family=%s transport=%s revision=%s", domain, family, transport, report.Revision)
-	}
-	report.Cases = append(report.Cases, runEchoStaircase(domain, family, transport)...)
-	report.Cases = append(report.Cases, runUpload4KStream(domain, family, transport)...)
-	report.Cases = append(report.Cases, runDownloadSizes(domain, family, transport)...)
-	if logInfo != nil {
-		logInfo.Printf("Worker network probe complete domain=%s ip_family=%s transport=%s cases=%d", domain, family, transport, len(report.Cases))
-	}
+func runWorkerNetworkProbe(domain,familyRaw,transportRaw string) workerNetworkProbeReport {
+	domain=NormalizeWorkerDomain(strings.TrimSpace(domain)); family,familyOK:=normalizeWorkerProbeIPFamily(familyRaw); transport,transportOK:=normalizeWorkerProbeTransport(transportRaw)
+	report:=workerNetworkProbeReport{Revision:"worker-network-probe-v4",Domain:domain,IPFamily:family,Transport:transport,Started:time.Now().UTC().Format(time.RFC3339)}
+	if domain=="" { report.Cases=[]workerNetworkProbeCase{{Mode:"validation",Error:"invalid_worker_domain"}}; return report }
+	if !familyOK { report.IPFamily=strings.TrimSpace(familyRaw); report.Cases=[]workerNetworkProbeCase{{Mode:"validation",Error:"invalid_ip_family"}}; return report }
+	if !transportOK { report.Transport=strings.TrimSpace(transportRaw); report.Cases=[]workerNetworkProbeCase{{Mode:"validation",Error:"invalid_transport"}}; return report }
+	if logInfo!=nil { logInfo.Printf("Worker network probe start domain=%s ip_family=%s transport=%s revision=%s",domain,family,transport,report.Revision) }
+	report.Cases=append(report.Cases,runEchoStaircase(domain,family,transport)...); report.Cases=append(report.Cases,runUpload4KStream(domain,family,transport)...); report.Cases=append(report.Cases,runDownloadSizes(domain,family,transport)...)
+	if logInfo!=nil { logInfo.Printf("Worker network probe complete domain=%s ip_family=%s transport=%s cases=%d",domain,family,transport,len(report.Cases)) }
 	return report
 }
 
-func encodeWorkerNetworkProbeReport(report workerNetworkProbeReport) *C.char {
-	encoded, err := json.Marshal(report)
-	if err != nil {
-		return C.CString(`{"revision":"worker-network-probe-v3","error":"json_encode_failed"}`)
-	}
-	return C.CString(string(encoded))
-}
+func encodeWorkerNetworkProbeReport(report workerNetworkProbeReport) *C.char { encoded,err:=json.Marshal(report); if err!=nil { return C.CString(`{"revision":"worker-network-probe-v4","error":"json_encode_failed"}`) }; return C.CString(string(encoded)) }
 
 //export RunWorkerNetworkProbe
-func RunWorkerNetworkProbe(cDomain *C.char) *C.char {
-	initLogging(true)
-	return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain), workerProbeIPAuto, workerProbeTransportGo))
-}
-
+func RunWorkerNetworkProbe(cDomain *C.char) *C.char { initLogging(true); return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain),workerProbeIPAuto,workerProbeTransportGo)) }
 //export RunWorkerNetworkProbeWithFamily
-func RunWorkerNetworkProbeWithFamily(cDomain *C.char, cFamily *C.char) *C.char {
-	initLogging(true)
-	return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain), C.GoString(cFamily), workerProbeTransportGo))
-}
-
+func RunWorkerNetworkProbeWithFamily(cDomain *C.char,cFamily *C.char) *C.char { initLogging(true); return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain),C.GoString(cFamily),workerProbeTransportGo)) }
 //export RunWorkerNetworkProbeWithFamilyAndTransport
-func RunWorkerNetworkProbeWithFamilyAndTransport(cDomain *C.char, cFamily *C.char, cTransport *C.char) *C.char {
-	initLogging(true)
-	return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain), C.GoString(cFamily), C.GoString(cTransport)))
-}
+func RunWorkerNetworkProbeWithFamilyAndTransport(cDomain *C.char,cFamily *C.char,cTransport *C.char) *C.char { initLogging(true); return encodeWorkerNetworkProbeReport(runWorkerNetworkProbe(C.GoString(cDomain),C.GoString(cFamily),C.GoString(cTransport))) }

--- a/native/tgwsproxy/worker_network_probe_test.go
+++ b/native/tgwsproxy/worker_network_probe_test.go
@@ -42,6 +42,12 @@ func TestNormalizeWorkerProbeTransport(t *testing.T) {
 		{"utls", workerProbeTransportUTLS, true},
 		{"chrome", workerProbeTransportUTLS, true},
 		{"chrome_auto", workerProbeTransportUTLS, true},
+		{"go_dynamic", workerProbeTransportGoDynamic, true},
+		{"GoDynamic", workerProbeTransportGoDynamic, true},
+		{"split1200", workerProbeTransportGoSplit1200, true},
+		{"GoSplit4K", workerProbeTransportGoSplit4K, true},
+		{"split16k", workerProbeTransportGoSplit16K, true},
+		{"GoPaced4K", workerProbeTransportGoPaced4K, true},
 		{"okhttp", "", false},
 		{"bogus", "", false},
 	}

--- a/scripts/test-worker-network-probe.ps1
+++ b/scripts/test-worker-network-probe.ps1
@@ -4,7 +4,7 @@ param(
     [string]$WorkerDomain,
     [ValidateSet("Auto", "IPv4", "IPv6")]
     [string]$IPFamily = "Auto",
-    [ValidateSet("Go", "OkHttp", "UTLS")]
+    [ValidateSet("Go", "OkHttp", "UTLS", "GoDynamic", "GoSplit1200", "GoSplit4K", "GoSplit16K", "GoPaced4K")]
     [string]$Transport = "Go",
     [switch]$SkipBuild,
     [string]$DeviceSerial = "",

--- a/scripts/test-worker-tls-shaping-matrix.ps1
+++ b/scripts/test-worker-tls-shaping-matrix.ps1
@@ -1,0 +1,69 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$WorkerDomain,
+    [ValidateSet("Auto", "IPv4", "IPv6")]
+    [string]$IPFamily = "IPv4",
+    [string]$DeviceSerial = "",
+    [int]$TimeoutSeconds = 240,
+    [switch]$IncludeControls
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+$probeScript = Join-Path $PSScriptRoot "test-worker-network-probe.ps1"
+if (-not (Test-Path $probeScript)) {
+    throw "Probe script not found: $probeScript"
+}
+
+$transports = @(
+    "Go",
+    "GoDynamic",
+    "GoSplit1200",
+    "GoSplit4K",
+    "GoSplit16K",
+    "GoPaced4K"
+)
+if ($IncludeControls) {
+    $transports += @("UTLS", "OkHttp")
+}
+
+Write-Host "Worker TLS shaping matrix"
+Write-Host "Domain:    $WorkerDomain"
+Write-Host "IP family: $IPFamily"
+Write-Host "Profiles:  $($transports -join ', ')"
+Write-Host ""
+
+$first = $true
+foreach ($transport in $transports) {
+    Write-Host ""
+    Write-Host "============================================================"
+    Write-Host "Transport: $transport"
+    Write-Host "============================================================"
+
+    $args = @{
+        WorkerDomain = $WorkerDomain
+        IPFamily = $IPFamily
+        Transport = $transport
+        TimeoutSeconds = $TimeoutSeconds
+    }
+    if ($DeviceSerial) {
+        $args.DeviceSerial = $DeviceSerial
+    }
+    if (-not $first) {
+        $args.SkipBuild = $true
+    }
+
+    & $probeScript @args
+    if ($LASTEXITCODE -ne 0) {
+        throw "Probe failed to launch for transport $transport."
+    }
+    $first = $false
+}
+
+Write-Host ""
+Write-Host "TLS shaping matrix complete."
+Write-Host "Logs: $(Join-Path $repoRoot 'artifacts\worker-tests\worker-network-probe-*-*.txt')"


### PR DESCRIPTION
## Цель

После device A/B из #43 проверить, объясняется ли преимущество Android OkHttp над Go/uTLS различиями TLS record sizing / application-write boundaries / pacing.

PR основан на #43 и не меняет production routing. Используются тот же `*.workers.dev`, те же `/diag/*` и те же WebSocket message boundaries.

## Профили

Добавлены диагностические native transport profiles:

- `Go` — текущий fixed-record baseline;
- `GoDynamic` — стандартный adaptive/dynamic TLS record sizing Go;
- `GoSplit1200` — fixed TLS, один WS frame передаётся в `crypto/tls` кусками по 1200 B;
- `GoSplit4K` — fixed TLS, writes по 4 KiB;
- `GoSplit16K` — fixed TLS, writes по 16 KiB;
- `GoPaced4K` — fixed TLS, writes по 4 KiB с паузой 2 ms между кусками.

Разбиение происходит **ниже WebSocket framing**: один WebSocket message остаётся одним frame/message, меняются только вызовы `tls.Conn.Write`. Тот же профиль применяется к HTTP/1.1 Upgrade и control/data writes.

`flowsealRawWebSocket` сохраняет исходный `net.Conn`, поэтому TCP_INFO/queue diagnostics продолжают работать.

## Device matrix — итоговые результаты, direct IPv4 без AWG/VPN

### Baseline `Go` / `uTLS`

Ранее подтверждено:

- echo: timeout на 8-KiB step (`13312` cumulative), около `15 KiB` ACKed;
- upload: timeout около `20 KiB`, `cwnd=1`, retransmissions;
- download: 16 KiB проходит, 24 KiB timeout.

Chrome-like `uTLS` не изменил профиль отказа.

### `GoDynamic`

Adaptive TLS record sizing не помогает:

- `echo_staircase`: 8-KiB step / `13312` cumulative timeout; перед закрытием `bytes_acked=15288`;
- `upload_4k_stream`: timeout на `20480` cumulative; перед закрытием `cwnd=1`, `total_retrans=6`, `bytes_acked=18372`;
- `download_single`: 16 KiB проходит, 24 KiB timeout;
- профиль подтверждён: `tls_record_sizing=dynamic`, `tls_write_chunk_bytes=0`.

### `GoSplit1200`

Очень мелкие TLS application writes тоже не помогают:

- `echo_staircase`: timeout на 8-KiB step / `13312` cumulative; перед закрытием `bytes_acked=15445`;
- `upload_4k_stream`: timeout уже на `16384` cumulative; перед закрытием `cwnd=1`, `total_retrans=6`, `bytes_acked=14425`;
- `download_single`: 16 KiB проходит, 24 KiB timeout;
- профиль подтверждён: `tls_write_chunk_bytes=1200`.

### `GoSplit4K`

- `echo_staircase`: timeout на 8-KiB step / `13312` cumulative; перед закрытием `bytes_acked=15311`;
- `upload_4k_stream`: timeout на `16384` cumulative; перед закрытием `cwnd=1`, `total_retrans=6`, `bytes_acked=14291`;
- `download_single`: 16 KiB проходит, 24 KiB timeout;
- профиль подтверждён: `tls_write_chunk_bytes=4096`.

### `GoSplit16K`

- `echo_staircase`: timeout на 8-KiB step / `13312` cumulative; перед закрытием `bytes_acked=15246`;
- `upload_4k_stream`: timeout на `20480` cumulative; перед закрытием `cwnd=1`, `total_retrans=6`, `bytes_acked=18352`;
- `download_single`: 16 KiB проходит, 24 KiB timeout.

### `GoPaced4K`

- `echo_staircase`: timeout на 8-KiB step / `13312` cumulative; перед закрытием `bytes_acked=15311`;
- `upload_4k_stream`: timeout на `16384` cumulative;
- `download_single`: 16 KiB проходит, 24 KiB timeout;
- `tls_write_chunk_bytes=4096`, `tls_write_pace_us=2000`.

## Сводка

Ни один native Go-профиль не приблизился к Android OkHttp:

| Transport | Echo | Upload | Download |
|---|---|---|---|
| Go fixed | FAIL @ 13 KiB cumulative | FAIL ~20 KiB | 16 KiB OK / 24 KiB FAIL |
| uTLS Chrome | то же | то же | то же |
| GoDynamic | то же | ~20 KiB | то же |
| GoSplit1200 | то же | ~16 KiB | то же |
| GoSplit4K | то же | ~16 KiB | то же |
| GoSplit16K | то же | ~20 KiB | то же |
| GoPaced4K | то же | ~16 KiB | то же |
| Android OkHttp | до 128-KiB message / 295936 cumulative | ~40 KiB | **до 1 MiB OK** |

## Вывод

Матрица закрывает гипотезу, что преимущество OkHttp объясняется только ClientHello, adaptive/fixed TLS record sizing, application-write chunk size или простым pacing.

Особенно важен downstream: все Go/uTLS/shaping варианты стабильно ломаются между 16 и 24 KiB даже при почти нулевом application upload, тогда как Android OkHttp получает 1 MiB. Следовательно, различие лежит глубже — в Android platform TLS/socket path, TCP/socket behavior либо в особенностях OkHttp поверх него.

Следующий наиболее точный A/B: **Android platform `SSLSocket` + ручной HTTP/1.1 WebSocket Upgrade и raw WebSocket framing без OkHttp**. Он сохранит платформенный TLS/socket stack, но уберёт OkHttp WebSocket implementation. Если такой probe повторит OkHttp, ключевой фактор — Android TLS/socket path; если повторит Go, искать нужно поведение OkHttp WebSocket/write scheduling.

QUIC/HTTP3 имеет смысл проверять только после этого более дешёвого изолирующего теста.

Worker заново деплоить не нужно.

CI #106: passed.

Draft: диагностический PR, не сливать как production fix.

Relates #29
Depends on #43