### PR TITLE
[experiment][#29] Validate short-connection Worker relay

### DIFF
--- a/app/src/main/java/com/amurcanov/tgwsproxy/FreshConnectionWorkerProbe.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/FreshConnectionWorkerProbe.kt
@@ -1,0 +1,152 @@
+package com.amurcanov.tgwsproxy
+
+import android.util.Log
+import okhttp3.ConnectionPool
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.IOException
+import java.security.SecureRandom
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tests the central #29 workaround hypothesis without changing production
+ * routing: can high-entropy traffic cross the same Worker when every 8 KiB
+ * chunk gets a brand-new HTTPS/TCP connection?
+ */
+object FreshConnectionWorkerProbe {
+    private const val TAG = "TgWsProxy"
+    private const val REVISION = "worker-fresh-connection-probe-v1"
+    private const val CHUNK_BYTES = 8 * 1024
+    private const val TARGET_BYTES = 1024 * 1024
+    private const val TIMEOUT_SECONDS = 12L
+    private val random = SecureRandom()
+    private val octetStream = "application/octet-stream".toMediaType()
+
+    private data class ProbeCase(
+        val mode: String,
+        val cumulativeBytes: Int,
+        val ok: Boolean,
+        val durationMs: Long,
+        val error: String = "",
+    ) {
+        fun json(): JSONObject = JSONObject().apply {
+            put("mode", mode)
+            put("chunk_bytes", CHUNK_BYTES)
+            put("cumulative_bytes", cumulativeBytes)
+            put("ok", ok)
+            put("duration_ms", durationMs)
+            if (error.isNotBlank()) put("error", error)
+        }
+    }
+
+    private fun client(): OkHttpClient = OkHttpClient.Builder()
+        .protocols(listOf(Protocol.HTTP_1_1))
+        .connectionPool(ConnectionPool(0, 1, TimeUnit.NANOSECONDS))
+        .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .writeTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(false)
+        .build()
+
+    private fun upload(domain: String): ProbeCase {
+        val started = System.nanoTime()
+        var cumulative = 0
+        return try {
+            while (cumulative < TARGET_BYTES) {
+                val bytes = ByteArray(CHUNK_BYTES).also(random::nextBytes)
+                val client = client()
+                try {
+                    val request = Request.Builder()
+                        .url("https://$domain/diag/fresh-upload")
+                        .header("Cache-Control", "no-store")
+                        .header("Connection", "close")
+                        .post(bytes.toRequestBody(octetStream))
+                        .build()
+                    client.newCall(request).execute().use { response ->
+                        if (!response.isSuccessful) throw IOException("HTTP ${response.code}")
+                        val body = response.body?.string().orEmpty()
+                        if (!body.contains("\"bytes\":8192")) throw IOException("unexpected response: $body")
+                    }
+                } finally {
+                    client.connectionPool.evictAll()
+                    client.dispatcher.executorService.shutdown()
+                }
+                cumulative += CHUNK_BYTES
+                if (cumulative == CHUNK_BYTES || cumulative % (64 * 1024) == 0 || cumulative == TARGET_BYTES) {
+                    Log.i(TAG, "Worker fresh-connection probe mode=upload chunk_bytes=$CHUNK_BYTES cumulative_bytes=$cumulative ok=true")
+                }
+            }
+            ProbeCase("fresh_upload", cumulative, true, elapsedMs(started))
+        } catch (t: Throwable) {
+            ProbeCase("fresh_upload", cumulative + CHUNK_BYTES, false, elapsedMs(started), "${t.javaClass.simpleName}:${t.message}")
+        }
+    }
+
+    private fun download(domain: String): ProbeCase {
+        val started = System.nanoTime()
+        var cumulative = 0
+        return try {
+            while (cumulative < TARGET_BYTES) {
+                val client = client()
+                try {
+                    val request = Request.Builder()
+                        .url("https://$domain/diag/fresh-download?size=$CHUNK_BYTES")
+                        .header("Cache-Control", "no-store")
+                        .header("Connection", "close")
+                        .get()
+                        .build()
+                    client.newCall(request).execute().use { response ->
+                        if (!response.isSuccessful) throw IOException("HTTP ${response.code}")
+                        val bytes = response.body?.bytes() ?: throw IOException("empty body")
+                        if (bytes.size != CHUNK_BYTES) throw IOException("unexpected size=${bytes.size}")
+                    }
+                } finally {
+                    client.connectionPool.evictAll()
+                    client.dispatcher.executorService.shutdown()
+                }
+                cumulative += CHUNK_BYTES
+                if (cumulative == CHUNK_BYTES || cumulative % (64 * 1024) == 0 || cumulative == TARGET_BYTES) {
+                    Log.i(TAG, "Worker fresh-connection probe mode=download chunk_bytes=$CHUNK_BYTES cumulative_bytes=$cumulative ok=true")
+                }
+            }
+            ProbeCase("fresh_download", cumulative, true, elapsedMs(started))
+        } catch (t: Throwable) {
+            ProbeCase("fresh_download", cumulative + CHUNK_BYTES, false, elapsedMs(started), "${t.javaClass.simpleName}:${t.message}")
+        }
+    }
+
+    private fun elapsedMs(started: Long): Long = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started)
+
+    fun run(domainRaw: String): String {
+        val domain = domainRaw.trim().removePrefix("https://").removePrefix("http://").trimEnd('/')
+        val report = JSONObject()
+        val cases = JSONArray()
+        report.put("revision", REVISION)
+        report.put("domain", domain)
+        report.put("transport", "freshhttp")
+        report.put("chunk_bytes", CHUNK_BYTES)
+        report.put("target_bytes", TARGET_BYTES)
+        report.put("cases", cases)
+
+        if (domain.isBlank() || domain.contains('/') || domain.contains(' ')) {
+            cases.put(ProbeCase("validation", 0, false, 0, "invalid_worker_domain").json())
+            return report.toString()
+        }
+
+        Log.i(TAG, "Worker fresh-connection probe start domain=$domain revision=$REVISION chunk_bytes=$CHUNK_BYTES target_bytes=$TARGET_BYTES")
+        val upload = upload(domain)
+        Log.i(TAG, "Worker fresh-connection probe mode=${upload.mode} cumulative_bytes=${upload.cumulativeBytes} ok=${upload.ok} duration_ms=${upload.durationMs} error=${upload.error.ifBlank { "none" }}")
+        cases.put(upload.json())
+
+        val download = download(domain)
+        Log.i(TAG, "Worker fresh-connection probe mode=${download.mode} cumulative_bytes=${download.cumulativeBytes} ok=${download.ok} duration_ms=${download.durationMs} error=${download.error.ifBlank { "none" }}")
+        cases.put(download.json())
+        Log.i(TAG, "Worker fresh-connection probe complete domain=$domain")
+        return report.toString()
+    }
+}

