### PR TITLE
[experiment][#29] Route real MTProto through short HTTP chunk relay

### DIFF
--- a/native/tgwsproxy/flowseal_websocket_connect.go
+++ b/native/tgwsproxy/flowseal_websocket_connect.go
@@ -14,11 +14,26 @@ import (
 	"time"
 )
 
+const workerChunkRelayExperimentEnabled = true
+
 func dialFlowsealWorkerCandidate(domain, path, logPrefix string) (mtProtoFrameSocket, error) {
 	return dialFlowsealWorkerCandidateContext(context.Background(), domain, path, logPrefix)
 }
 
 func dialFlowsealWorkerCandidateContext(ctx context.Context, domain, path, logPrefix string) (mtProtoFrameSocket, error) {
+	if workerChunkRelayExperimentEnabled {
+		socket, err := dialMtProtoChunkRelayFrameSocket(ctx, domain, path, logPrefix)
+		if err != nil {
+			logDomainConnectFailure(logPrefix, domain, domain, err)
+			return nil, err
+		}
+		if logInfo != nil {
+			logInfo.Printf("%s Worker transport=chunk_relay_http host=%s path=%s chunk_bytes=%d max_retries=%d",
+				logPrefix, domain, path, mtProtoChunkRelayBytes, mtProtoChunkRelayMaxRetries)
+		}
+		return socket, nil
+	}
+
 	ws, err := connectFlowsealRawWebSocketContext(ctx, domain, domain, path, 10)
 	if err != nil {
 		logDomainConnectFailure(logPrefix, domain, domain, err)

--- a/native/tgwsproxy/mtproto_chunk_relay.go
+++ b/native/tgwsproxy/mtproto_chunk_relay.go
@@ -1,0 +1,425 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"tg-ws-proxy/mtproxyfrontend"
+)
+
+const (
+	mtProtoChunkRelayBytes      = 8 * 1024
+	mtProtoChunkRelayMaxRetries = 3
+	mtProtoChunkRelayTimeout    = 12 * time.Second
+	mtProtoChunkRelayPollWaitMS = 900
+)
+
+type chunkRelayRequestFunc func(
+	ctx context.Context,
+	action string,
+	query url.Values,
+	body []byte,
+) (status int, headers http.Header, responseBody []byte, err error)
+
+type mtProtoChunkRelayConn struct {
+	domain    string
+	sessionID string
+	workerDst string
+	request   chunkRelayRequestFunc
+	cancel    context.CancelFunc
+	lifeCtx   context.Context
+
+	writeMu   sync.Mutex
+	upSeq     int64
+	upBytes   int64
+
+	readMu     sync.Mutex
+	readBuf    []byte
+	pendingSeq int64
+	ackSeq     int64
+	downBytes  int64
+
+	deadlineMu    sync.RWMutex
+	readDeadline  time.Time
+	writeDeadline time.Time
+
+	closeMu sync.Mutex
+	closed  bool
+}
+
+func dialMtProtoChunkRelay(
+	ctx context.Context,
+	domain, sessionID, workerDst, logPrefix string,
+) (net.Conn, error) {
+	domain = strings.TrimSpace(domain)
+	sessionID = strings.TrimSpace(sessionID)
+	workerDst = strings.TrimSpace(workerDst)
+	if domain == "" || sessionID == "" || workerDst == "" {
+		return nil, fmt.Errorf("chunk relay requires domain, session id and destination")
+	}
+
+	lifeCtx, cancel := context.WithCancel(context.Background())
+	conn := &mtProtoChunkRelayConn{
+		domain:    domain,
+		sessionID: sessionID,
+		workerDst: workerDst,
+		lifeCtx:   lifeCtx,
+		cancel:    cancel,
+	}
+	conn.request = conn.freshHTTPRequest
+
+	openQuery := url.Values{
+		"sid": {sessionID},
+		"dst": {workerDst},
+	}
+	status, headers, _, err := conn.requestWithRetry(ctx, "open", openQuery, nil, "open", 0)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("open chunk relay: %w", err)
+	}
+	if status != http.StatusNoContent {
+		cancel()
+		return nil, fmt.Errorf("open chunk relay: HTTP %d", status)
+	}
+	if strings.TrimSpace(headers.Get("X-Tgws-Chunk-Relay-Revision")) == "" {
+		cancel()
+		return nil, fmt.Errorf("open chunk relay: missing relay revision header")
+	}
+
+	if logInfo != nil {
+		logInfo.Printf(
+			"%s MTProto Worker chunk relay ready session_id=%s worker_host=%s worker_dst=%s chunk_bytes=%d max_retries=%d revision=%s",
+			logPrefix,
+			sessionID,
+			domain,
+			workerDst,
+			mtProtoChunkRelayBytes,
+			mtProtoChunkRelayMaxRetries,
+			mtProtoStatusField(headers.Get("X-Tgws-Chunk-Relay-Revision")),
+		)
+	}
+	return conn, nil
+}
+
+func (c *mtProtoChunkRelayConn) freshHTTPRequest(
+	ctx context.Context,
+	action string,
+	query url.Values,
+	body []byte,
+) (int, http.Header, []byte, error) {
+	endpoint := url.URL{
+		Scheme:   "https",
+		Host:     c.domain,
+		Path:     "/chunk-relay/" + action,
+		RawQuery: query.Encode(),
+	}
+
+	method := http.MethodPost
+	if action == "down" {
+		method = http.MethodGet
+	}
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), reader)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	req.Header.Set("Cache-Control", "no-store")
+	req.Header.Set("Connection", "close")
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/octet-stream")
+	}
+
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	transport := &http.Transport{
+		Proxy:               nil,
+		DialContext:         dialer.DialContext,
+		DisableKeepAlives:   true,
+		ForceAttemptHTTP2:   false,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, // Match the existing Flowseal Worker TLS policy in this experiment.
+			ServerName:         c.domain,
+			NextProtos:         []string{"http/1.1"},
+		},
+	}
+	client := &http.Client{Transport: transport}
+	defer transport.CloseIdleConnections()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, mtProtoChunkRelayBytes+4096))
+	if err != nil {
+		return resp.StatusCode, resp.Header.Clone(), nil, err
+	}
+	return resp.StatusCode, resp.Header.Clone(), responseBody, nil
+}
+
+func (c *mtProtoChunkRelayConn) requestWithRetry(
+	parent context.Context,
+	action string,
+	query url.Values,
+	body []byte,
+	direction string,
+	seq int64,
+) (int, http.Header, []byte, error) {
+	var lastErr error
+	for attempt := 0; attempt <= mtProtoChunkRelayMaxRetries; attempt++ {
+		ctx, cancel := c.requestContext(parent, direction)
+		status, headers, responseBody, err := c.request(ctx, action, query, body)
+		cancel()
+		if err == nil {
+			return status, headers, responseBody, nil
+		}
+		lastErr = err
+		if attempt >= mtProtoChunkRelayMaxRetries {
+			break
+		}
+		if logInfo != nil {
+			logInfo.Printf(
+				"MTProto Worker chunk relay retry session_id=%s direction=%s seq=%d attempt=%d/%d error=%s",
+				c.sessionID,
+				direction,
+				seq,
+				attempt+1,
+				mtProtoChunkRelayMaxRetries,
+				mtProtoStatusField(err.Error()),
+			)
+		}
+		backoff := 300 * time.Millisecond * time.Duration(1<<attempt)
+		timer := time.NewTimer(backoff)
+		select {
+		case <-c.lifeCtx.Done():
+			timer.Stop()
+			return 0, nil, nil, net.ErrClosed
+		case <-parent.Done():
+			timer.Stop()
+			return 0, nil, nil, parent.Err()
+		case <-timer.C:
+		}
+	}
+	return 0, nil, nil, lastErr
+}
+
+func (c *mtProtoChunkRelayConn) requestContext(parent context.Context, direction string) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	base, baseCancel := context.WithCancel(parent)
+	stopLife := context.AfterFunc(c.lifeCtx, baseCancel)
+
+	deadline := time.Now().Add(mtProtoChunkRelayTimeout)
+	c.deadlineMu.RLock()
+	if direction == "up" && !c.writeDeadline.IsZero() && c.writeDeadline.Before(deadline) {
+		deadline = c.writeDeadline
+	}
+	if direction == "down" && !c.readDeadline.IsZero() && c.readDeadline.Before(deadline) {
+		deadline = c.readDeadline
+	}
+	c.deadlineMu.RUnlock()
+
+	ctx, timeoutCancel := context.WithDeadline(base, deadline)
+	return ctx, func() {
+		timeoutCancel()
+		stopLife()
+		baseCancel()
+	}
+}
+
+func (c *mtProtoChunkRelayConn) Write(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if c.isClosed() {
+		return 0, net.ErrClosed
+	}
+
+	written := 0
+	for written < len(data) {
+		end := written + mtProtoChunkRelayBytes
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[written:end]
+		seq := c.upSeq + 1
+		query := url.Values{
+			"sid": {c.sessionID},
+			"dst": {c.workerDst},
+			"seq": {strconv.FormatInt(seq, 10)},
+		}
+		status, headers, _, err := c.requestWithRetry(context.Background(), "up", query, chunk, "up", seq)
+		if err != nil {
+			return written, err
+		}
+		if status == http.StatusGone {
+			return written, io.EOF
+		}
+		if status != http.StatusNoContent {
+			return written, fmt.Errorf("chunk relay up seq %d: HTTP %d", seq, status)
+		}
+		ack, err := strconv.ParseInt(strings.TrimSpace(headers.Get("X-Tgws-Chunk-Ack")), 10, 64)
+		if err != nil || ack != seq {
+			return written, fmt.Errorf("chunk relay up seq %d: invalid ack %q", seq, headers.Get("X-Tgws-Chunk-Ack"))
+		}
+		c.upSeq = seq
+		c.upBytes += int64(len(chunk))
+		written = end
+		if logInfo != nil && (seq <= 2 || c.upBytes%(64*1024) < int64(len(chunk))) {
+			logInfo.Printf(
+				"MTProto Worker chunk relay up session_id=%s seq=%d bytes=%d confirmed_bytes=%d",
+				c.sessionID, seq, len(chunk), c.upBytes,
+			)
+		}
+	}
+	return written, nil
+}
+
+func (c *mtProtoChunkRelayConn) Read(dst []byte) (int, error) {
+	if len(dst) == 0 {
+		return 0, nil
+	}
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+
+	for {
+		if len(c.readBuf) > 0 {
+			n := copy(dst, c.readBuf)
+			c.readBuf = c.readBuf[n:]
+			if len(c.readBuf) == 0 && c.pendingSeq > 0 {
+				c.ackSeq = c.pendingSeq
+				c.pendingSeq = 0
+			}
+			return n, nil
+		}
+		if c.isClosed() {
+			return 0, net.ErrClosed
+		}
+
+		query := url.Values{
+			"sid":  {c.sessionID},
+			"dst":  {c.workerDst},
+			"ack":  {strconv.FormatInt(c.ackSeq, 10)},
+			"wait": {strconv.Itoa(mtProtoChunkRelayPollWaitMS)},
+		}
+		status, headers, body, err := c.requestWithRetry(context.Background(), "down", query, nil, "down", c.ackSeq)
+		if err != nil {
+			return 0, err
+		}
+		switch status {
+		case http.StatusNoContent:
+			continue
+		case http.StatusGone:
+			return 0, io.EOF
+		case http.StatusOK:
+		default:
+			return 0, fmt.Errorf("chunk relay down: HTTP %d", status)
+		}
+		seq, err := strconv.ParseInt(strings.TrimSpace(headers.Get("X-Tgws-Chunk-Seq")), 10, 64)
+		if err != nil || seq <= 0 {
+			return 0, fmt.Errorf("chunk relay down: invalid seq %q", headers.Get("X-Tgws-Chunk-Seq"))
+		}
+		if len(body) == 0 || len(body) > mtProtoChunkRelayBytes {
+			return 0, fmt.Errorf("chunk relay down seq %d: invalid body size %d", seq, len(body))
+		}
+		if seq <= c.ackSeq {
+			continue
+		}
+		c.pendingSeq = seq
+		c.readBuf = body
+		c.downBytes += int64(len(body))
+		if logInfo != nil && (seq <= 2 || c.downBytes%(64*1024) < int64(len(body))) {
+			logInfo.Printf(
+				"MTProto Worker chunk relay down session_id=%s seq=%d bytes=%d received_bytes=%d",
+				c.sessionID, seq, len(body), c.downBytes,
+			)
+		}
+	}
+}
+
+func (c *mtProtoChunkRelayConn) Close() error {
+	c.closeMu.Lock()
+	if c.closed {
+		c.closeMu.Unlock()
+		return nil
+	}
+	c.closed = true
+	c.closeMu.Unlock()
+	c.cancel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	query := url.Values{"sid": {c.sessionID}, "dst": {c.workerDst}}
+	_, _, _, _ = c.request(ctx, "close", query, nil)
+	if logInfo != nil {
+		logInfo.Printf(
+			"MTProto Worker chunk relay closed session_id=%s worker_dst=%s up_bytes=%d down_bytes=%d up_seq=%d down_ack=%d",
+			c.sessionID, c.workerDst, c.upBytes, c.downBytes, c.upSeq, c.ackSeq,
+		)
+	}
+	return nil
+}
+
+func (c *mtProtoChunkRelayConn) isClosed() bool {
+	c.closeMu.Lock()
+	defer c.closeMu.Unlock()
+	return c.closed
+}
+
+func (c *mtProtoChunkRelayConn) LocalAddr() net.Addr {
+	return mtProtoNetAddr("mtproto-chunk-relay-local")
+}
+
+func (c *mtProtoChunkRelayConn) RemoteAddr() net.Addr {
+	return mtProtoNetAddr(strings.TrimSpace(c.domain))
+}
+
+func (c *mtProtoChunkRelayConn) SetDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	c.readDeadline = t
+	c.writeDeadline = t
+	c.deadlineMu.Unlock()
+	return nil
+}
+
+func (c *mtProtoChunkRelayConn) SetReadDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	c.readDeadline = t
+	c.deadlineMu.Unlock()
+	return nil
+}
+
+func (c *mtProtoChunkRelayConn) SetWriteDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	c.writeDeadline = t
+	c.deadlineMu.Unlock()
+	return nil
+}
+
+func (c *mtProtoChunkRelayConn) RouteDiagnostics() mtproxyfrontend.RouteDiagnostics {
+	return mtproxyfrontend.RouteDiagnostics{
+		SessionID: strings.TrimSpace(c.sessionID),
+		WorkerDst: strings.TrimSpace(c.workerDst),
+	}
+}
+
+var (
+	_ net.Conn                                 = (*mtProtoChunkRelayConn)(nil)
+	_ mtproxyfrontend.RouteDiagnosticsProvider = (*mtProtoChunkRelayConn)(nil)
+)

