### PR TITLE
[experiment][#29] Test 12 KiB sliding relay with lower concurrency

### DIFF
--- a/native/tgwsproxy/mtproto_chunk_relay_frames.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_frames.go
@@ -32,9 +32,10 @@ func dialMtProtoChunkRelayFrameSocket(ctx context.Context, domain, path, logPref
 		enableMtProtoChunkRelayRequestLimit(chunkConn)
 		if logInfo != nil {
 			logInfo.Printf(
-				"%s MTProto Worker chunk relay upload pipeline session_id=%s window=%d primary_requests=%d global_http_requests=%d hol_hedge_delay_ms=%d hedge_policy=oldest_unacked",
+				"%s MTProto Worker chunk relay upload pipeline session_id=%s upload_chunk_bytes=%d window=%d primary_requests=%d global_http_requests=%d hol_hedge_delay_ms=%d hedge_policy=oldest_unacked",
 				logPrefix,
 				sessionID,
+				mtProtoChunkRelayUploadBytes,
 				mtProtoChunkRelayUpWindow,
 				mtProtoChunkRelayPrimaryRequests,
 				mtProtoChunkRelayGlobalHTTPRequests,

--- a/native/tgwsproxy/mtproto_chunk_relay_hol_hedge_test.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_hol_hedge_test.go
@@ -42,7 +42,7 @@ func TestChunkRelayPipelineHedgesOnlyOldestUnacked(t *testing.T) {
 		return http.StatusNoContent, headers, nil, nil
 	})
 
-	payload := make([]byte, mtProtoChunkRelayBytes*mtProtoChunkRelayUpWindow)
+	payload := make([]byte, mtProtoChunkRelayUploadBytes*mtProtoChunkRelayUpWindow)
 	started := time.Now()
 	n, err := writePipelinedMtProtoChunkRelay(conn, payload)
 	if err != nil {

--- a/native/tgwsproxy/mtproto_chunk_relay_pipeline.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_pipeline.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	mtProtoChunkRelayUploadBytes       = 12 * 1024
 	mtProtoChunkRelayUpWindow           = 4
 	mtProtoChunkRelayPrimaryRequests    = 16
 	mtProtoChunkRelayGlobalHTTPRequests = 24
@@ -269,10 +270,10 @@ func writePipelinedMtProtoChunkRelay(c *mtProtoChunkRelayConn, data []byte) (int
 		return 0, net.ErrClosed
 	}
 
-	specs := make([]mtProtoChunkUploadSpec, 0, (len(data)+mtProtoChunkRelayBytes-1)/mtProtoChunkRelayBytes)
+	specs := make([]mtProtoChunkUploadSpec, 0, (len(data)+mtProtoChunkRelayUploadBytes-1)/mtProtoChunkRelayUploadBytes)
 	baseSeq := c.upSeq
-	for start := 0; start < len(data); start += mtProtoChunkRelayBytes {
-		end := start + mtProtoChunkRelayBytes
+	for start := 0; start < len(data); start += mtProtoChunkRelayUploadBytes {
+		end := start + mtProtoChunkRelayUploadBytes
 		if end > len(data) {
 			end = len(data)
 		}
@@ -375,11 +376,12 @@ func writePipelinedMtProtoChunkRelay(c *mtProtoChunkRelayConn, data []byte) (int
 
 			if logInfo != nil && (spec.seq <= 2 || c.upBytes%(64*1024) < int64(chunkBytes)) {
 				logInfo.Printf(
-					"MTProto Worker chunk relay up session_id=%s seq=%d bytes=%d confirmed_bytes=%d upload_window=%d pipeline=%s",
+					"MTProto Worker chunk relay up session_id=%s seq=%d bytes=%d confirmed_bytes=%d upload_chunk_bytes=%d upload_window=%d pipeline=%s",
 					c.sessionID,
 					spec.seq,
 					chunkBytes,
 					c.upBytes,
+					mtProtoChunkRelayUploadBytes,
 					mtProtoChunkRelayUpWindow,
 					mtProtoChunkRelayPipelineMode,
 				)

--- a/native/tgwsproxy/mtproto_chunk_relay_pipeline.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_pipeline.go
@@ -15,10 +15,10 @@ import (
 
 const (
 	mtProtoChunkRelayUploadBytes       = 12 * 1024
-	mtProtoChunkRelayUpWindow           = 4
-	mtProtoChunkRelayPrimaryRequests    = 16
-	mtProtoChunkRelayGlobalHTTPRequests = 24
-	mtProtoChunkRelayPipelineMode       = "sliding"
+	mtProtoChunkRelayUpWindow          = 2
+	mtProtoChunkRelayPrimaryRequests   = 8
+	mtProtoChunkRelayGlobalHTTPRequests = 12
+	mtProtoChunkRelayPipelineMode      = "sliding-w2"
 )
 
 var (

--- a/native/tgwsproxy/mtproto_chunk_relay_pipeline_test.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
@@ -29,7 +30,7 @@ func TestChunkRelayPipelineStartsWindowBeforeWaitingForAck(t *testing.T) {
 		return http.StatusNoContent, headers, nil, nil
 	})
 
-	payload := make([]byte, mtProtoChunkRelayBytes*mtProtoChunkRelayUpWindow)
+	payload := make([]byte, mtProtoChunkRelayUploadBytes*mtProtoChunkRelayUpWindow)
 	done := make(chan error, 1)
 	go func() {
 		_, err := writePipelinedMtProtoChunkRelay(conn, payload)
@@ -97,7 +98,7 @@ func TestChunkRelaySlidingWindowRefillsAfterSingleAck(t *testing.T) {
 		return http.StatusNoContent, headers, nil, nil
 	})
 
-	payload := make([]byte, mtProtoChunkRelayBytes*totalChunks)
+	payload := make([]byte, mtProtoChunkRelayUploadBytes*totalChunks)
 	done := make(chan error, 1)
 	go func() {
 		_, err := writePipelinedMtProtoChunkRelay(conn, payload)
@@ -153,5 +154,45 @@ func TestChunkRelaySlidingWindowRefillsAfterSingleAck(t *testing.T) {
 	}
 	if conn.upBytes != int64(len(payload)) {
 		t.Fatalf("upBytes=%d want=%d", conn.upBytes, len(payload))
+	}
+}
+
+func TestChunkRelayPipelineUses12KiBUploadChunks(t *testing.T) {
+	if mtProtoChunkRelayUploadBytes != 12*1024 {
+		t.Fatalf("upload chunk bytes=%d want=%d", mtProtoChunkRelayUploadBytes, 12*1024)
+	}
+
+	var mu sync.Mutex
+	var sizes []int
+	conn := newTestChunkRelayConn(t, func(_ context.Context, action string, query url.Values, body []byte) (int, http.Header, []byte, error) {
+		if action != "up" {
+			t.Fatalf("action=%s", action)
+		}
+		seq, err := strconv.ParseInt(query.Get("seq"), 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mu.Lock()
+		sizes = append(sizes, len(body))
+		mu.Unlock()
+		headers := make(http.Header)
+		headers.Set("X-Tgws-Chunk-Ack", strconv.FormatInt(seq, 10))
+		return http.StatusNoContent, headers, nil, nil
+	})
+
+	payload := make([]byte, mtProtoChunkRelayUploadBytes+100)
+	n, err := writePipelinedMtProtoChunkRelay(conn, payload)
+	if err != nil {
+		t.Fatalf("pipeline write: %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("n=%d want=%d", n, len(payload))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	sort.Ints(sizes)
+	if len(sizes) != 2 || sizes[0] != 100 || sizes[1] != mtProtoChunkRelayUploadBytes {
+		t.Fatalf("sizes=%v", sizes)
 	}
 }

--- a/scripts/cloudflare-worker/chunk-relay-worker.js
+++ b/scripts/cloudflare-worker/chunk-relay-worker.js
@@ -2,8 +2,9 @@ import baseWorker from "./worker.js";
 import { connect } from "cloudflare:sockets";
 import { DurableObject } from "cloudflare:workers";
 
-const REVISION = "chunk-relay-mtproto-v5";
-const RELAY_MAX_CHUNK_BYTES = 8 * 1024;
+const REVISION = "chunk-relay-mtproto-v6";
+const RELAY_MAX_UPLOAD_CHUNK_BYTES = 12 * 1024;
+const RELAY_MAX_DOWN_CHUNK_BYTES = 8 * 1024;
 const DIAG_MAX_CHUNK_BYTES = 12 * 1024;
 const MAX_QUEUE_BYTES = 2 * 1024 * 1024;
 const MAX_POLL_WAIT_MS = 6000;
@@ -71,8 +72,8 @@ export class ChunkRelaySession extends DurableObject {
     this.upPending.clear();
   }
 
-  async waitForDrain() {
-    if (this.queueBytes < MAX_QUEUE_BYTES || this.closed) return;
+  async waitForDrain(requiredBytes) {
+    if (this.queueBytes + requiredBytes <= MAX_QUEUE_BYTES || this.closed) return;
     await new Promise((resolve) => this.drainWaiters.add(resolve));
   }
 
@@ -123,10 +124,10 @@ export class ChunkRelaySession extends DurableObject {
         return;
       }
       const bytes = value instanceof Uint8Array ? value : new Uint8Array(value || 0);
-      for (let offset = 0; offset < bytes.byteLength; offset += RELAY_MAX_CHUNK_BYTES) {
-        const chunk = bytes.slice(offset, Math.min(offset + RELAY_MAX_CHUNK_BYTES, bytes.byteLength));
+      for (let offset = 0; offset < bytes.byteLength; offset += RELAY_MAX_DOWN_CHUNK_BYTES) {
+        const chunk = bytes.slice(offset, Math.min(offset + RELAY_MAX_DOWN_CHUNK_BYTES, bytes.byteLength));
         while (!this.closed && this.queueBytes + chunk.byteLength > MAX_QUEUE_BYTES) {
-          await this.waitForDrain();
+          await this.waitForDrain(chunk.byteLength);
         }
         if (this.closed) return;
         this.queue.push(chunk);
@@ -189,7 +190,7 @@ export class ChunkRelaySession extends DurableObject {
     }
 
     const body = new Uint8Array(await request.arrayBuffer());
-    if (!body.byteLength || body.byteLength > RELAY_MAX_CHUNK_BYTES) {
+    if (!body.byteLength || body.byteLength > RELAY_MAX_UPLOAD_CHUNK_BYTES) {
       return new Response("bad size", { status: 413, headers: headers() });
     }
 

--- a/scripts/cloudflare-worker/chunk-relay-worker.test.mjs
+++ b/scripts/cloudflare-worker/chunk-relay-worker.test.mjs
@@ -78,3 +78,48 @@ test("relay binds a session to one target", async (t) => {
   ));
   assert.equal(second.status, 502);
 });
+
+test("relay accepts 12 KiB upload chunks and rejects larger bodies", async (t) => {
+  const writes = [];
+  const oldConnect = globalThis.__chunkRelayConnect;
+  globalThis.__chunkRelayConnect = () => makeSocket(writes);
+  t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
+
+  const relay = new mod.ChunkRelaySession({}, {});
+  const open = await relay.fetch(new Request(
+    "https://example.workers.dev/chunk-relay/open?sid=session_size_123&dst=149.154.167.51",
+    { method: "POST" },
+  ));
+  assert.equal(open.status, 204);
+
+  const ok = await relay.fetch(new Request(
+    "https://example.workers.dev/chunk-relay/up?sid=session_size_123&dst=149.154.167.51&seq=1",
+    { method: "POST", body: new Uint8Array(12 * 1024) },
+  ));
+  assert.equal(ok.status, 204);
+  assert.equal(ok.headers.get("X-Tgws-Chunk-Ack"), "1");
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].byteLength, 12 * 1024);
+
+  const tooLarge = await relay.fetch(new Request(
+    "https://example.workers.dev/chunk-relay/up?sid=session_size_123&dst=149.154.167.51&seq=2",
+    { method: "POST", body: new Uint8Array(12 * 1024 + 1) },
+  ));
+  assert.equal(tooLarge.status, 413);
+  assert.equal(writes.length, 1);
+});
+
+test("backpressure waits when the next downstream chunk would exceed the queue limit", async () => {
+  const relay = new mod.ChunkRelaySession({}, {});
+  relay.queueBytes = 2 * 1024 * 1024 - 1;
+
+  let resolved = false;
+  const wait = relay.waitForDrain(2).then(() => { resolved = true; });
+  await Promise.resolve();
+  assert.equal(resolved, false);
+
+  relay.queueBytes -= 2;
+  relay.wakeDrain();
+  await wait;
+  assert.equal(resolved, true);
+});


### PR DESCRIPTION
## Цель

Проверить гипотезу из device-прогона v6: 12 KiB заметно повышает стартовую пропускную способность, но window=4 / primary=16 / global=24 со временем создаёт слишком высокий churn коротких HTTPS/TLS соединений и средняя скорость деградирует.

## A/B профиль

- upload chunk: 12 KiB;
- sliding window: 2 вместо 4;
- primary request limit: 8 вместо 16;
- global HTTP request limit: 12 вместо 24;
- HOL hedge: 900 ms, policy `oldest_unacked` — без изменений;
- retry/backoff и ordered Worker write — без изменений;
- pipeline diagnostic mode: `sliding-w2`.

## Что измеряем

Сравнивать с предыдущим v6 / 12 KiB / window=4 на том же Worker и том же файле:

- throughput по окнам 30/60/90/120/150 s;
- upload retry rate;
- hedge / hedge-won ratio;
- наличие 5 s deadline clusters;
- итоговую среднюю скорость за 2–3 минуты.

Гипотеза: меньшая стартовая параллельность может снизить пик, но должна уменьшить connection churn и повысить sustained throughput после первой минуты.

Draft only. Не сливать без device A/B result.

Relates #29
Depends on #48