--- a/app/src/main/java/com/amurcanov/tgwsproxy/FreshConnectionWorkerProbe.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/FreshConnectionWorkerProbe.kt
@@ -1,5 +1,6 @@
 package com.amurcanov.tgwsproxy
 
+import android.os.SystemClock
 import android.util.Log
 import okhttp3.ConnectionPool
 import okhttp3.MediaType.Companion.toMediaType
@@ -12,36 +13,56 @@ import org.json.JSONObject
 import java.io.IOException
 import java.security.SecureRandom
 import java.util.concurrent.TimeUnit
+import kotlin.math.min
 
 /**
- * Tests the central #29 workaround hypothesis without changing production
- * routing: can high-entropy traffic cross the same Worker when every 8 KiB
- * chunk gets a brand-new HTTPS/TCP connection?
+ * Tests the #29 short-connection workaround without changing production
+ * routing. Every chunk is sent over a brand-new HTTP/1.1/TLS connection.
+ * Profiles isolate retry/backoff, pacing, and a larger 12 KiB chunk size.
  */
 object FreshConnectionWorkerProbe {
     private const val TAG = "TgWsProxy"
-    private const val REVISION = "worker-fresh-connection-probe-v1"
-    private const val CHUNK_BYTES = 8 * 1024
+    private const val REVISION = "worker-fresh-connection-probe-v2"
     private const val TARGET_BYTES = 1024 * 1024
     private const val TIMEOUT_SECONDS = 12L
     private val random = SecureRandom()
     private val octetStream = "application/octet-stream".toMediaType()
 
+    private data class Profile(
+        val transport: String,
+        val chunkBytes: Int,
+        val maxRetries: Int,
+        val baseBackoffMs: Long,
+        val paceMs: Long,
+    )
+
     private data class ProbeCase(
         val mode: String,
-        val cumulativeBytes: Int,
+        val confirmedBytes: Int,
+        val attemptedBytes: Int,
         val ok: Boolean,
         val durationMs: Long,
+        val retriesUsed: Int,
         val error: String = "",
     ) {
-        fun json(): JSONObject = JSONObject().apply {
+        fun json(profile: Profile): JSONObject = JSONObject().apply {
             put("mode", mode)
-            put("chunk_bytes", CHUNK_BYTES)
-            put("cumulative_bytes", cumulativeBytes)
+            put("chunk_bytes", profile.chunkBytes)
+            put("confirmed_bytes", confirmedBytes)
+            put("cumulative_bytes", confirmedBytes)
+            put("attempted_cumulative_bytes", attemptedBytes)
             put("ok", ok)
             put("duration_ms", durationMs)
+            put("retries_used", retriesUsed)
             if (error.isNotBlank()) put("error", error)
         }
+    }
+
+    private fun profileFor(transportRaw: String): Profile = when (transportRaw.trim().lowercase()) {
+        "freshhttpretry8k" -> Profile("freshhttpretry8k", 8 * 1024, 3, 300, 0)
+        "freshhttppaced8k" -> Profile("freshhttppaced8k", 8 * 1024, 3, 300, 75)
+        "freshhttpretry12k" -> Profile("freshhttpretry12k", 12 * 1024, 3, 300, 0)
+        else -> Profile("freshhttp", 8 * 1024, 0, 0, 0)
     }
 
     private fun client(): OkHttpClient = OkHttpClient.Builder()
@@ -53,100 +74,204 @@ object FreshConnectionWorkerProbe {
         .retryOnConnectionFailure(false)
         .build()
 
-    private fun upload(domain: String): ProbeCase {
-        val started = System.nanoTime()
-        var cumulative = 0
+    private fun backoff(profile: Profile, retryIndex: Int) {
+        if (profile.baseBackoffMs <= 0) return
+        val multiplier = 1L shl min(retryIndex, 4)
+        SystemClock.sleep(profile.baseBackoffMs * multiplier)
+    }
+
+    private fun <T> withFreshClient(block: (OkHttpClient) -> T): T {
+        val client = client()
         return try {
-            while (cumulative < TARGET_BYTES) {
-                val bytes = ByteArray(CHUNK_BYTES).also(random::nextBytes)
-                val client = client()
-                try {
-                    val request = Request.Builder()
-                        .url("https://$domain/diag/fresh-upload")
-                        .header("Cache-Control", "no-store")
-                        .header("Connection", "close")
-                        .post(bytes.toRequestBody(octetStream))
-                        .build()
-                    client.newCall(request).execute().use { response ->
-                        if (!response.isSuccessful) throw IOException("HTTP ${response.code}")
-                        val body = response.body?.string().orEmpty()
-                        if (!body.contains("\"bytes\":8192")) throw IOException("unexpected response: $body")
-                    }
-                } finally {
-                    client.connectionPool.evictAll()
-                    client.dispatcher.executorService.shutdown()
-                }
-                cumulative += CHUNK_BYTES
-                if (cumulative == CHUNK_BYTES || cumulative % (64 * 1024) == 0 || cumulative == TARGET_BYTES) {
-                    Log.i(TAG, "Worker fresh-connection probe mode=upload chunk_bytes=$CHUNK_BYTES cumulative_bytes=$cumulative ok=true")
-                }
-            }
-            ProbeCase("fresh_upload", cumulative, true, elapsedMs(started))
-        } catch (t: Throwable) {
-            ProbeCase("fresh_upload", cumulative + CHUNK_BYTES, false, elapsedMs(started), "${t.javaClass.simpleName}:${t.message}")
+            block(client)
+        } finally {
+            client.connectionPool.evictAll()
+            client.dispatcher.executorService.shutdown()
         }
     }
 
-    private fun download(domain: String): ProbeCase {
-        val started = System.nanoTime()
-        var cumulative = 0
-        return try {
-            while (cumulative < TARGET_BYTES) {
-                val client = client()
-                try {
-                    val request = Request.Builder()
-                        .url("https://$domain/diag/fresh-download?size=$CHUNK_BYTES")
-                        .header("Cache-Control", "no-store")
-                        .header("Connection", "close")
-                        .get()
-                        .build()
-                    client.newCall(request).execute().use { response ->
-                        if (!response.isSuccessful) throw IOException("HTTP ${response.code}")
-                        val bytes = response.body?.bytes() ?: throw IOException("empty body")
-                        if (bytes.size != CHUNK_BYTES) throw IOException("unexpected size=${bytes.size}")
-                    }
-                } finally {
-                    client.connectionPool.evictAll()
-                    client.dispatcher.executorService.shutdown()
-                }
-                cumulative += CHUNK_BYTES
-                if (cumulative == CHUNK_BYTES || cumulative % (64 * 1024) == 0 || cumulative == TARGET_BYTES) {
-                    Log.i(TAG, "Worker fresh-connection probe mode=download chunk_bytes=$CHUNK_BYTES cumulative_bytes=$cumulative ok=true")
+    private fun uploadChunk(domain: String, bytes: ByteArray) {
+        withFreshClient { client ->
+            val request = Request.Builder()
+                .url("https://$domain/diag/fresh-upload")
+                .header("Cache-Control", "no-store")
+                .header("Connection", "close")
+                .post(bytes.toRequestBody(octetStream))
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw IOException("HTTP ${response.code}")
+                val body = response.body?.string().orEmpty()
+                if (!body.contains("\"bytes\":${bytes.size}")) {
+                    throw IOException("unexpected response: $body")
                 }
             }
-            ProbeCase("fresh_download", cumulative, true, elapsedMs(started))
-        } catch (t: Throwable) {
-            ProbeCase("fresh_download", cumulative + CHUNK_BYTES, false, elapsedMs(started), "${t.javaClass.simpleName}:${t.message}")
         }
+    }
+
+    private fun downloadChunk(domain: String, size: Int) {
+        withFreshClient { client ->
+            val request = Request.Builder()
+                .url("https://$domain/diag/fresh-download?size=$size")
+                .header("Cache-Control", "no-store")
+                .header("Connection", "close")
+                .get()
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw IOException("HTTP ${response.code}")
+                val bytes = response.body?.bytes() ?: throw IOException("empty body")
+                if (bytes.size != size) throw IOException("unexpected size=${bytes.size}")
+            }
+        }
+    }
+
+    private fun upload(domain: String, profile: Profile): ProbeCase {
+        val started = System.nanoTime()
+        var confirmed = 0
+        var retriesUsed = 0
+        while (confirmed < TARGET_BYTES) {
+            val size = min(profile.chunkBytes, TARGET_BYTES - confirmed)
+            val bytes = ByteArray(size).also(random::nextBytes)
+            var lastError: Throwable? = null
+            var delivered = false
+            for (attempt in 0..profile.maxRetries) {
+                try {
+                    uploadChunk(domain, bytes)
+                    delivered = true
+                    break
+                } catch (t: Throwable) {
+                    lastError = t
+                    if (attempt >= profile.maxRetries) break
+                    retriesUsed++
+                    Log.i(
+                        TAG,
+                        "Worker fresh-connection probe mode=upload retry=${attempt + 1}/${profile.maxRetries} " +
+                            "chunk_bytes=$size confirmed_bytes=$confirmed error=${t.javaClass.simpleName}:${t.message}",
+                    )
+                    backoff(profile, attempt)
+                }
+            }
+            if (!delivered) {
+                val attempted = min(TARGET_BYTES, confirmed + size)
+                return ProbeCase(
+                    "fresh_upload",
+                    confirmed,
+                    attempted,
+                    false,
+                    elapsedMs(started),
+                    retriesUsed,
+                    "${lastError?.javaClass?.simpleName}:${lastError?.message}",
+                )
+            }
+            confirmed += size
+            if (confirmed == size || confirmed % (64 * 1024) < size || confirmed == TARGET_BYTES) {
+                Log.i(
+                    TAG,
+                    "Worker fresh-connection probe mode=upload chunk_bytes=$size cumulative_bytes=$confirmed " +
+                        "retries_used=$retriesUsed ok=true",
+                )
+            }
+            if (profile.paceMs > 0 && confirmed < TARGET_BYTES) SystemClock.sleep(profile.paceMs)
+        }
+        return ProbeCase("fresh_upload", confirmed, confirmed, true, elapsedMs(started), retriesUsed)
+    }
+
+    private fun download(domain: String, profile: Profile): ProbeCase {
+        val started = System.nanoTime()
+        var confirmed = 0
+        var retriesUsed = 0
+        while (confirmed < TARGET_BYTES) {
+            val size = min(profile.chunkBytes, TARGET_BYTES - confirmed)
+            var lastError: Throwable? = null
+            var delivered = false
+            for (attempt in 0..profile.maxRetries) {
+                try {
+                    downloadChunk(domain, size)
+                    delivered = true
+                    break
+                } catch (t: Throwable) {
+                    lastError = t
+                    if (attempt >= profile.maxRetries) break
+                    retriesUsed++
+                    Log.i(
+                        TAG,
+                        "Worker fresh-connection probe mode=download retry=${attempt + 1}/${profile.maxRetries} " +
+                            "chunk_bytes=$size confirmed_bytes=$confirmed error=${t.javaClass.simpleName}:${t.message}",
+                    )
+                    backoff(profile, attempt)
+                }
+            }
+            if (!delivered) {
+                val attempted = min(TARGET_BYTES, confirmed + size)
+                return ProbeCase(
+                    "fresh_download",
+                    confirmed,
+                    attempted,
+                    false,
+                    elapsedMs(started),
+                    retriesUsed,
+                    "${lastError?.javaClass?.simpleName}:${lastError?.message}",
+                )
+            }
+            confirmed += size
+            if (confirmed == size || confirmed % (64 * 1024) < size || confirmed == TARGET_BYTES) {
+                Log.i(
+                    TAG,
+                    "Worker fresh-connection probe mode=download chunk_bytes=$size cumulative_bytes=$confirmed " +
+                        "retries_used=$retriesUsed ok=true",
+                )
+            }
+            if (profile.paceMs > 0 && confirmed < TARGET_BYTES) SystemClock.sleep(profile.paceMs)
+        }
+        return ProbeCase("fresh_download", confirmed, confirmed, true, elapsedMs(started), retriesUsed)
     }
 
     private fun elapsedMs(started: Long): Long = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started)
 
-    fun run(domainRaw: String): String {
+    fun run(domainRaw: String, transportRaw: String = "freshhttp"): String {
         val domain = domainRaw.trim().removePrefix("https://").removePrefix("http://").trimEnd('/')
+        val profile = profileFor(transportRaw)
         val report = JSONObject()
         val cases = JSONArray()
         report.put("revision", REVISION)
         report.put("domain", domain)
-        report.put("transport", "freshhttp")
-        report.put("chunk_bytes", CHUNK_BYTES)
+        report.put("transport", profile.transport)
+        report.put("chunk_bytes", profile.chunkBytes)
+        report.put("max_retries", profile.maxRetries)
+        report.put("base_backoff_ms", profile.baseBackoffMs)
+        report.put("pace_ms", profile.paceMs)
         report.put("target_bytes", TARGET_BYTES)
         report.put("cases", cases)
 
         if (domain.isBlank() || domain.contains('/') || domain.contains(' ')) {
-            cases.put(ProbeCase("validation", 0, false, 0, "invalid_worker_domain").json())
+            cases.put(ProbeCase("validation", 0, 0, false, 0, 0, "invalid_worker_domain").json(profile))
             return report.toString()
         }
 
-        Log.i(TAG, "Worker fresh-connection probe start domain=$domain revision=$REVISION chunk_bytes=$CHUNK_BYTES target_bytes=$TARGET_BYTES")
-        val upload = upload(domain)
-        Log.i(TAG, "Worker fresh-connection probe mode=${upload.mode} cumulative_bytes=${upload.cumulativeBytes} ok=${upload.ok} duration_ms=${upload.durationMs} error=${upload.error.ifBlank { "none" }}")
-        cases.put(upload.json())
+        Log.i(
+            TAG,
+            "Worker fresh-connection probe start domain=$domain revision=$REVISION transport=${profile.transport} " +
+                "chunk_bytes=${profile.chunkBytes} max_retries=${profile.maxRetries} " +
+                "base_backoff_ms=${profile.baseBackoffMs} pace_ms=${profile.paceMs} target_bytes=$TARGET_BYTES",
+        )
 
-        val download = download(domain)
-        Log.i(TAG, "Worker fresh-connection probe mode=${download.mode} cumulative_bytes=${download.cumulativeBytes} ok=${download.ok} duration_ms=${download.durationMs} error=${download.error.ifBlank { "none" }}")
-        cases.put(download.json())
-        Log.i(TAG, "Worker fresh-connection probe complete domain=$domain")
+        val upload = upload(domain, profile)
+        Log.i(
+            TAG,
+            "Worker fresh-connection probe mode=${upload.mode} confirmed_bytes=${upload.confirmedBytes} " +
+                "attempted_cumulative_bytes=${upload.attemptedBytes} ok=${upload.ok} duration_ms=${upload.durationMs} " +
+                "retries_used=${upload.retriesUsed} error=${upload.error.ifBlank { "none" }}",
+        )
+        cases.put(upload.json(profile))
+
+        val download = download(domain, profile)
+        Log.i(
+            TAG,
+            "Worker fresh-connection probe mode=${download.mode} confirmed_bytes=${download.confirmedBytes} " +
+                "attempted_cumulative_bytes=${download.attemptedBytes} ok=${download.ok} duration_ms=${download.durationMs} " +
+                "retries_used=${download.retriesUsed} error=${download.error.ifBlank { "none" }}",
+        )
+        cases.put(download.json(profile))
+        Log.i(TAG, "Worker fresh-connection probe complete domain=$domain transport=${profile.transport}")
         return report.toString()
     }
 }

--- a/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
@@ -25,6 +25,7 @@ class WorkerNetworkProbeActivity : Activity() {
                     "okhttprandom",
                     "okhttpnocompressionrandom" -> OkHttpWorkerNetworkProbe.run(domain, family, transport)
                     "sslsocket" -> AndroidSslSocketWorkerNetworkProbe.run(domain, family)
+                    "freshhttp" -> FreshConnectionWorkerProbe.run(domain)
                     else -> NativeProxy.runWorkerNetworkProbe(domain, family, transport).orEmpty()
                 }
                 if (report.isEmpty()) {

--- a/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
+++ b/app/src/main/java/com/amurcanov/tgwsproxy/WorkerNetworkProbeActivity.kt
@@ -25,7 +25,10 @@ class WorkerNetworkProbeActivity : Activity() {
                     "okhttprandom",
                     "okhttpnocompressionrandom" -> OkHttpWorkerNetworkProbe.run(domain, family, transport)
                     "sslsocket" -> AndroidSslSocketWorkerNetworkProbe.run(domain, family)
-                    "freshhttp" -> FreshConnectionWorkerProbe.run(domain)
+                    "freshhttp",
+                    "freshhttpretry8k",
+                    "freshhttppaced8k",
+                    "freshhttpretry12k" -> FreshConnectionWorkerProbe.run(domain, transport)
                     else -> NativeProxy.runWorkerNetworkProbe(domain, family, transport).orEmpty()
                 }
                 if (report.isEmpty()) {

--- a/scripts/cloudflare-worker/chunk-relay-worker.js
+++ b/scripts/cloudflare-worker/chunk-relay-worker.js
@@ -1,0 +1,121 @@
+import baseWorker from "./worker.js";
+import { connect } from "cloudflare:sockets";
+import { DurableObject } from "cloudflare:workers";
+
+const REVISION = "chunk-relay-dc2-v1";
+const TELEGRAM_DC2 = "149.154.167.51";
+const MAX_CHUNK_BYTES = 8 * 1024;
+const MAX_QUEUE_BYTES = 2 * 1024 * 1024;
+
+function headers(extra = {}) {
+  return { "Cache-Control": "no-store", "X-Tgws-Chunk-Relay-Revision": REVISION, ...extra };
+}
+
+export class ChunkRelaySession extends DurableObject {
+  constructor(ctx, env) {
+    super(ctx, env);
+    this.socket = null;
+    this.writer = null;
+    this.reader = null;
+    this.upSeq = 0;
+    this.downSeq = 0;
+    this.pending = null;
+    this.queue = [];
+    this.queueBytes = 0;
+    this.waiters = new Set();
+    this.closed = false;
+  }
+
+  wake() {
+    for (const resolve of this.waiters) resolve();
+    this.waiters.clear();
+  }
+
+  async ensureSocket() {
+    if (this.socket) return;
+    const socket = connect({ hostname: TELEGRAM_DC2, port: 443 }, { secureTransport: "off", allowHalfOpen: true });
+    await socket.opened;
+    this.socket = socket;
+    this.writer = socket.writable.getWriter();
+    this.reader = socket.readable.getReader();
+    this.pump().catch(() => { this.closed = true; this.wake(); });
+  }
+
+  async pump() {
+    while (!this.closed) {
+      const { value, done } = await this.reader.read();
+      if (done) { this.closed = true; this.wake(); return; }
+      const bytes = value instanceof Uint8Array ? value : new Uint8Array(value || 0);
+      for (let offset = 0; offset < bytes.byteLength; offset += MAX_CHUNK_BYTES) {
+        const chunk = bytes.slice(offset, Math.min(offset + MAX_CHUNK_BYTES, bytes.byteLength));
+        if (this.queueBytes + chunk.byteLength > MAX_QUEUE_BYTES) throw new Error("queue_limit");
+        this.queue.push(chunk);
+        this.queueBytes += chunk.byteLength;
+      }
+      this.wake();
+    }
+  }
+
+  async wait(ms) {
+    if (this.pending || this.queue.length || this.closed) return;
+    await new Promise((resolve) => {
+      const done = () => { clearTimeout(timer); this.waiters.delete(done); resolve(); };
+      const timer = setTimeout(done, Math.min(Math.max(ms, 0), 1000));
+      this.waiters.add(done);
+    });
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+    const action = url.pathname.split("/").filter(Boolean).at(-1) || "";
+    if (action === "open") {
+      await this.ensureSocket();
+      return new Response(null, { status: 204, headers: headers() });
+    }
+    if (action === "up") {
+      await this.ensureSocket();
+      const seq = Number.parseInt(url.searchParams.get("seq") || "0", 10);
+      if (!Number.isSafeInteger(seq) || seq <= 0) return new Response("bad seq", { status: 400 });
+      if (seq <= this.upSeq) return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
+      if (seq !== this.upSeq + 1) return new Response("sequence gap", { status: 409 });
+      const body = new Uint8Array(await request.arrayBuffer());
+      if (!body.byteLength || body.byteLength > MAX_CHUNK_BYTES) return new Response("bad size", { status: 413 });
+      await this.writer.write(body);
+      this.upSeq = seq;
+      return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
+    }
+    if (action === "down") {
+      await this.ensureSocket();
+      const ack = Number.parseInt(url.searchParams.get("ack") || "0", 10);
+      if (this.pending && ack === this.pending.seq) this.pending = null;
+      await this.wait(Number.parseInt(url.searchParams.get("wait") || "0", 10));
+      if (!this.pending && this.queue.length) {
+        const data = this.queue.shift();
+        this.queueBytes -= data.byteLength;
+        this.pending = { seq: ++this.downSeq, data };
+      }
+      if (this.pending) return new Response(this.pending.data, { status: 200, headers: headers({ "Content-Type": "application/octet-stream", "X-Tgws-Chunk-Seq": String(this.pending.seq) }) });
+      if (this.closed) return new Response("closed", { status: 410, headers: headers() });
+      return new Response(null, { status: 204, headers: headers() });
+    }
+    if (action === "close") {
+      this.closed = true;
+      this.wake();
+      try { await this.socket?.close(); } catch {}
+      return new Response(null, { status: 204, headers: headers() });
+    }
+    return new Response("not found", { status: 404, headers: headers() });
+  }
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    if (url.pathname.startsWith("/chunk-relay/")) {
+      const sid = (url.searchParams.get("sid") || "").trim();
+      if (!/^[A-Za-z0-9_-]{8,128}$/.test(sid)) return new Response("invalid sid", { status: 400 });
+      return env.CHUNK_RELAY.getByName(sid).fetch(request);
+    }
+    return baseWorker.fetch(request, env, ctx);
+  },
+};

--- a/scripts/cloudflare-worker/chunk-relay-worker.js
+++ b/scripts/cloudflare-worker/chunk-relay-worker.js
@@ -2,9 +2,10 @@ import baseWorker from "./worker.js";
 import { connect } from "cloudflare:sockets";
 import { DurableObject } from "cloudflare:workers";
 
-const REVISION = "chunk-relay-dc2-v1";
+const REVISION = "chunk-relay-dc2-v2";
 const TELEGRAM_DC2 = "149.154.167.51";
-const MAX_CHUNK_BYTES = 8 * 1024;
+const RELAY_MAX_CHUNK_BYTES = 8 * 1024;
+const DIAG_MAX_CHUNK_BYTES = 12 * 1024;
 const MAX_QUEUE_BYTES = 2 * 1024 * 1024;
 
 function headers(extra = {}) {
@@ -52,8 +53,8 @@ export class ChunkRelaySession extends DurableObject {
       const { value, done } = await this.reader.read();
       if (done) { this.closed = true; this.wake(); return; }
       const bytes = value instanceof Uint8Array ? value : new Uint8Array(value || 0);
-      for (let offset = 0; offset < bytes.byteLength; offset += MAX_CHUNK_BYTES) {
-        const chunk = bytes.slice(offset, Math.min(offset + MAX_CHUNK_BYTES, bytes.byteLength));
+      for (let offset = 0; offset < bytes.byteLength; offset += RELAY_MAX_CHUNK_BYTES) {
+        const chunk = bytes.slice(offset, Math.min(offset + RELAY_MAX_CHUNK_BYTES, bytes.byteLength));
         if (this.queueBytes + chunk.byteLength > MAX_QUEUE_BYTES) throw new Error("queue_limit");
         this.queue.push(chunk);
         this.queueBytes += chunk.byteLength;
@@ -85,7 +86,7 @@ export class ChunkRelaySession extends DurableObject {
       if (seq <= this.upSeq) return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
       if (seq !== this.upSeq + 1) return new Response("sequence gap", { status: 409 });
       const body = new Uint8Array(await request.arrayBuffer());
-      if (!body.byteLength || body.byteLength > MAX_CHUNK_BYTES) return new Response("bad size", { status: 413 });
+      if (!body.byteLength || body.byteLength > RELAY_MAX_CHUNK_BYTES) return new Response("bad size", { status: 413 });
       await this.writer.write(body);
       this.upSeq = seq;
       return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
@@ -121,13 +122,13 @@ export default {
     if (url.pathname === "/diag/fresh-upload") {
       if (request.method !== "POST") return new Response("method", { status: 405, headers: headers() });
       const body = new Uint8Array(await request.arrayBuffer());
-      if (!body.byteLength || body.byteLength > MAX_CHUNK_BYTES) return new Response("bad size", { status: 413, headers: headers() });
+      if (!body.byteLength || body.byteLength > DIAG_MAX_CHUNK_BYTES) return new Response("bad size", { status: 413, headers: headers() });
       return Response.json({ ok: true, bytes: body.byteLength, revision: REVISION }, { headers: headers() });
     }
 
     if (url.pathname === "/diag/fresh-download") {
       const size = Number.parseInt(url.searchParams.get("size") || "0", 10);
-      if (!Number.isSafeInteger(size) || size <= 0 || size > MAX_CHUNK_BYTES) return new Response("bad size", { status: 400, headers: headers() });
+      if (!Number.isSafeInteger(size) || size <= 0 || size > DIAG_MAX_CHUNK_BYTES) return new Response("bad size", { status: 400, headers: headers() });
       return new Response(randomBytes(size), { status: 200, headers: headers({ "Content-Type": "application/octet-stream" }) });
     }
 

--- a/scripts/cloudflare-worker/chunk-relay-worker.js
+++ b/scripts/cloudflare-worker/chunk-relay-worker.js
@@ -11,6 +11,12 @@ function headers(extra = {}) {
   return { "Cache-Control": "no-store", "X-Tgws-Chunk-Relay-Revision": REVISION, ...extra };
 }
 
+function randomBytes(size) {
+  const bytes = new Uint8Array(size);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
 export class ChunkRelaySession extends DurableObject {
   constructor(ctx, env) {
     super(ctx, env);
@@ -111,6 +117,20 @@ export class ChunkRelaySession extends DurableObject {
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
+
+    if (url.pathname === "/diag/fresh-upload") {
+      if (request.method !== "POST") return new Response("method", { status: 405, headers: headers() });
+      const body = new Uint8Array(await request.arrayBuffer());
+      if (!body.byteLength || body.byteLength > MAX_CHUNK_BYTES) return new Response("bad size", { status: 413, headers: headers() });
+      return Response.json({ ok: true, bytes: body.byteLength, revision: REVISION }, { headers: headers() });
+    }
+
+    if (url.pathname === "/diag/fresh-download") {
+      const size = Number.parseInt(url.searchParams.get("size") || "0", 10);
+      if (!Number.isSafeInteger(size) || size <= 0 || size > MAX_CHUNK_BYTES) return new Response("bad size", { status: 400, headers: headers() });
+      return new Response(randomBytes(size), { status: 200, headers: headers({ "Content-Type": "application/octet-stream" }) });
+    }
+
     if (url.pathname.startsWith("/chunk-relay/")) {
       const sid = (url.searchParams.get("sid") || "").trim();
       if (!/^[A-Za-z0-9_-]{8,128}$/.test(sid)) return new Response("invalid sid", { status: 400 });

--- a/scripts/cloudflare-worker/wrangler.chunk-relay.jsonc
+++ b/scripts/cloudflare-worker/wrangler.chunk-relay.jsonc
@@ -1,0 +1,20 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "tgproxy",
+  "main": "chunk-relay-worker.js",
+  "compatibility_date": "2026-09-12",
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "CHUNK_RELAY",
+        "class_name": "ChunkRelaySession"
+      }
+    ]
+  },
+  "exports": {
+    "ChunkRelaySession": {
+      "type": "durable-object",
+      "storage": "sqlite"
+    }
+  }
+}

--- a/scripts/test-worker-fresh-http-resilience-matrix.ps1
+++ b/scripts/test-worker-fresh-http-resilience-matrix.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$WorkerDomain,
+    [ValidateSet("Auto", "IPv4", "IPv6")]
+    [string]$IPFamily = "IPv4",
+    [switch]$IncludeBaseline,
+    [string]$DeviceSerial = "",
+    [int]$TimeoutSeconds = 420
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+$runner = Join-Path $PSScriptRoot "test-worker-network-probe.ps1"
+if (-not (Test-Path $runner)) { throw "Probe runner not found: $runner" }
+
+$profiles = @()
+if ($IncludeBaseline) { $profiles += "FreshHTTP" }
+$profiles += @("FreshHTTPRetry8K", "FreshHTTPPaced8K", "FreshHTTPRetry12K")
+
+$first = $true
+foreach ($profile in $profiles) {
+    Write-Host ""
+    Write-Host "=== $profile / $IPFamily ==="
+    $params = @{
+        WorkerDomain = $WorkerDomain
+        IPFamily = $IPFamily
+        Transport = $profile
+        TimeoutSeconds = $TimeoutSeconds
+    }
+    if ($DeviceSerial) { $params.DeviceSerial = $DeviceSerial }
+    if (-not $first) { $params.SkipBuild = $true }
+    & $runner @params
+    if ($LASTEXITCODE -ne 0) { throw "$profile probe failed with exit code $LASTEXITCODE" }
+    $first = $false
+}
+
+Write-Host ""
+Write-Host "Fresh HTTP resilience matrix completed."

--- a/scripts/test-worker-network-probe.ps1
+++ b/scripts/test-worker-network-probe.ps1
@@ -4,7 +4,7 @@ param(
     [string]$WorkerDomain,
     [ValidateSet("Auto", "IPv4", "IPv6")]
     [string]$IPFamily = "Auto",
-    [ValidateSet("Go", "OkHttp", "OkHttpNoCompression", "OkHttpRandom", "OkHttpNoCompressionRandom", "SSLSocket", "UTLS", "GoDynamic", "GoSplit1200", "GoSplit4K", "GoSplit16K", "GoPaced4K")]
+    [ValidateSet("Go", "OkHttp", "OkHttpNoCompression", "OkHttpRandom", "OkHttpNoCompressionRandom", "SSLSocket", "FreshHTTP", "UTLS", "GoDynamic", "GoSplit1200", "GoSplit4K", "GoSplit16K", "GoPaced4K")]
     [string]$Transport = "Go",
     [switch]$SkipBuild,
     [string]$DeviceSerial = "",
@@ -108,7 +108,7 @@ $finalDump | Set-Content -Encoding UTF8 $runtimeLog
 
 Write-Host ""
 Write-Host "=== Probe summary ==="
-$finalDump | Select-String "Worker network probe|MTProto Worker transport ready|PROBE_" | ForEach-Object { $_.Line }
+$finalDump | Select-String "Worker network probe|Worker fresh-connection probe|MTProto Worker transport ready|PROBE_" | ForEach-Object { $_.Line }
 Write-Host ""
 Write-Host "Runtime log: $runtimeLog"
 Write-Host "Metadata:    $metaLog"

--- a/scripts/test-worker-network-probe.ps1
+++ b/scripts/test-worker-network-probe.ps1
@@ -4,7 +4,7 @@ param(
     [string]$WorkerDomain,
     [ValidateSet("Auto", "IPv4", "IPv6")]
     [string]$IPFamily = "Auto",
-    [ValidateSet("Go", "OkHttp", "OkHttpNoCompression", "OkHttpRandom", "OkHttpNoCompressionRandom", "SSLSocket", "FreshHTTP", "UTLS", "GoDynamic", "GoSplit1200", "GoSplit4K", "GoSplit16K", "GoPaced4K")]
+    [ValidateSet("Go", "OkHttp", "OkHttpNoCompression", "OkHttpRandom", "OkHttpNoCompressionRandom", "SSLSocket", "FreshHTTP", "FreshHTTPRetry8K", "FreshHTTPPaced8K", "FreshHTTPRetry12K", "UTLS", "GoDynamic", "GoSplit1200", "GoSplit4K", "GoSplit16K", "GoPaced4K")]
     [string]$Transport = "Go",
     [switch]$SkipBuild,
     [string]$DeviceSerial = "",


### PR DESCRIPTION
## Цель

После A/B из #46 проверить архитектурный workaround для direct `*.workers.dev`: не держать один внешний WSS/TLS поток, а передавать MTProto как серию коротких HTTPS/TLS transfers с небольшими chunks и retry/backoff.

Это **не production fix** и пока не меняет обычный `cf_worker_ws` route. PR проверяет сетевую жизнеспособность short-connection транспорта и содержит экспериментальный Durable Object relay.

## Что добавлено

- `FreshHTTP` Android probe с random/high-entropy payload;
- профили:
  - `FreshHTTPRetry8K`: 8 KiB, до 3 retry, exponential backoff 300/600/1200 ms;
  - `FreshHTTPPaced8K`: то же + 75 ms pacing;
  - `FreshHTTPRetry12K`: 12 KiB, до 3 retry, без pacing;
- каждый request использует новый HTTP/1.1/TLS connection (`Connection: close`, новый client/pool, retries OkHttp отключены);
- отчёт разделяет `confirmed_bytes`, `attempted_cumulative_bytes` и `retries_used`;
- Worker diagnostic endpoints для fresh upload/download;
- experimental Durable Object `ChunkRelaySession`:
  - один stateful TCP socket к Telegram DC2;
  - ingress/egress по 8-KiB chunks;
  - upload sequence + idempotent ack, чтобы retry одного seq не дублировал запись в Telegram TCP stream;
  - downstream sequence + explicit ack;
  - bounded downstream queue.

Обычные `/apiws` и прежние `/diag/*` делегируются существующему Worker handler.

## Device result — direct IPv4, AWG/WARP/VPN off

Все resilience-профили достигли **1 MiB confirmed в обе стороны**:

| Profile | Upload | Download | Retries | Duration upload / download |
| --- | --- | --- | --- | --- |
| `FreshHTTPRetry8K` | 1,048,576 B OK | 1,048,576 B OK | 1 / 1 | 44.3 s / 43.9 s |
| `FreshHTTPPaced8K` | 1,048,576 B OK | 1,048,576 B OK | 2 / 2 | 62.0 s / 72.9 s |
| `FreshHTTPRetry12K` | 1,048,576 B OK | 1,048,576 B OK | 2 / 2 | 43.3 s / 46.6 s |

Ключевой вывод: short-connection + retry/backoff **подтверждён на сетевом уровне**. В отличие от baseline `FreshHTTP`, одиночные `SocketTimeoutException` больше не обрывают весь transfer: тот же chunk повторяется на новом соединении и поток доходит до 1 MiB.

Pacing 75 ms не дал преимущества и только увеличил время. 12 KiB тоже работает, но текущий DO relay уже рассчитан на 8 KiB. Поэтому следующий real-MTProto A/B следует делать с **8 KiB, без pacing, до 3 retry, backoff 300/600/1200 ms**.

## Следующий шаг

Подключить настоящий `cf_worker_ws` MTProto stream к `ChunkRelaySession` вместо постоянного WSS:

- client→Worker: последовательные 8-KiB `up` requests с `seq`, retry того же `seq` до получения ack;
- Worker→client: long-poll/poll `down` с sequence + ack;
- сохранить один TCP stream Worker→Telegram внутри DO;
- не менять MTProto payload/message boundaries на локальной стороне;
- оставить новый transport экспериментальным до реального Telegram device test.

## CI

CI #117 — success.

Draft: не сливать до реального MTProto device result.

Relates #29
Depends on #46