--- a/native/tgwsproxy/mtproto_chunk_relay.go
+++ b/native/tgwsproxy/mtproto_chunk_relay.go
@@ -18,12 +18,13 @@ import (
 )
 
 const (
-	mtProtoChunkRelayBytes       = 8 * 1024
-	mtProtoChunkRelayMaxRetries  = 3
-	mtProtoChunkRelayOpenTimeout = 10 * time.Second
-	mtProtoChunkRelayUpTimeout   = 5 * time.Second
-	mtProtoChunkRelayDownTimeout = 10 * time.Second
-	mtProtoChunkRelayPollWaitMS  = 6000
+	mtProtoChunkRelayBytes        = 8 * 1024
+	mtProtoChunkRelayMaxRetries   = 3
+	mtProtoChunkRelayOpenTimeout  = 10 * time.Second
+	mtProtoChunkRelayUpTimeout    = 5 * time.Second
+	mtProtoChunkRelayUpHedgeDelay = 400 * time.Millisecond
+	mtProtoChunkRelayDownTimeout  = 10 * time.Second
+	mtProtoChunkRelayPollWaitMS   = 6000
 )
 
 // Each relay request still uses a fresh TCP/TLS connection. Sharing only the
@@ -105,7 +106,7 @@ func dialMtProtoChunkRelay(
 
 	if logInfo != nil {
 		logInfo.Printf(
-			"%s MTProto Worker chunk relay ready session_id=%s worker_host=%s worker_dst=%s chunk_bytes=%d max_retries=%d poll_wait_ms=%d up_timeout_ms=%d down_timeout_ms=%d tls_session_cache=true revision=%s",
+			"%s MTProto Worker chunk relay ready session_id=%s worker_host=%s worker_dst=%s chunk_bytes=%d max_retries=%d poll_wait_ms=%d up_timeout_ms=%d down_timeout_ms=%d up_hedge_delay_ms=%d tls_session_cache=true revision=%s",
 			logPrefix,
 			sessionID,
 			domain,
@@ -115,6 +116,7 @@ func dialMtProtoChunkRelay(
 			mtProtoChunkRelayPollWaitMS,
 			mtProtoChunkRelayUpTimeout.Milliseconds(),
 			mtProtoChunkRelayDownTimeout.Milliseconds(),
+			mtProtoChunkRelayUpHedgeDelay.Milliseconds(),
 			mtProtoStatusField(headers.Get("X-Tgws-Chunk-Relay-Revision")),
 		)
 	}
@@ -191,9 +193,17 @@ func (c *mtProtoChunkRelayConn) requestWithRetry(
 ) (int, http.Header, []byte, error) {
 	var lastErr error
 	for attempt := 0; attempt <= mtProtoChunkRelayMaxRetries; attempt++ {
-		ctx, cancel := c.requestContext(parent, direction)
-		status, headers, responseBody, err := c.request(ctx, action, query, body)
-		cancel()
+		var status int
+		var headers http.Header
+		var responseBody []byte
+		var err error
+		if action == "up" && direction == "up" {
+			status, headers, responseBody, err = c.requestUpHedgeRound(parent, query, body, seq)
+		} else {
+			ctx, cancel := c.requestContext(parent, direction)
+			status, headers, responseBody, err = c.request(ctx, action, query, body)
+			cancel()
+		}
 		if err == nil {
 			return status, headers, responseBody, nil
 		}
@@ -225,6 +235,104 @@ func (c *mtProtoChunkRelayConn) requestWithRetry(
 		}
 	}
 	return 0, nil, nil, lastErr
+}
+
+type chunkRelayAttemptResult struct {
+	status       int
+	headers      http.Header
+	responseBody []byte
+	err          error
+	leg          string
+}
+
+func (c *mtProtoChunkRelayConn) requestUpHedgeRound(
+	parent context.Context,
+	query url.Values,
+	body []byte,
+	seq int64,
+) (int, http.Header, []byte, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	roundCtx, roundCancel := context.WithCancel(parent)
+	defer roundCancel()
+
+	results := make(chan chunkRelayAttemptResult, 2)
+	launch := func(leg string) {
+		go func() {
+			ctx, cancel := c.requestContext(roundCtx, "up")
+			status, headers, responseBody, err := c.request(ctx, "up", query, body)
+			cancel()
+			results <- chunkRelayAttemptResult{
+				status:       status,
+				headers:      headers,
+				responseBody: responseBody,
+				err:          err,
+				leg:          leg,
+			}
+		}()
+	}
+
+	launch("primary")
+	timer := time.NewTimer(mtProtoChunkRelayUpHedgeDelay)
+	defer timer.Stop()
+	hedgeLaunched := false
+	completed := 0
+	var lastErr error
+
+	launchHedge := func(reason string) {
+		if hedgeLaunched {
+			return
+		}
+		hedgeLaunched = true
+		launch("hedge")
+		if logInfo != nil {
+			logInfo.Printf(
+				"MTProto Worker chunk relay hedge session_id=%s direction=up seq=%d delay_ms=%d reason=%s",
+				c.sessionID,
+				seq,
+				mtProtoChunkRelayUpHedgeDelay.Milliseconds(),
+				reason,
+			)
+		}
+	}
+
+	for {
+		select {
+		case result := <-results:
+			completed++
+			if result.err == nil {
+				roundCancel()
+				if result.leg == "hedge" && logInfo != nil {
+					logInfo.Printf(
+						"MTProto Worker chunk relay hedge won session_id=%s direction=up seq=%d",
+						c.sessionID,
+						seq,
+					)
+				}
+				return result.status, result.headers, result.responseBody, nil
+			}
+			lastErr = result.err
+			if !hedgeLaunched {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				launchHedge("primary_error")
+			}
+			if hedgeLaunched && completed >= 2 {
+				return 0, nil, nil, lastErr
+			}
+		case <-timer.C:
+			launchHedge("delay")
+		case <-parent.Done():
+			return 0, nil, nil, parent.Err()
+		case <-c.lifeCtx.Done():
+			return 0, nil, nil, net.ErrClosed
+		}
+	}
 }
 
 func (c *mtProtoChunkRelayConn) requestContext(parent context.Context, direction string) (context.Context, context.CancelFunc) {

--- a/native/tgwsproxy/mtproto_chunk_relay.go
+++ b/native/tgwsproxy/mtproto_chunk_relay.go
@@ -18,11 +18,18 @@ import (
 )
 
 const (
-	mtProtoChunkRelayBytes      = 8 * 1024
-	mtProtoChunkRelayMaxRetries = 3
-	mtProtoChunkRelayTimeout    = 12 * time.Second
-	mtProtoChunkRelayPollWaitMS = 900
+	mtProtoChunkRelayBytes       = 8 * 1024
+	mtProtoChunkRelayMaxRetries  = 3
+	mtProtoChunkRelayOpenTimeout = 10 * time.Second
+	mtProtoChunkRelayUpTimeout   = 5 * time.Second
+	mtProtoChunkRelayDownTimeout = 10 * time.Second
+	mtProtoChunkRelayPollWaitMS  = 6000
 )
+
+// Each relay request still uses a fresh TCP/TLS connection. Sharing only the
+// client-session cache allows TLS resumption without reintroducing a long-lived
+// workers.dev byte stream.
+var mtProtoChunkRelayTLSCache = tls.NewLRUClientSessionCache(256)
 
 type chunkRelayRequestFunc func(
 	ctx context.Context,
@@ -39,9 +46,9 @@ type mtProtoChunkRelayConn struct {
 	cancel    context.CancelFunc
 	lifeCtx   context.Context
 
-	writeMu   sync.Mutex
-	upSeq     int64
-	upBytes   int64
+	writeMu sync.Mutex
+	upSeq   int64
+	upBytes int64
 
 	readMu     sync.Mutex
 	readBuf    []byte
@@ -98,13 +105,16 @@ func dialMtProtoChunkRelay(
 
 	if logInfo != nil {
 		logInfo.Printf(
-			"%s MTProto Worker chunk relay ready session_id=%s worker_host=%s worker_dst=%s chunk_bytes=%d max_retries=%d revision=%s",
+			"%s MTProto Worker chunk relay ready session_id=%s worker_host=%s worker_dst=%s chunk_bytes=%d max_retries=%d poll_wait_ms=%d up_timeout_ms=%d down_timeout_ms=%d tls_session_cache=true revision=%s",
 			logPrefix,
 			sessionID,
 			domain,
 			workerDst,
 			mtProtoChunkRelayBytes,
 			mtProtoChunkRelayMaxRetries,
+			mtProtoChunkRelayPollWaitMS,
+			mtProtoChunkRelayUpTimeout.Milliseconds(),
+			mtProtoChunkRelayDownTimeout.Milliseconds(),
 			mtProtoStatusField(headers.Get("X-Tgws-Chunk-Relay-Revision")),
 		)
 	}
@@ -153,6 +163,7 @@ func (c *mtProtoChunkRelayConn) freshHTTPRequest(
 			InsecureSkipVerify: true, // Match the existing Flowseal Worker TLS policy in this experiment.
 			ServerName:         c.domain,
 			NextProtos:         []string{"http/1.1"},
+			ClientSessionCache: mtProtoChunkRelayTLSCache,
 		},
 	}
 	client := &http.Client{Transport: transport}
@@ -223,7 +234,14 @@ func (c *mtProtoChunkRelayConn) requestContext(parent context.Context, direction
 	base, baseCancel := context.WithCancel(parent)
 	stopLife := context.AfterFunc(c.lifeCtx, baseCancel)
 
-	deadline := time.Now().Add(mtProtoChunkRelayTimeout)
+	timeout := mtProtoChunkRelayOpenTimeout
+	switch direction {
+	case "up":
+		timeout = mtProtoChunkRelayUpTimeout
+	case "down":
+		timeout = mtProtoChunkRelayDownTimeout
+	}
+	deadline := time.Now().Add(timeout)
 	c.deadlineMu.RLock()
 	if direction == "up" && !c.writeDeadline.IsZero() && c.writeDeadline.Before(deadline) {
 		deadline = c.writeDeadline

--- a/native/tgwsproxy/mtproto_chunk_relay_frames.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_frames.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"strings"
@@ -27,10 +28,32 @@ func dialMtProtoChunkRelayFrameSocket(ctx context.Context, domain, path, logPref
 	if err != nil {
 		return nil, err
 	}
+	if chunkConn, ok := conn.(*mtProtoChunkRelayConn); ok {
+		enableMtProtoChunkRelayRequestLimit(chunkConn)
+		if logInfo != nil {
+			logInfo.Printf(
+				"%s MTProto Worker chunk relay upload pipeline session_id=%s window=%d global_http_requests=%d",
+				logPrefix,
+				sessionID,
+				mtProtoChunkRelayUpWindow,
+				mtProtoChunkRelayGlobalHTTPRequests,
+			)
+		}
+	}
 	return &mtProtoChunkRelayFrameSocket{conn: conn}, nil
 }
 
 func (s *mtProtoChunkRelayFrameSocket) Send(data []byte) error {
+	if conn, ok := s.conn.(*mtProtoChunkRelayConn); ok {
+		n, err := writePipelinedMtProtoChunkRelay(conn, data)
+		if err != nil {
+			return err
+		}
+		if n != len(data) {
+			return io.ErrShortWrite
+		}
+		return nil
+	}
 	return writeFullConn(s.conn, data)
 }
 

--- a/native/tgwsproxy/mtproto_chunk_relay_frames.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_frames.go
@@ -32,11 +32,13 @@ func dialMtProtoChunkRelayFrameSocket(ctx context.Context, domain, path, logPref
 		enableMtProtoChunkRelayRequestLimit(chunkConn)
 		if logInfo != nil {
 			logInfo.Printf(
-				"%s MTProto Worker chunk relay upload pipeline session_id=%s window=%d global_http_requests=%d",
+				"%s MTProto Worker chunk relay upload pipeline session_id=%s window=%d primary_requests=%d global_http_requests=%d hol_hedge_delay_ms=%d hedge_policy=oldest_unacked",
 				logPrefix,
 				sessionID,
 				mtProtoChunkRelayUpWindow,
+				mtProtoChunkRelayPrimaryRequests,
 				mtProtoChunkRelayGlobalHTTPRequests,
+				mtProtoChunkRelayHOLHedgeDelay.Milliseconds(),
 			)
 		}
 	}

--- a/native/tgwsproxy/mtproto_chunk_relay_frames.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_frames.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type mtProtoChunkRelayFrameSocket struct {
+	conn net.Conn
+}
+
+func dialMtProtoChunkRelayFrameSocket(ctx context.Context, domain, path, logPrefix string) (mtProtoFrameSocket, error) {
+	parsed, err := url.ParseRequestURI(path)
+	if err != nil {
+		return nil, fmt.Errorf("parse chunk relay path: %w", err)
+	}
+	sessionID := strings.TrimSpace(parsed.Query().Get("sid"))
+	workerDst := strings.TrimSpace(parsed.Query().Get("dst"))
+	if sessionID == "" || workerDst == "" {
+		return nil, fmt.Errorf("chunk relay path missing sid/dst")
+	}
+	conn, err := dialMtProtoChunkRelay(ctx, domain, sessionID, workerDst, logPrefix)
+	if err != nil {
+		return nil, err
+	}
+	return &mtProtoChunkRelayFrameSocket{conn: conn}, nil
+}
+
+func (s *mtProtoChunkRelayFrameSocket) Send(data []byte) error {
+	return writeFullConn(s.conn, data)
+}
+
+func (s *mtProtoChunkRelayFrameSocket) SendBatch(parts [][]byte) error {
+	for _, part := range parts {
+		if err := s.Send(part); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *mtProtoChunkRelayFrameSocket) Recv() ([]byte, error) {
+	buf := make([]byte, mtProtoChunkRelayBytes)
+	n, err := s.conn.Read(buf)
+	if n > 0 {
+		return buf[:n], nil
+	}
+	return nil, err
+}
+
+func (s *mtProtoChunkRelayFrameSocket) Close() {
+	_ = s.conn.Close()
+}
+
+func (s *mtProtoChunkRelayFrameSocket) SetDeadline(t time.Time) error {
+	return s.conn.SetDeadline(t)
+}
+
+func (s *mtProtoChunkRelayFrameSocket) SetReadDeadline(t time.Time) error {
+	return s.conn.SetReadDeadline(t)
+}
+
+func (s *mtProtoChunkRelayFrameSocket) SetWriteDeadline(t time.Time) error {
+	return s.conn.SetWriteDeadline(t)
+}
+
+var _ mtProtoFrameSocket = (*mtProtoChunkRelayFrameSocket)(nil)

--- a/native/tgwsproxy/mtproto_chunk_relay_hedge_test.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_hedge_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestChunkRelayWriteHedgesSlowUploadWithSameSequence(t *testing.T) {
+	var mu sync.Mutex
+	var seqs []int64
+	calls := 0
+
+	conn := newTestChunkRelayConn(t, func(ctx context.Context, action string, query url.Values, body []byte) (int, http.Header, []byte, error) {
+		if action != "up" {
+			t.Fatalf("action=%s", action)
+		}
+		seq, err := strconv.ParseInt(query.Get("seq"), 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mu.Lock()
+		calls++
+		call := calls
+		seqs = append(seqs, seq)
+		mu.Unlock()
+
+		if call == 1 {
+			<-ctx.Done()
+			return 0, nil, nil, ctx.Err()
+		}
+
+		headers := make(http.Header)
+		headers.Set("X-Tgws-Chunk-Ack", strconv.FormatInt(seq, 10))
+		return http.StatusNoContent, headers, nil, nil
+	})
+
+	started := time.Now()
+	payload := make([]byte, 1024)
+	n, err := conn.Write(payload)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("n=%d want=%d", n, len(payload))
+	}
+	if elapsed := time.Since(started); elapsed >= mtProtoChunkRelayUpTimeout {
+		t.Fatalf("hedged write took %s, expected less than upload timeout %s", elapsed, mtProtoChunkRelayUpTimeout)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("calls=%d want=2", calls)
+	}
+	if len(seqs) != 2 || seqs[0] != 1 || seqs[1] != 1 {
+		t.Fatalf("seqs=%v want=[1 1]", seqs)
+	}
+}
+
+func TestChunkRelayWriteDoesNotHedgeFastUpload(t *testing.T) {
+	var mu sync.Mutex
+	calls := 0
+
+	conn := newTestChunkRelayConn(t, func(_ context.Context, action string, query url.Values, _ []byte) (int, http.Header, []byte, error) {
+		if action != "up" {
+			t.Fatalf("action=%s", action)
+		}
+		seq, err := strconv.ParseInt(query.Get("seq"), 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		headers := make(http.Header)
+		headers.Set("X-Tgws-Chunk-Ack", strconv.FormatInt(seq, 10))
+		return http.StatusNoContent, headers, nil, nil
+	})
+
+	if _, err := conn.Write([]byte("fast")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Give any incorrectly scheduled hedge enough time to fire.
+	time.Sleep(mtProtoChunkRelayUpHedgeDelay + 50*time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("calls=%d want=1", calls)
+	}
+}

--- a/native/tgwsproxy/mtproto_chunk_relay_hol_hedge_test.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_hol_hedge_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestChunkRelayPipelineHedgesOnlyOldestUnacked(t *testing.T) {
+	oldDelay := mtProtoChunkRelayHOLHedgeDelay
+	mtProtoChunkRelayHOLHedgeDelay = 50 * time.Millisecond
+	defer func() { mtProtoChunkRelayHOLHedgeDelay = oldDelay }()
+
+	var mu sync.Mutex
+	calls := map[int64]int{}
+
+	conn := newTestChunkRelayConn(t, func(ctx context.Context, action string, query url.Values, _ []byte) (int, http.Header, []byte, error) {
+		if action != "up" {
+			t.Fatalf("action=%s", action)
+		}
+		seq, err := strconv.ParseInt(query.Get("seq"), 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mu.Lock()
+		calls[seq]++
+		call := calls[seq]
+		mu.Unlock()
+
+		if seq == 1 && call == 1 {
+			<-ctx.Done()
+			return 0, nil, nil, ctx.Err()
+		}
+
+		headers := make(http.Header)
+		headers.Set("X-Tgws-Chunk-Ack", strconv.FormatInt(seq, 10))
+		return http.StatusNoContent, headers, nil, nil
+	})
+
+	payload := make([]byte, mtProtoChunkRelayBytes*mtProtoChunkRelayUpWindow)
+	started := time.Now()
+	n, err := writePipelinedMtProtoChunkRelay(conn, payload)
+	if err != nil {
+		t.Fatalf("pipeline write: %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("n=%d want=%d", n, len(payload))
+	}
+	if elapsed := time.Since(started); elapsed >= mtProtoChunkRelayUpTimeout {
+		t.Fatalf("HOL hedge took %s, expected less than upload timeout %s", elapsed, mtProtoChunkRelayUpTimeout)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls[1] != 2 {
+		t.Fatalf("seq1 calls=%d want=2", calls[1])
+	}
+	for seq := int64(2); seq <= int64(mtProtoChunkRelayUpWindow); seq++ {
+		if calls[seq] != 1 {
+			t.Fatalf("seq%d calls=%d want=1; only oldest unacked seq may hedge", seq, calls[seq])
+		}
+	}
+}

--- a/native/tgwsproxy/mtproto_chunk_relay_pipeline.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_pipeline.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	mtProtoChunkRelayUpWindow          = 4
+	mtProtoChunkRelayGlobalHTTPRequests = 12
+)
+
+var mtProtoChunkRelayHTTPSlots = make(chan struct{}, mtProtoChunkRelayGlobalHTTPRequests)
+
+func enableMtProtoChunkRelayRequestLimit(c *mtProtoChunkRelayConn) {
+	base := c.request
+	c.request = func(ctx context.Context, action string, query url.Values, body []byte) (int, http.Header, []byte, error) {
+		select {
+		case mtProtoChunkRelayHTTPSlots <- struct{}{}:
+			defer func() { <-mtProtoChunkRelayHTTPSlots }()
+		case <-ctx.Done():
+			return 0, nil, nil, ctx.Err()
+		case <-c.lifeCtx.Done():
+			return 0, nil, nil, net.ErrClosed
+		}
+		return base(ctx, action, query, body)
+	}
+}
+
+type mtProtoChunkUploadSpec struct {
+	seq   int64
+	start int
+	end   int
+}
+
+type mtProtoChunkUploadResult struct {
+	spec    mtProtoChunkUploadSpec
+	status  int
+	headers http.Header
+	err     error
+}
+
+func writePipelinedMtProtoChunkRelay(c *mtProtoChunkRelayConn, data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if c.isClosed() {
+		return 0, net.ErrClosed
+	}
+
+	specs := make([]mtProtoChunkUploadSpec, 0, (len(data)+mtProtoChunkRelayBytes-1)/mtProtoChunkRelayBytes)
+	baseSeq := c.upSeq
+	for start := 0; start < len(data); start += mtProtoChunkRelayBytes {
+		end := start + mtProtoChunkRelayBytes
+		if end > len(data) {
+			end = len(data)
+		}
+		specs = append(specs, mtProtoChunkUploadSpec{
+			seq:   baseSeq + int64(len(specs)) + 1,
+			start: start,
+			end:   end,
+		})
+	}
+
+	written := 0
+	for batchStart := 0; batchStart < len(specs); batchStart += mtProtoChunkRelayUpWindow {
+		batchEnd := batchStart + mtProtoChunkRelayUpWindow
+		if batchEnd > len(specs) {
+			batchEnd = len(specs)
+		}
+		batch := specs[batchStart:batchEnd]
+		results := make(chan mtProtoChunkUploadResult, len(batch))
+
+		for _, spec := range batch {
+			spec := spec
+			go func() {
+				query := url.Values{
+					"sid": {c.sessionID},
+					"dst": {c.workerDst},
+					"seq": {strconv.FormatInt(spec.seq, 10)},
+				}
+				status, headers, _, err := c.requestWithRetry(
+					context.Background(),
+					"up",
+					query,
+					data[spec.start:spec.end],
+					"up",
+					spec.seq,
+				)
+				results <- mtProtoChunkUploadResult{spec: spec, status: status, headers: headers, err: err}
+			}()
+		}
+
+		bySeq := make(map[int64]mtProtoChunkUploadResult, len(batch))
+		for range batch {
+			result := <-results
+			bySeq[result.spec.seq] = result
+		}
+
+		for _, spec := range batch {
+			result := bySeq[spec.seq]
+			if result.err != nil {
+				return written, result.err
+			}
+			if result.status == http.StatusGone {
+				return written, io.EOF
+			}
+			if result.status != http.StatusNoContent {
+				return written, fmt.Errorf("chunk relay up seq %d: HTTP %d", spec.seq, result.status)
+			}
+			ack, err := strconv.ParseInt(strings.TrimSpace(result.headers.Get("X-Tgws-Chunk-Ack")), 10, 64)
+			if err != nil || ack != spec.seq {
+				return written, fmt.Errorf("chunk relay up seq %d: invalid ack %q", spec.seq, result.headers.Get("X-Tgws-Chunk-Ack"))
+			}
+
+			chunkBytes := spec.end - spec.start
+			c.upSeq = spec.seq
+			c.upBytes += int64(chunkBytes)
+			written = spec.end
+			if logInfo != nil && (spec.seq <= 2 || c.upBytes%(64*1024) < int64(chunkBytes)) {
+				logInfo.Printf(
+					"MTProto Worker chunk relay up session_id=%s seq=%d bytes=%d confirmed_bytes=%d upload_window=%d",
+					c.sessionID,
+					spec.seq,
+					chunkBytes,
+					c.upBytes,
+					mtProtoChunkRelayUpWindow,
+				)
+			}
+		}
+	}
+
+	return written, nil
+}

--- a/native/tgwsproxy/mtproto_chunk_relay_pipeline.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_pipeline.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	mtProtoChunkRelayUpWindow            = 4
-	mtProtoChunkRelayPrimaryRequests     = 16
-	mtProtoChunkRelayGlobalHTTPRequests  = 24
+	mtProtoChunkRelayUpWindow           = 4
+	mtProtoChunkRelayPrimaryRequests    = 16
+	mtProtoChunkRelayGlobalHTTPRequests = 24
+	mtProtoChunkRelayPipelineMode       = "sliding"
 )
 
 var (
@@ -282,81 +283,105 @@ func writePipelinedMtProtoChunkRelay(c *mtProtoChunkRelayConn, data []byte) (int
 		})
 	}
 
+	pipelineCtx, pipelineCancel := context.WithCancel(context.Background())
+	defer pipelineCancel()
+
+	results := make(chan mtProtoChunkUploadResult, len(specs))
+	head := newMtProtoChunkRelayHeadTracker(specs[0].seq)
+
+	launch := func(spec mtProtoChunkUploadSpec) {
+		go func() {
+			if err := acquireMtProtoChunkRelayPrimarySlot(c); err != nil {
+				results <- mtProtoChunkUploadResult{spec: spec, err: err}
+				return
+			}
+			defer releaseMtProtoChunkRelayPrimarySlot()
+
+			query := url.Values{
+				"sid": {c.sessionID},
+				"dst": {c.workerDst},
+				"seq": {strconv.FormatInt(spec.seq, 10)},
+			}
+			status, headers, _, err := c.requestPipelinedUploadWithRetry(
+				pipelineCtx,
+				query,
+				data[spec.start:spec.end],
+				spec.seq,
+				head,
+			)
+			if err == nil && status == http.StatusNoContent {
+				ack, ackErr := strconv.ParseInt(strings.TrimSpace(headers.Get("X-Tgws-Chunk-Ack")), 10, 64)
+				if ackErr == nil && ack == spec.seq {
+					head.markDone(spec.seq)
+				}
+			}
+			results <- mtProtoChunkUploadResult{spec: spec, status: status, headers: headers, err: err}
+		}()
+	}
+
+	nextLaunch := 0
+	for nextLaunch < len(specs) && nextLaunch < mtProtoChunkRelayUpWindow {
+		launch(specs[nextLaunch])
+		nextLaunch++
+	}
+
+	completed := make(map[int64]mtProtoChunkUploadResult, mtProtoChunkRelayUpWindow)
+	nextCommit := 0
 	written := 0
-	for batchStart := 0; batchStart < len(specs); batchStart += mtProtoChunkRelayUpWindow {
-		batchEnd := batchStart + mtProtoChunkRelayUpWindow
-		if batchEnd > len(specs) {
-			batchEnd = len(specs)
+
+	for nextCommit < len(specs) {
+		result := <-results
+
+		if result.err != nil {
+			pipelineCancel()
+			return written, result.err
 		}
-		batch := specs[batchStart:batchEnd]
-		results := make(chan mtProtoChunkUploadResult, len(batch))
-		head := newMtProtoChunkRelayHeadTracker(batch[0].seq)
-
-		for _, spec := range batch {
-			spec := spec
-			go func() {
-				if err := acquireMtProtoChunkRelayPrimarySlot(c); err != nil {
-					results <- mtProtoChunkUploadResult{spec: spec, err: err}
-					return
-				}
-				defer releaseMtProtoChunkRelayPrimarySlot()
-
-				query := url.Values{
-					"sid": {c.sessionID},
-					"dst": {c.workerDst},
-					"seq": {strconv.FormatInt(spec.seq, 10)},
-				}
-				status, headers, _, err := c.requestPipelinedUploadWithRetry(
-					context.Background(),
-					query,
-					data[spec.start:spec.end],
-					spec.seq,
-					head,
-				)
-				if err == nil && status == http.StatusNoContent {
-					ack, ackErr := strconv.ParseInt(strings.TrimSpace(headers.Get("X-Tgws-Chunk-Ack")), 10, 64)
-					if ackErr == nil && ack == spec.seq {
-						head.markDone(spec.seq)
-					}
-				}
-				results <- mtProtoChunkUploadResult{spec: spec, status: status, headers: headers, err: err}
-			}()
+		if result.status == http.StatusGone {
+			pipelineCancel()
+			return written, io.EOF
+		}
+		if result.status != http.StatusNoContent {
+			pipelineCancel()
+			return written, fmt.Errorf("chunk relay up seq %d: HTTP %d", result.spec.seq, result.status)
+		}
+		ack, err := strconv.ParseInt(strings.TrimSpace(result.headers.Get("X-Tgws-Chunk-Ack")), 10, 64)
+		if err != nil || ack != result.spec.seq {
+			pipelineCancel()
+			return written, fmt.Errorf("chunk relay up seq %d: invalid ack %q", result.spec.seq, result.headers.Get("X-Tgws-Chunk-Ack"))
 		}
 
-		bySeq := make(map[int64]mtProtoChunkUploadResult, len(batch))
-		for range batch {
-			result := <-results
-			bySeq[result.spec.seq] = result
+		completed[result.spec.seq] = result
+
+		// True sliding window: as soon as any in-flight chunk receives a valid
+		// ACK, immediately launch the next chunk instead of waiting for the
+		// remaining members of a fixed batch.
+		if nextLaunch < len(specs) {
+			launch(specs[nextLaunch])
+			nextLaunch++
 		}
 
-		for _, spec := range batch {
-			result := bySeq[spec.seq]
-			if result.err != nil {
-				return written, result.err
+		for nextCommit < len(specs) {
+			spec := specs[nextCommit]
+			if _, ok := completed[spec.seq]; !ok {
+				break
 			}
-			if result.status == http.StatusGone {
-				return written, io.EOF
-			}
-			if result.status != http.StatusNoContent {
-				return written, fmt.Errorf("chunk relay up seq %d: HTTP %d", spec.seq, result.status)
-			}
-			ack, err := strconv.ParseInt(strings.TrimSpace(result.headers.Get("X-Tgws-Chunk-Ack")), 10, 64)
-			if err != nil || ack != spec.seq {
-				return written, fmt.Errorf("chunk relay up seq %d: invalid ack %q", spec.seq, result.headers.Get("X-Tgws-Chunk-Ack"))
-			}
+			delete(completed, spec.seq)
 
 			chunkBytes := spec.end - spec.start
 			c.upSeq = spec.seq
 			c.upBytes += int64(chunkBytes)
 			written = spec.end
+			nextCommit++
+
 			if logInfo != nil && (spec.seq <= 2 || c.upBytes%(64*1024) < int64(chunkBytes)) {
 				logInfo.Printf(
-					"MTProto Worker chunk relay up session_id=%s seq=%d bytes=%d confirmed_bytes=%d upload_window=%d",
+					"MTProto Worker chunk relay up session_id=%s seq=%d bytes=%d confirmed_bytes=%d upload_window=%d pipeline=%s",
 					c.sessionID,
 					spec.seq,
 					chunkBytes,
 					c.upBytes,
 					mtProtoChunkRelayUpWindow,
+					mtProtoChunkRelayPipelineMode,
 				)
 			}
 		}

--- a/native/tgwsproxy/mtproto_chunk_relay_pipeline.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_pipeline.go
@@ -9,14 +9,21 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 )
 
 const (
-	mtProtoChunkRelayUpWindow          = 4
-	mtProtoChunkRelayGlobalHTTPRequests = 12
+	mtProtoChunkRelayUpWindow            = 4
+	mtProtoChunkRelayPrimaryRequests     = 16
+	mtProtoChunkRelayGlobalHTTPRequests  = 24
 )
 
-var mtProtoChunkRelayHTTPSlots = make(chan struct{}, mtProtoChunkRelayGlobalHTTPRequests)
+var (
+	mtProtoChunkRelayHTTPSlots     = make(chan struct{}, mtProtoChunkRelayGlobalHTTPRequests)
+	mtProtoChunkRelayPrimarySlots  = make(chan struct{}, mtProtoChunkRelayPrimaryRequests)
+	mtProtoChunkRelayHOLHedgeDelay = 900 * time.Millisecond
+)
 
 func enableMtProtoChunkRelayRequestLimit(c *mtProtoChunkRelayConn) {
 	base := c.request
@@ -33,6 +40,19 @@ func enableMtProtoChunkRelayRequestLimit(c *mtProtoChunkRelayConn) {
 	}
 }
 
+func acquireMtProtoChunkRelayPrimarySlot(c *mtProtoChunkRelayConn) error {
+	select {
+	case mtProtoChunkRelayPrimarySlots <- struct{}{}:
+		return nil
+	case <-c.lifeCtx.Done():
+		return net.ErrClosed
+	}
+}
+
+func releaseMtProtoChunkRelayPrimarySlot() {
+	<-mtProtoChunkRelayPrimarySlots
+}
+
 type mtProtoChunkUploadSpec struct {
 	seq   int64
 	start int
@@ -44,6 +64,197 @@ type mtProtoChunkUploadResult struct {
 	status  int
 	headers http.Header
 	err     error
+}
+
+type mtProtoChunkRelayHeadTracker struct {
+	mu      sync.Mutex
+	head    int64
+	done    map[int64]struct{}
+	changed chan struct{}
+}
+
+func newMtProtoChunkRelayHeadTracker(head int64) *mtProtoChunkRelayHeadTracker {
+	return &mtProtoChunkRelayHeadTracker{
+		head:    head,
+		done:    make(map[int64]struct{}),
+		changed: make(chan struct{}),
+	}
+}
+
+func (t *mtProtoChunkRelayHeadTracker) state(seq int64) (isHead bool, alreadyDone bool, changed <-chan struct{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return seq == t.head, seq < t.head, t.changed
+}
+
+func (t *mtProtoChunkRelayHeadTracker) markDone(seq int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if seq < t.head {
+		return
+	}
+	t.done[seq] = struct{}{}
+	advanced := false
+	for {
+		if _, ok := t.done[t.head]; !ok {
+			break
+		}
+		delete(t.done, t.head)
+		t.head++
+		advanced = true
+	}
+	if advanced {
+		close(t.changed)
+		t.changed = make(chan struct{})
+	}
+}
+
+func (c *mtProtoChunkRelayConn) requestPipelinedUploadWithRetry(
+	parent context.Context,
+	query url.Values,
+	body []byte,
+	seq int64,
+	head *mtProtoChunkRelayHeadTracker,
+) (int, http.Header, []byte, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	var lastErr error
+	for attempt := 0; attempt <= mtProtoChunkRelayMaxRetries; attempt++ {
+		status, headers, responseBody, err := c.requestPipelinedUploadRound(parent, query, body, seq, head)
+		if err == nil {
+			return status, headers, responseBody, nil
+		}
+		lastErr = err
+		if attempt >= mtProtoChunkRelayMaxRetries {
+			break
+		}
+		if logInfo != nil {
+			logInfo.Printf(
+				"MTProto Worker chunk relay retry session_id=%s direction=up seq=%d attempt=%d/%d error=%s",
+				c.sessionID,
+				seq,
+				attempt+1,
+				mtProtoChunkRelayMaxRetries,
+				mtProtoStatusField(err.Error()),
+			)
+		}
+		backoff := 300 * time.Millisecond * time.Duration(1<<attempt)
+		timer := time.NewTimer(backoff)
+		select {
+		case <-c.lifeCtx.Done():
+			timer.Stop()
+			return 0, nil, nil, net.ErrClosed
+		case <-parent.Done():
+			timer.Stop()
+			return 0, nil, nil, parent.Err()
+		case <-timer.C:
+		}
+	}
+	return 0, nil, nil, lastErr
+}
+
+func (c *mtProtoChunkRelayConn) requestPipelinedUploadRound(
+	parent context.Context,
+	query url.Values,
+	body []byte,
+	seq int64,
+	head *mtProtoChunkRelayHeadTracker,
+) (int, http.Header, []byte, error) {
+	roundCtx, roundCancel := context.WithCancel(parent)
+	defer roundCancel()
+
+	results := make(chan chunkRelayAttemptResult, 2)
+	launch := func(leg string) {
+		go func() {
+			ctx, cancel := c.requestContext(roundCtx, "up")
+			status, headers, responseBody, err := c.request(ctx, "up", query, body)
+			cancel()
+			results <- chunkRelayAttemptResult{
+				status:       status,
+				headers:      headers,
+				responseBody: responseBody,
+				err:          err,
+				leg:          leg,
+			}
+		}()
+	}
+
+	launch("primary")
+	timer := time.NewTimer(mtProtoChunkRelayHOLHedgeDelay)
+	defer timer.Stop()
+
+	hedgeLaunched := false
+	delayElapsed := false
+	completed := 0
+	var lastErr error
+
+	launchHedge := func(reason string) {
+		if hedgeLaunched {
+			return
+		}
+		hedgeLaunched = true
+		launch("hedge")
+		if logInfo != nil {
+			logInfo.Printf(
+				"MTProto Worker chunk relay hedge session_id=%s direction=up seq=%d delay_ms=%d reason=%s policy=oldest_unacked",
+				c.sessionID,
+				seq,
+				mtProtoChunkRelayHOLHedgeDelay.Milliseconds(),
+				reason,
+			)
+		}
+	}
+
+	for {
+		var headChanged <-chan struct{}
+		if delayElapsed && !hedgeLaunched {
+			isHead, alreadyDone, changed := head.state(seq)
+			if alreadyDone {
+				headChanged = nil
+			} else if isHead {
+				launchHedge("head_of_line")
+			} else {
+				headChanged = changed
+			}
+		}
+
+		select {
+		case result := <-results:
+			completed++
+			if result.err == nil {
+				roundCancel()
+				if result.leg == "hedge" && logInfo != nil {
+					logInfo.Printf(
+						"MTProto Worker chunk relay hedge won session_id=%s direction=up seq=%d policy=oldest_unacked",
+						c.sessionID,
+						seq,
+					)
+				}
+				return result.status, result.headers, result.responseBody, nil
+			}
+			lastErr = result.err
+			if !hedgeLaunched {
+				isHead, alreadyDone, _ := head.state(seq)
+				if isHead && !alreadyDone {
+					launchHedge("primary_error_head")
+				} else {
+					return 0, nil, nil, lastErr
+				}
+			}
+			if hedgeLaunched && completed >= 2 {
+				return 0, nil, nil, lastErr
+			}
+		case <-timer.C:
+			delayElapsed = true
+		case <-headChanged:
+			// Re-evaluate whether this sequence is now the oldest unacknowledged chunk.
+		case <-parent.Done():
+			return 0, nil, nil, parent.Err()
+		case <-c.lifeCtx.Done():
+			return 0, nil, nil, net.ErrClosed
+		}
+	}
 }
 
 func writePipelinedMtProtoChunkRelay(c *mtProtoChunkRelayConn, data []byte) (int, error) {
@@ -79,23 +290,35 @@ func writePipelinedMtProtoChunkRelay(c *mtProtoChunkRelayConn, data []byte) (int
 		}
 		batch := specs[batchStart:batchEnd]
 		results := make(chan mtProtoChunkUploadResult, len(batch))
+		head := newMtProtoChunkRelayHeadTracker(batch[0].seq)
 
 		for _, spec := range batch {
 			spec := spec
 			go func() {
+				if err := acquireMtProtoChunkRelayPrimarySlot(c); err != nil {
+					results <- mtProtoChunkUploadResult{spec: spec, err: err}
+					return
+				}
+				defer releaseMtProtoChunkRelayPrimarySlot()
+
 				query := url.Values{
 					"sid": {c.sessionID},
 					"dst": {c.workerDst},
 					"seq": {strconv.FormatInt(spec.seq, 10)},
 				}
-				status, headers, _, err := c.requestWithRetry(
+				status, headers, _, err := c.requestPipelinedUploadWithRetry(
 					context.Background(),
-					"up",
 					query,
 					data[spec.start:spec.end],
-					"up",
 					spec.seq,
+					head,
 				)
+				if err == nil && status == http.StatusNoContent {
+					ack, ackErr := strconv.ParseInt(strings.TrimSpace(headers.Get("X-Tgws-Chunk-Ack")), 10, 64)
+					if ackErr == nil && ack == spec.seq {
+						head.markDone(spec.seq)
+					}
+				}
 				results <- mtProtoChunkUploadResult{spec: spec, status: status, headers: headers, err: err}
 			}()
 		}

--- a/native/tgwsproxy/mtproto_chunk_relay_pipeline_test.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_pipeline_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestChunkRelayPipelineStartsWindowBeforeWaitingForAck(t *testing.T) {
+	started := make(chan int64, mtProtoChunkRelayUpWindow)
+	release := make(chan struct{})
+
+	conn := newTestChunkRelayConn(t, func(_ context.Context, action string, query url.Values, _ []byte) (int, http.Header, []byte, error) {
+		if action != "up" {
+			t.Fatalf("action=%s", action)
+		}
+		seq, err := strconv.ParseInt(query.Get("seq"), 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		started <- seq
+		<-release
+		headers := make(http.Header)
+		headers.Set("X-Tgws-Chunk-Ack", strconv.FormatInt(seq, 10))
+		return http.StatusNoContent, headers, nil, nil
+	})
+
+	payload := make([]byte, mtProtoChunkRelayBytes*mtProtoChunkRelayUpWindow)
+	done := make(chan error, 1)
+	go func() {
+		_, err := writePipelinedMtProtoChunkRelay(conn, payload)
+		done <- err
+	}()
+
+	seqs := make([]int64, 0, mtProtoChunkRelayUpWindow)
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	for len(seqs) < mtProtoChunkRelayUpWindow {
+		select {
+		case seq := <-started:
+			seqs = append(seqs, seq)
+		case <-deadline.C:
+			t.Fatalf("only %d uploads started before ACK release: %v", len(seqs), seqs)
+		}
+	}
+
+	sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
+	for i, seq := range seqs {
+		want := int64(i + 1)
+		if seq != want {
+			t.Fatalf("seqs=%v want 1..%d", seqs, mtProtoChunkRelayUpWindow)
+		}
+	}
+
+	close(release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("pipeline write: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pipeline write did not complete")
+	}
+	if conn.upSeq != int64(mtProtoChunkRelayUpWindow) {
+		t.Fatalf("upSeq=%d want=%d", conn.upSeq, mtProtoChunkRelayUpWindow)
+	}
+	if conn.upBytes != int64(len(payload)) {
+		t.Fatalf("upBytes=%d want=%d", conn.upBytes, len(payload))
+	}
+}

--- a/native/tgwsproxy/mtproto_chunk_relay_pipeline_test.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_pipeline_test.go
@@ -72,3 +72,86 @@ func TestChunkRelayPipelineStartsWindowBeforeWaitingForAck(t *testing.T) {
 		t.Fatalf("upBytes=%d want=%d", conn.upBytes, len(payload))
 	}
 }
+
+func TestChunkRelaySlidingWindowRefillsAfterSingleAck(t *testing.T) {
+	const totalChunks = mtProtoChunkRelayUpWindow + 1
+
+	started := make(chan int64, totalChunks)
+	releases := make(map[int64]chan struct{}, totalChunks)
+	for seq := int64(1); seq <= totalChunks; seq++ {
+		releases[seq] = make(chan struct{})
+	}
+
+	conn := newTestChunkRelayConn(t, func(_ context.Context, action string, query url.Values, _ []byte) (int, http.Header, []byte, error) {
+		if action != "up" {
+			t.Fatalf("action=%s", action)
+		}
+		seq, err := strconv.ParseInt(query.Get("seq"), 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		started <- seq
+		<-releases[seq]
+		headers := make(http.Header)
+		headers.Set("X-Tgws-Chunk-Ack", strconv.FormatInt(seq, 10))
+		return http.StatusNoContent, headers, nil, nil
+	})
+
+	payload := make([]byte, mtProtoChunkRelayBytes*totalChunks)
+	done := make(chan error, 1)
+	go func() {
+		_, err := writePipelinedMtProtoChunkRelay(conn, payload)
+		done <- err
+	}()
+
+	seen := make(map[int64]bool, mtProtoChunkRelayUpWindow)
+	deadline := time.NewTimer(time.Second)
+	for len(seen) < mtProtoChunkRelayUpWindow {
+		select {
+		case seq := <-started:
+			seen[seq] = true
+		case <-deadline.C:
+			deadline.Stop()
+			t.Fatalf("only %d initial uploads started: %v", len(seen), seen)
+		}
+	}
+	deadline.Stop()
+
+	for seq := int64(1); seq <= mtProtoChunkRelayUpWindow; seq++ {
+		if !seen[seq] {
+			t.Fatalf("initial window missing seq=%d: %v", seq, seen)
+		}
+	}
+
+	// Release only seq=1. A fixed four-chunk batch would still wait for 2..4;
+	// a sliding window must immediately refill the freed slot with seq=5.
+	close(releases[1])
+	select {
+	case seq := <-started:
+		if seq != totalChunks {
+			t.Fatalf("next started seq=%d want=%d", seq, totalChunks)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sliding window did not launch seq=5 after seq=1 ACK")
+	}
+
+	for seq := int64(2); seq <= totalChunks; seq++ {
+		close(releases[seq])
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("pipeline write: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sliding pipeline write did not complete")
+	}
+
+	if conn.upSeq != totalChunks {
+		t.Fatalf("upSeq=%d want=%d", conn.upSeq, totalChunks)
+	}
+	if conn.upBytes != int64(len(payload)) {
+		t.Fatalf("upBytes=%d want=%d", conn.upBytes, len(payload))
+	}
+}

--- a/native/tgwsproxy/mtproto_chunk_relay_test.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func newTestChunkRelayConn(t *testing.T, request chunkRelayRequestFunc) *mtProtoChunkRelayConn {
+	t.Helper()
+	lifeCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &mtProtoChunkRelayConn{
+		domain:    "example.workers.dev",
+		sessionID: "session_test_123",
+		workerDst: "149.154.167.51",
+		request:   request,
+		lifeCtx:   lifeCtx,
+		cancel:    cancel,
+	}
+}
+
+func TestChunkRelayWriteRetriesSameSequence(t *testing.T) {
+	var mu sync.Mutex
+	var seqs []int64
+	var sizes []int
+	failedFirst := false
+	conn := newTestChunkRelayConn(t, func(_ context.Context, action string, query url.Values, body []byte) (int, http.Header, []byte, error) {
+		if action != "up" {
+			t.Fatalf("action=%s", action)
+		}
+		seq, err := strconv.ParseInt(query.Get("seq"), 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mu.Lock()
+		seqs = append(seqs, seq)
+		sizes = append(sizes, len(body))
+		if seq == 1 && !failedFirst {
+			failedFirst = true
+			mu.Unlock()
+			return 0, nil, nil, errors.New("synthetic timeout")
+		}
+		mu.Unlock()
+		headers := make(http.Header)
+		headers.Set("X-Tgws-Chunk-Ack", strconv.FormatInt(seq, 10))
+		return http.StatusNoContent, headers, nil, nil
+	})
+
+	payload := make([]byte, mtProtoChunkRelayBytes+808)
+	n, err := conn.Write(payload)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("n=%d want=%d", n, len(payload))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seqs) != 3 || seqs[0] != 1 || seqs[1] != 1 || seqs[2] != 2 {
+		t.Fatalf("seqs=%v", seqs)
+	}
+	if sizes[0] != mtProtoChunkRelayBytes || sizes[1] != mtProtoChunkRelayBytes || sizes[2] != 808 {
+		t.Fatalf("sizes=%v", sizes)
+	}
+}
+
+func TestChunkRelayReadAcknowledgesAfterBufferedChunkIsConsumed(t *testing.T) {
+	var mu sync.Mutex
+	var acks []string
+	calls := 0
+	conn := newTestChunkRelayConn(t, func(_ context.Context, action string, query url.Values, _ []byte) (int, http.Header, []byte, error) {
+		if action != "down" {
+			t.Fatalf("action=%s", action)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		acks = append(acks, query.Get("ack"))
+		calls++
+		if calls == 1 {
+			headers := make(http.Header)
+			headers.Set("X-Tgws-Chunk-Seq", "1")
+			return http.StatusOK, headers, []byte("abcdefgh"), nil
+		}
+		return http.StatusGone, make(http.Header), nil, nil
+	})
+
+	first := make([]byte, 3)
+	n, err := conn.Read(first)
+	if err != nil || n != 3 || string(first) != "abc" {
+		t.Fatalf("first n=%d err=%v data=%q", n, err, first)
+	}
+	second := make([]byte, 5)
+	n, err = conn.Read(second)
+	if err != nil || n != 5 || string(second) != "defgh" {
+		t.Fatalf("second n=%d err=%v data=%q", n, err, second)
+	}
+	if conn.ackSeq != 1 {
+		t.Fatalf("ackSeq=%d want=1", conn.ackSeq)
+	}
+
+	_, err = conn.Read(make([]byte, 1))
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("third err=%v want EOF", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(acks) != 2 || acks[0] != "0" || acks[1] != "1" {
+		t.Fatalf("acks=%v", acks)
+	}
+}
+
+func TestChunkRelayFrameSocketRequiresSessionAndDestination(t *testing.T) {
+	_, err := dialMtProtoChunkRelayFrameSocket(context.Background(), "example.workers.dev", "/apiws?sid=abc", "test")
+	if err == nil {
+		t.Fatal("expected missing destination error")
+	}
+}

--- a/scripts/cloudflare-worker/chunk-relay-window.test.mjs
+++ b/scripts/cloudflare-worker/chunk-relay-window.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = (await readFile(new URL("./chunk-relay-worker.js", import.meta.url), "utf8"))
+  .replace('import baseWorker from "./worker.js";', 'const baseWorker = { fetch() { return new Response("base", { status: 200 }); } };')
+  .replace('import { connect } from "cloudflare:sockets";', 'const connect = (...args) => globalThis.__chunkRelayConnect(...args);')
+  .replace('import { DurableObject } from "cloudflare:workers";', 'class DurableObject { constructor(ctx, env) { this.ctx = ctx; this.env = env; } }');
+
+const mod = await import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+
+function makeSocket(writes) {
+  return {
+    opened: Promise.resolve(),
+    writable: {
+      getWriter() {
+        return {
+          async write(data) {
+            writes.push(new Uint8Array(data).slice());
+          },
+        };
+      },
+    },
+    readable: {
+      getReader() {
+        return { read: () => new Promise(() => {}) };
+      },
+    },
+    async close() {},
+  };
+}
+
+function up(relay, seq, body) {
+  return relay.fetch(new Request(
+    `https://example.workers.dev/chunk-relay/up?sid=session_window_123&dst=149.154.167.51&seq=${seq}`,
+    { method: "POST", body },
+  ));
+}
+
+test("out-of-order pipelined uploads are written and acked in sequence", async (t) => {
+  const writes = [];
+  const oldConnect = globalThis.__chunkRelayConnect;
+  globalThis.__chunkRelayConnect = () => makeSocket(writes);
+  t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
+
+  const relay = new mod.ChunkRelaySession({}, {});
+  const open = await relay.fetch(new Request(
+    "https://example.workers.dev/chunk-relay/open?sid=session_window_123&dst=149.154.167.51",
+    { method: "POST" },
+  ));
+  assert.equal(open.status, 204);
+
+  const secondPromise = up(relay, 2, new Uint8Array([2, 2]));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(writes.length, 0);
+
+  const firstPromise = up(relay, 1, new Uint8Array([1, 1]));
+  const [second, first] = await Promise.all([secondPromise, firstPromise]);
+
+  assert.equal(first.status, 204);
+  assert.equal(second.status, 204);
+  assert.equal(first.headers.get("X-Tgws-Chunk-Ack"), "1");
+  assert.equal(second.headers.get("X-Tgws-Chunk-Ack"), "2");
+  assert.equal(writes.length, 2);
+  assert.deepEqual([...writes[0]], [1, 1]);
+  assert.deepEqual([...writes[1]], [2, 2]);
+});

--- a/scripts/cloudflare-worker/chunk-relay-worker.js
+++ b/scripts/cloudflare-worker/chunk-relay-worker.js
@@ -237,7 +237,7 @@ export default {
 
     if (url.pathname.startsWith("/chunk-relay/")) {
       const sid = (url.searchParams.get("sid") || "").trim();
-      if (!/^[A-Za-z0-9_-]{8,128}$/.test(sid)) return new Response("invalid sid", { status: 400 });
+      if (!/^[A-Za-z0-9_-]{8,128}$/.test(sid)) return new Response("invalid sid", { status: 400, headers: headers() });
       return env.CHUNK_RELAY.getByName(sid).fetch(request);
     }
     return baseWorker.fetch(request, env, ctx);

--- a/scripts/cloudflare-worker/chunk-relay-worker.js
+++ b/scripts/cloudflare-worker/chunk-relay-worker.js
@@ -2,8 +2,7 @@ import baseWorker from "./worker.js";
 import { connect } from "cloudflare:sockets";
 import { DurableObject } from "cloudflare:workers";
 
-const REVISION = "chunk-relay-dc2-v2";
-const TELEGRAM_DC2 = "149.154.167.51";
+const REVISION = "chunk-relay-mtproto-v3";
 const RELAY_MAX_CHUNK_BYTES = 8 * 1024;
 const DIAG_MAX_CHUNK_BYTES = 12 * 1024;
 const MAX_QUEUE_BYTES = 2 * 1024 * 1024;
@@ -18,18 +17,29 @@ function randomBytes(size) {
   return bytes;
 }
 
+function validTarget(value) {
+  const target = (value || "").trim();
+  return target.length >= 3 && target.length <= 64 && /^[0-9A-Fa-f:.]+$/.test(target);
+}
+
 export class ChunkRelaySession extends DurableObject {
   constructor(ctx, env) {
     super(ctx, env);
     this.socket = null;
     this.writer = null;
     this.reader = null;
+    this.target = "";
+    this.openPromise = null;
+    this.upChain = Promise.resolve();
     this.upSeq = 0;
+    this.upBytes = 0;
     this.downSeq = 0;
+    this.downBytes = 0;
     this.pending = null;
     this.queue = [];
     this.queueBytes = 0;
     this.waiters = new Set();
+    this.drainWaiters = new Set();
     this.closed = false;
   }
 
@@ -38,26 +48,70 @@ export class ChunkRelaySession extends DurableObject {
     this.waiters.clear();
   }
 
-  async ensureSocket() {
+  wakeDrain() {
+    for (const resolve of this.drainWaiters) resolve();
+    this.drainWaiters.clear();
+  }
+
+  async waitForDrain() {
+    if (this.queueBytes < MAX_QUEUE_BYTES || this.closed) return;
+    await new Promise((resolve) => this.drainWaiters.add(resolve));
+  }
+
+  async ensureSocket(targetRaw) {
+    const target = (targetRaw || "").trim();
+    if (!validTarget(target)) throw new Error("invalid_target");
+    if (this.closed) throw new Error("session_closed");
+    if (this.target && this.target !== target) throw new Error("target_mismatch");
     if (this.socket) return;
-    const socket = connect({ hostname: TELEGRAM_DC2, port: 443 }, { secureTransport: "off", allowHalfOpen: true });
-    await socket.opened;
-    this.socket = socket;
-    this.writer = socket.writable.getWriter();
-    this.reader = socket.readable.getReader();
-    this.pump().catch(() => { this.closed = true; this.wake(); });
+    if (this.openPromise) return this.openPromise;
+
+    this.openPromise = (async () => {
+      const socket = connect({ hostname: target, port: 443 }, { secureTransport: "off", allowHalfOpen: true });
+      await socket.opened;
+      if (this.closed) {
+        try { await socket.close(); } catch {}
+        throw new Error("session_closed");
+      }
+      this.target = target;
+      this.socket = socket;
+      this.writer = socket.writable.getWriter();
+      this.reader = socket.readable.getReader();
+      console.log("chunk relay opened", { revision: REVISION, target });
+      this.pump().catch((error) => {
+        console.log("chunk relay pump failed", { revision: REVISION, target, error: String(error) });
+        this.closed = true;
+        this.wake();
+        this.wakeDrain();
+      });
+    })();
+
+    try {
+      await this.openPromise;
+    } finally {
+      this.openPromise = null;
+    }
   }
 
   async pump() {
     while (!this.closed) {
       const { value, done } = await this.reader.read();
-      if (done) { this.closed = true; this.wake(); return; }
+      if (done) {
+        this.closed = true;
+        this.wake();
+        this.wakeDrain();
+        return;
+      }
       const bytes = value instanceof Uint8Array ? value : new Uint8Array(value || 0);
       for (let offset = 0; offset < bytes.byteLength; offset += RELAY_MAX_CHUNK_BYTES) {
         const chunk = bytes.slice(offset, Math.min(offset + RELAY_MAX_CHUNK_BYTES, bytes.byteLength));
-        if (this.queueBytes + chunk.byteLength > MAX_QUEUE_BYTES) throw new Error("queue_limit");
+        while (!this.closed && this.queueBytes + chunk.byteLength > MAX_QUEUE_BYTES) {
+          await this.waitForDrain();
+        }
+        if (this.closed) return;
         this.queue.push(chunk);
         this.queueBytes += chunk.byteLength;
+        this.downBytes += chunk.byteLength;
       }
       this.wake();
     }
@@ -72,45 +126,93 @@ export class ChunkRelaySession extends DurableObject {
     });
   }
 
+  async handleUp(request, url) {
+    const seq = Number.parseInt(url.searchParams.get("seq") || "0", 10);
+    if (!Number.isSafeInteger(seq) || seq <= 0) return new Response("bad seq", { status: 400, headers: headers() });
+    if (!this.socket && this.upSeq === 0 && seq > 1) return new Response("session lost", { status: 410, headers: headers() });
+
+    const run = async () => {
+      await this.ensureSocket(url.searchParams.get("dst"));
+      if (seq <= this.upSeq) {
+        return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
+      }
+      if (seq !== this.upSeq + 1) return new Response("sequence gap", { status: 409, headers: headers() });
+      const body = new Uint8Array(await request.arrayBuffer());
+      if (!body.byteLength || body.byteLength > RELAY_MAX_CHUNK_BYTES) return new Response("bad size", { status: 413, headers: headers() });
+      await this.writer.write(body);
+      this.upSeq = seq;
+      this.upBytes += body.byteLength;
+      if (seq <= 2 || this.upBytes % (64 * 1024) < body.byteLength) {
+        console.log("chunk relay up", { revision: REVISION, target: this.target, seq, bytes: body.byteLength, up_bytes: this.upBytes });
+      }
+      return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
+    };
+
+    const result = this.upChain.then(run, run);
+    this.upChain = result.then(() => undefined, () => undefined);
+    return result;
+  }
+
   async fetch(request) {
     const url = new URL(request.url);
     const action = url.pathname.split("/").filter(Boolean).at(-1) || "";
-    if (action === "open") {
-      await this.ensureSocket();
-      return new Response(null, { status: 204, headers: headers() });
-    }
-    if (action === "up") {
-      await this.ensureSocket();
-      const seq = Number.parseInt(url.searchParams.get("seq") || "0", 10);
-      if (!Number.isSafeInteger(seq) || seq <= 0) return new Response("bad seq", { status: 400 });
-      if (seq <= this.upSeq) return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
-      if (seq !== this.upSeq + 1) return new Response("sequence gap", { status: 409 });
-      const body = new Uint8Array(await request.arrayBuffer());
-      if (!body.byteLength || body.byteLength > RELAY_MAX_CHUNK_BYTES) return new Response("bad size", { status: 413 });
-      await this.writer.write(body);
-      this.upSeq = seq;
-      return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
-    }
-    if (action === "down") {
-      await this.ensureSocket();
-      const ack = Number.parseInt(url.searchParams.get("ack") || "0", 10);
-      if (this.pending && ack === this.pending.seq) this.pending = null;
-      await this.wait(Number.parseInt(url.searchParams.get("wait") || "0", 10));
-      if (!this.pending && this.queue.length) {
-        const data = this.queue.shift();
-        this.queueBytes -= data.byteLength;
-        this.pending = { seq: ++this.downSeq, data };
+
+    try {
+      if (action === "open") {
+        if (request.method !== "POST") return new Response("method", { status: 405, headers: headers() });
+        await this.ensureSocket(url.searchParams.get("dst"));
+        return new Response(null, { status: 204, headers: headers() });
       }
-      if (this.pending) return new Response(this.pending.data, { status: 200, headers: headers({ "Content-Type": "application/octet-stream", "X-Tgws-Chunk-Seq": String(this.pending.seq) }) });
-      if (this.closed) return new Response("closed", { status: 410, headers: headers() });
-      return new Response(null, { status: 204, headers: headers() });
+
+      if (action === "up") {
+        if (request.method !== "POST") return new Response("method", { status: 405, headers: headers() });
+        return await this.handleUp(request, url);
+      }
+
+      if (action === "down") {
+        if (request.method !== "GET") return new Response("method", { status: 405, headers: headers() });
+        const ack = Number.parseInt(url.searchParams.get("ack") || "0", 10);
+        if (!Number.isSafeInteger(ack) || ack < 0) return new Response("bad ack", { status: 400, headers: headers() });
+        if (!this.socket && ack > 0) return new Response("session lost", { status: 410, headers: headers() });
+        await this.ensureSocket(url.searchParams.get("dst"));
+        if (this.pending && ack === this.pending.seq) this.pending = null;
+        await this.wait(Number.parseInt(url.searchParams.get("wait") || "0", 10));
+        if (!this.pending && this.queue.length) {
+          const data = this.queue.shift();
+          this.queueBytes -= data.byteLength;
+          this.wakeDrain();
+          this.pending = { seq: ++this.downSeq, data };
+        }
+        if (this.pending) {
+          return new Response(this.pending.data, {
+            status: 200,
+            headers: headers({ "Content-Type": "application/octet-stream", "X-Tgws-Chunk-Seq": String(this.pending.seq) }),
+          });
+        }
+        if (this.closed) return new Response("closed", { status: 410, headers: headers() });
+        return new Response(null, { status: 204, headers: headers() });
+      }
+
+      if (action === "close") {
+        this.closed = true;
+        this.wake();
+        this.wakeDrain();
+        try { await this.socket?.close(); } catch {}
+        console.log("chunk relay closed", {
+          revision: REVISION,
+          target: this.target,
+          up_seq: this.upSeq,
+          up_bytes: this.upBytes,
+          down_seq: this.downSeq,
+          down_bytes: this.downBytes,
+        });
+        return new Response(null, { status: 204, headers: headers() });
+      }
+    } catch (error) {
+      console.log("chunk relay request failed", { revision: REVISION, action, target: this.target, error: String(error) });
+      return new Response("relay failed", { status: 502, headers: headers() });
     }
-    if (action === "close") {
-      this.closed = true;
-      this.wake();
-      try { await this.socket?.close(); } catch {}
-      return new Response(null, { status: 204, headers: headers() });
-    }
+
     return new Response("not found", { status: 404, headers: headers() });
   }
 }
@@ -134,7 +236,7 @@ export default {
 
     if (url.pathname.startsWith("/chunk-relay/")) {
       const sid = (url.searchParams.get("sid") || "").trim();
-      if (!/^[A-Za-z0-9_-]{8,128}$/.test(sid)) return new Response("invalid sid", { status: 400 });
+      if (!/^[A-Za-z0-9_-]{8,128}$/.test(sid)) return new Response("invalid sid", { status: 400, headers: headers() });
       return env.CHUNK_RELAY.getByName(sid).fetch(request);
     }
     return baseWorker.fetch(request, env, ctx);

--- a/scripts/cloudflare-worker/chunk-relay-worker.js
+++ b/scripts/cloudflare-worker/chunk-relay-worker.js
@@ -2,11 +2,12 @@ import baseWorker from "./worker.js";
 import { connect } from "cloudflare:sockets";
 import { DurableObject } from "cloudflare:workers";
 
-const REVISION = "chunk-relay-mtproto-v4";
+const REVISION = "chunk-relay-mtproto-v5";
 const RELAY_MAX_CHUNK_BYTES = 8 * 1024;
 const DIAG_MAX_CHUNK_BYTES = 12 * 1024;
 const MAX_QUEUE_BYTES = 2 * 1024 * 1024;
 const MAX_POLL_WAIT_MS = 6000;
+const MAX_UPLOAD_REORDER_WINDOW = 16;
 
 function headers(extra = {}) {
   return { "Cache-Control": "no-store", "X-Tgws-Chunk-Relay-Revision": REVISION, ...extra };
@@ -23,6 +24,16 @@ function validTarget(value) {
   return target.length >= 3 && target.length <= 64 && /^[0-9A-Fa-f:.]+$/.test(target);
 }
 
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 export class ChunkRelaySession extends DurableObject {
   constructor(ctx, env) {
     super(ctx, env);
@@ -34,6 +45,7 @@ export class ChunkRelaySession extends DurableObject {
     this.upChain = Promise.resolve();
     this.upSeq = 0;
     this.upBytes = 0;
+    this.upPending = new Map();
     this.downSeq = 0;
     this.downBytes = 0;
     this.pending = null;
@@ -52,6 +64,11 @@ export class ChunkRelaySession extends DurableObject {
   wakeDrain() {
     for (const resolve of this.drainWaiters) resolve();
     this.drainWaiters.clear();
+  }
+
+  rejectPendingUploads(error) {
+    for (const entry of this.upPending.values()) entry.done.reject(error);
+    this.upPending.clear();
   }
 
   async waitForDrain() {
@@ -82,6 +99,7 @@ export class ChunkRelaySession extends DurableObject {
       this.pump().catch((error) => {
         console.log("chunk relay pump failed", { revision: REVISION, target, error: String(error) });
         this.closed = true;
+        this.rejectPendingUploads(error);
         this.wake();
         this.wakeDrain();
       });
@@ -99,6 +117,7 @@ export class ChunkRelaySession extends DurableObject {
       const { value, done } = await this.reader.read();
       if (done) {
         this.closed = true;
+        this.rejectPendingUploads(new Error("upstream_closed"));
         this.wake();
         this.wakeDrain();
         return;
@@ -127,31 +146,81 @@ export class ChunkRelaySession extends DurableObject {
     });
   }
 
+  async drainUploads() {
+    while (!this.closed) {
+      const nextSeq = this.upSeq + 1;
+      const entry = this.upPending.get(nextSeq);
+      if (!entry) return;
+
+      try {
+        await this.writer.write(entry.data);
+      } catch (error) {
+        this.closed = true;
+        entry.done.reject(error);
+        this.upPending.delete(nextSeq);
+        this.rejectPendingUploads(error);
+        this.wake();
+        this.wakeDrain();
+        throw error;
+      }
+
+      this.upPending.delete(nextSeq);
+      this.upSeq = nextSeq;
+      this.upBytes += entry.data.byteLength;
+      entry.done.resolve();
+      if (nextSeq <= 2 || this.upBytes % (64 * 1024) < entry.data.byteLength) {
+        console.log("chunk relay up", {
+          revision: REVISION,
+          target: this.target,
+          seq: nextSeq,
+          bytes: entry.data.byteLength,
+          up_bytes: this.upBytes,
+          pending_uploads: this.upPending.size,
+        });
+      }
+    }
+  }
+
   async handleUp(request, url) {
     const seq = Number.parseInt(url.searchParams.get("seq") || "0", 10);
     if (!Number.isSafeInteger(seq) || seq <= 0) return new Response("bad seq", { status: 400, headers: headers() });
-    if (!this.socket && this.upSeq === 0 && seq > 1) return new Response("session lost", { status: 410, headers: headers() });
+    if (!this.socket && this.upSeq === 0 && seq > MAX_UPLOAD_REORDER_WINDOW) {
+      return new Response("session lost", { status: 410, headers: headers() });
+    }
 
-    const run = async () => {
+    const body = new Uint8Array(await request.arrayBuffer());
+    if (!body.byteLength || body.byteLength > RELAY_MAX_CHUNK_BYTES) {
+      return new Response("bad size", { status: 413, headers: headers() });
+    }
+
+    const admit = async () => {
       await this.ensureSocket(url.searchParams.get("dst"));
-      if (seq <= this.upSeq) {
-        return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
+      if (seq <= this.upSeq) return { immediate: true };
+      if (seq > this.upSeq + MAX_UPLOAD_REORDER_WINDOW) return { status: 409 };
+
+      let entry = this.upPending.get(seq);
+      if (!entry) {
+        entry = { data: body, done: deferred() };
+        this.upPending.set(seq, entry);
       }
-      if (seq !== this.upSeq + 1) return new Response("sequence gap", { status: 409, headers: headers() });
-      const body = new Uint8Array(await request.arrayBuffer());
-      if (!body.byteLength || body.byteLength > RELAY_MAX_CHUNK_BYTES) return new Response("bad size", { status: 413, headers: headers() });
-      await this.writer.write(body);
-      this.upSeq = seq;
-      this.upBytes += body.byteLength;
-      if (seq <= 2 || this.upBytes % (64 * 1024) < body.byteLength) {
-        console.log("chunk relay up", { revision: REVISION, target: this.target, seq, bytes: body.byteLength, up_bytes: this.upBytes });
-      }
-      return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
+
+      await this.drainUploads();
+      return { entry };
     };
 
-    const result = this.upChain.then(run, run);
-    this.upChain = result.then(() => undefined, () => undefined);
-    return result;
+    const admittedPromise = this.upChain.then(admit, admit);
+    this.upChain = admittedPromise.then(() => undefined, () => undefined);
+    const admitted = await admittedPromise;
+
+    if (admitted.immediate) {
+      return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
+    }
+    if (admitted.status) {
+      return new Response("sequence window", { status: admitted.status, headers: headers() });
+    }
+
+    await admitted.entry.done.promise;
+    return new Response(null, { status: 204, headers: headers({ "X-Tgws-Chunk-Ack": String(seq) }) });
   }
 
   async fetch(request) {
@@ -196,6 +265,7 @@ export class ChunkRelaySession extends DurableObject {
 
       if (action === "close") {
         this.closed = true;
+        this.rejectPendingUploads(new Error("session_closed"));
         this.wake();
         this.wakeDrain();
         try { await this.socket?.close(); } catch {}

--- a/scripts/cloudflare-worker/chunk-relay-worker.js
+++ b/scripts/cloudflare-worker/chunk-relay-worker.js
@@ -2,10 +2,11 @@ import baseWorker from "./worker.js";
 import { connect } from "cloudflare:sockets";
 import { DurableObject } from "cloudflare:workers";
 
-const REVISION = "chunk-relay-mtproto-v3";
+const REVISION = "chunk-relay-mtproto-v4";
 const RELAY_MAX_CHUNK_BYTES = 8 * 1024;
 const DIAG_MAX_CHUNK_BYTES = 12 * 1024;
 const MAX_QUEUE_BYTES = 2 * 1024 * 1024;
+const MAX_POLL_WAIT_MS = 6000;
 
 function headers(extra = {}) {
   return { "Cache-Control": "no-store", "X-Tgws-Chunk-Relay-Revision": REVISION, ...extra };
@@ -121,7 +122,7 @@ export class ChunkRelaySession extends DurableObject {
     if (this.pending || this.queue.length || this.closed) return;
     await new Promise((resolve) => {
       const done = () => { clearTimeout(timer); this.waiters.delete(done); resolve(); };
-      const timer = setTimeout(done, Math.min(Math.max(ms, 0), 1000));
+      const timer = setTimeout(done, Math.min(Math.max(ms, 0), MAX_POLL_WAIT_MS));
       this.waiters.add(done);
     });
   }
@@ -236,7 +237,7 @@ export default {
 
     if (url.pathname.startsWith("/chunk-relay/")) {
       const sid = (url.searchParams.get("sid") || "").trim();
-      if (!/^[A-Za-z0-9_-]{8,128}$/.test(sid)) return new Response("invalid sid", { status: 400, headers: headers() });
+      if (!/^[A-Za-z0-9_-]{8,128}$/.test(sid)) return new Response("invalid sid", { status: 400 });
       return env.CHUNK_RELAY.getByName(sid).fetch(request);
     }
     return baseWorker.fetch(request, env, ctx);

--- a/scripts/cloudflare-worker/chunk-relay-worker.test.mjs
+++ b/scripts/cloudflare-worker/chunk-relay-worker.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = (await readFile(new URL("./chunk-relay-worker.js", import.meta.url), "utf8"))
+  .replace('import baseWorker from "./worker.js";', 'const baseWorker = { fetch() { return new Response("base", { status: 200 }); } };')
+  .replace('import { connect } from "cloudflare:sockets";', 'const connect = (...args) => globalThis.__chunkRelayConnect(...args);')
+  .replace('import { DurableObject } from "cloudflare:workers";', 'class DurableObject { constructor(ctx, env) { this.ctx = ctx; this.env = env; } }');
+
+const mod = await import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+
+function makeSocket(writes) {
+  return {
+    opened: Promise.resolve(),
+    writable: {
+      getWriter() {
+        return {
+          async write(data) { writes.push(new Uint8Array(data).slice()); },
+        };
+      },
+    },
+    readable: {
+      getReader() {
+        return { read: () => new Promise(() => {}) };
+      },
+    },
+    async close() {},
+  };
+}
+
+test("duplicate upload sequence is written only once", async (t) => {
+  const writes = [];
+  const oldConnect = globalThis.__chunkRelayConnect;
+  globalThis.__chunkRelayConnect = ({ hostname }) => {
+    assert.equal(hostname, "149.154.167.51");
+    return makeSocket(writes);
+  };
+  t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
+
+  const relay = new mod.ChunkRelaySession({}, {});
+  const open = await relay.fetch(new Request(
+    "https://example.workers.dev/chunk-relay/open?sid=session_test_123&dst=149.154.167.51",
+    { method: "POST" },
+  ));
+  assert.equal(open.status, 204);
+
+  const body = new Uint8Array([1, 2, 3, 4]);
+  const makeUp = () => relay.fetch(new Request(
+    "https://example.workers.dev/chunk-relay/up?sid=session_test_123&dst=149.154.167.51&seq=1",
+    { method: "POST", body },
+  ));
+
+  const [first, retry] = await Promise.all([makeUp(), makeUp()]);
+  assert.equal(first.status, 204);
+  assert.equal(retry.status, 204);
+  assert.equal(first.headers.get("X-Tgws-Chunk-Ack"), "1");
+  assert.equal(retry.headers.get("X-Tgws-Chunk-Ack"), "1");
+  assert.equal(writes.length, 1);
+  assert.deepEqual([...writes[0]], [...body]);
+});
+
+test("relay binds a session to one target", async (t) => {
+  const writes = [];
+  const oldConnect = globalThis.__chunkRelayConnect;
+  globalThis.__chunkRelayConnect = () => makeSocket(writes);
+  t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
+
+  const relay = new mod.ChunkRelaySession({}, {});
+  const first = await relay.fetch(new Request(
+    "https://example.workers.dev/chunk-relay/open?sid=session_test_456&dst=149.154.167.51",
+    { method: "POST" },
+  ));
+  assert.equal(first.status, 204);
+
+  const second = await relay.fetch(new Request(
+    "https://example.workers.dev/chunk-relay/open?sid=session_test_456&dst=149.154.167.91",
+    { method: "POST" },
+  ));
+  assert.equal(second.status, 502);
+});


### PR DESCRIPTION
## Цель

Следующий этап после PR #47: проверить настоящий Telegram/MTProto трафик через подтверждённый short-connection workaround вместо постоянного Worker WebSocket.

PR остаётся **draft** и основан на #47. Production/main не затрагивается.

## Реализация

- Worker route в этой экспериментальной ветке переключён с одного долгоживущего WSS на `chunk_relay_http`.
- Существующий MTProto frontend и re-encryption не меняются: `relay_init` и последующий преобразованный byte stream проходят через тот же `mtProtoFrameSocket` контракт.
- Android/native → Worker:
  - chunks максимум 8 KiB;
  - новый HTTP/1.1 + TLS connection на каждый request;
  - `Connection: close`;
  - до 3 retry того же `seq`;
  - backoff 300/600/1200 ms;
  - Worker ACK обязателен до подтверждения `Write`.
- Worker → Android/native:
  - fresh GET long-poll requests;
  - sequence + explicit ack;
  - chunk считается подтверждённым только после полного потребления локальным `Read` buffer.
- Durable Object держит один непрерывный TCP socket к фактическому `worker_dst` текущей MTProto-сессии.
- `dst` больше не захардкожен на DC2; сессия привязывается к первому target и отклоняет target mismatch.
- Повтор одного upload `seq` сериализован через `upChain`, чтобы timeout + retry не мог дважды записать один chunk в Telegram TCP stream.
- Downstream queue получил backpressure вместо аварийного закрытия при временном отставании клиента.
- Session loss после DO restart/eviction для уже начатой последовательности возвращает HTTP 410 вместо молчаливого подключения нового Telegram TCP stream.

## Диагностика

Логи содержат `transport=chunk_relay_http`, `session_id`, `worker_dst`, upload/download seq и cumulative bytes, а также retries. Payload не логируется.

## Тесты

- Go: retry сохраняет тот же upload `seq`; buffered downstream ACK отправляется только после полного потребления chunk.
- Worker: параллельный retry одного upload `seq` приводит только к одному `writer.write`; target session binding проверяется отдельно.

## Device test

Нужен реальный Telegram-прогон без AWG/WARP/VPN:

1. deploy `wrangler.chunk-relay.jsonc`;
2. собрать/install APK этой ветки;
3. Worker-only route на `tgproxy.carkov195.workers.dev`;
4. проверить обычное подключение;
5. отправить/скачать новый файл 20+ MiB;
6. приложить runtime log с `MTProto Worker chunk relay ...`.

Draft: не сливать до device result.

Relates #29
Depends on #47