### PR TITLE
Issue #29: sticky MTProto session distribution across Worker pool

### DIFF
--- a/native/tgwsproxy/mtproto_chunk_relay.go
+++ b/native/tgwsproxy/mtproto_chunk_relay.go
@@ -25,6 +25,10 @@ const (
 	mtProtoChunkRelayUpHedgeDelay = 400 * time.Millisecond
 	mtProtoChunkRelayDownTimeout  = 10 * time.Second
 	mtProtoChunkRelayPollWaitMS   = 6000
+
+	chunkRelayWorkerStateHeader      = "X-Tgws-Worker-State"
+	chunkRelayQuotaResetHeader       = "X-Tgws-Quota-Reset"
+	chunkRelayQuotaExhaustedState    = "do-quota-exhausted"
 )
 
 // Each relay request still uses a fresh TCP/TLS connection. Sharing only the
@@ -65,6 +69,36 @@ type mtProtoChunkRelayConn struct {
 	closed  bool
 }
 
+func chunkRelayQuotaResetFromHeaders(headers http.Header, now time.Time) time.Time {
+	if headers != nil {
+		if raw := strings.TrimSpace(headers.Get(chunkRelayQuotaResetHeader)); raw != "" {
+			if parsed, err := time.Parse(time.RFC3339, raw); err == nil && parsed.After(now) {
+				return parsed
+			}
+		}
+		if raw := strings.TrimSpace(headers.Get("Retry-After")); raw != "" {
+			if seconds, err := strconv.Atoi(raw); err == nil && seconds > 0 {
+				return now.Add(time.Duration(seconds) * time.Second)
+			}
+		}
+	}
+	return nextWorkerQuotaReset(now)
+}
+
+func chunkRelayCircuitErrorForResponse(domain string, status int, headers http.Header, now time.Time) error {
+	if headers == nil || !strings.EqualFold(strings.TrimSpace(headers.Get(chunkRelayWorkerStateHeader)), chunkRelayQuotaExhaustedState) {
+		return nil
+	}
+	until := chunkRelayQuotaResetFromHeaders(headers, now)
+	markWorkerQuotaExhausted(domain, until)
+	return &workerCircuitOpenError{
+		Domain: domain,
+		Reason: workerCircuitReasonQuotaExhausted,
+		Until:  until,
+		Status: status,
+	}
+}
+
 func dialMtProtoChunkRelay(
 	ctx context.Context,
 	domain, sessionID, workerDst, logPrefix string,
@@ -74,6 +108,13 @@ func dialMtProtoChunkRelay(
 	workerDst = strings.TrimSpace(workerDst)
 	if domain == "" || sessionID == "" || workerDst == "" {
 		return nil, fmt.Errorf("chunk relay requires domain, session id and destination")
+	}
+	if state, blocked := activeWorkerCircuit(domain, time.Now()); blocked {
+		return nil, &workerCircuitOpenError{
+			Domain: domain,
+			Reason: state.Reason,
+			Until:  state.Until,
+		}
 	}
 
 	lifeCtx, cancel := context.WithCancel(context.Background())
@@ -97,12 +138,22 @@ func dialMtProtoChunkRelay(
 	}
 	if status != http.StatusNoContent {
 		cancel()
+		if status >= 500 {
+			until := markWorkerTemporaryFailure(domain, time.Now())
+			return nil, fmt.Errorf("open chunk relay: %w", &workerCircuitOpenError{
+				Domain: domain,
+				Reason: workerCircuitReasonTemporaryFailed,
+				Until:  until,
+				Status: status,
+			})
+		}
 		return nil, fmt.Errorf("open chunk relay: HTTP %d", status)
 	}
 	if strings.TrimSpace(headers.Get("X-Tgws-Chunk-Relay-Revision")) == "" {
 		cancel()
 		return nil, fmt.Errorf("open chunk relay: missing relay revision header")
 	}
+	clearWorkerCircuit(domain)
 
 	if logInfo != nil {
 		logInfo.Printf(
@@ -177,10 +228,14 @@ func (c *mtProtoChunkRelayConn) freshHTTPRequest(
 	}
 	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, mtProtoChunkRelayBytes+4096))
+	headers := resp.Header.Clone()
 	if err != nil {
-		return resp.StatusCode, resp.Header.Clone(), nil, err
+		return resp.StatusCode, headers, nil, err
 	}
-	return resp.StatusCode, resp.Header.Clone(), responseBody, nil
+	if circuitErr := chunkRelayCircuitErrorForResponse(c.domain, resp.StatusCode, headers, time.Now()); circuitErr != nil {
+		return resp.StatusCode, headers, responseBody, circuitErr
+	}
+	return resp.StatusCode, headers, responseBody, nil
 }
 
 func (c *mtProtoChunkRelayConn) requestWithRetry(
@@ -206,6 +261,9 @@ func (c *mtProtoChunkRelayConn) requestWithRetry(
 		}
 		if err == nil {
 			return status, headers, responseBody, nil
+		}
+		if _, circuitOpen := workerCircuitError(err); circuitOpen {
+			return status, headers, responseBody, err
 		}
 		lastErr = err
 		if attempt >= mtProtoChunkRelayMaxRetries {
@@ -311,6 +369,10 @@ func (c *mtProtoChunkRelayConn) requestUpHedgeRound(
 					)
 				}
 				return result.status, result.headers, result.responseBody, nil
+			}
+			if _, circuitOpen := workerCircuitError(result.err); circuitOpen {
+				roundCancel()
+				return result.status, result.headers, result.responseBody, result.err
 			}
 			lastErr = result.err
 			if !hedgeLaunched {
@@ -546,6 +608,6 @@ func (c *mtProtoChunkRelayConn) RouteDiagnostics() mtproxyfrontend.RouteDiagnost
 }
 
 var (
-	_ net.Conn                                 = (*mtProtoChunkRelayConn)(nil)
+	_ net.Conn                                  = (*mtProtoChunkRelayConn)(nil)
 	_ mtproxyfrontend.RouteDiagnosticsProvider = (*mtProtoChunkRelayConn)(nil)
 )

--- a/native/tgwsproxy/mtproto_worker_route.go
+++ b/native/tgwsproxy/mtproto_worker_route.go
@@ -239,11 +239,30 @@ func (c *mtProtoWorkerConnector) Connect(
 	}
 
 	settings := getRuntimeSettings()
-	candidates := settings.Worker.Failover.effectiveCandidates(settings.Worker.Domain)
+	// The frontend and Worker connector independently derive the same opaque
+	// identifier from relay_init, so Worker selection is deterministic for the
+	// lifetime of this Telegram session without exposing relay key material.
+	sessionID := mtproxyfrontend.SessionIDForRequest(request)
+	candidates, stickyIndex := workerCandidatesForSession(
+		settings.Worker.Failover,
+		settings.Worker.Domain,
+		sessionID,
+	)
 	if len(candidates) == 0 {
 		result.Reason = "worker_not_configured"
 		result.Err = fmt.Errorf("MTProto Worker backend is not configured")
 		return nil, result
+	}
+	if logInfo != nil {
+		logInfo.Printf(
+			"MTProto Worker session selection session_id=%s strategy=%s candidate_count=%d sticky_index=%d primary_worker_id=%s primary_worker_host=%s",
+			sessionID,
+			mtProtoStatusField(settings.Worker.Failover.SelectionStrategy),
+			len(candidates),
+			stickyIndex,
+			candidates[0].ID,
+			candidates[0].Domain,
+		)
 	}
 
 	destination := buildMtProtoWorkerDestinationPlan(
@@ -295,10 +314,6 @@ func (c *mtProtoWorkerConnector) Connect(
 		return nil, result
 	}
 
-	// The frontend and Worker connector independently derive the same opaque
-	// identifier from relay_init, so every lifecycle log can be correlated
-	// without exposing relay key material or relying on log ordering.
-	sessionID := mtproxyfrontend.SessionIDForRequest(request)
 	var lastErr error
 	var lastReason string
 	for i := 0; i < maxAttempts; i++ {

--- a/native/tgwsproxy/mtproto_worker_sticky_pool_test.go
+++ b/native/tgwsproxy/mtproto_worker_sticky_pool_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"tg-ws-proxy/mtproxyfrontend"
+	"tg-ws-proxy/tgwsroute"
+)
+
+func TestMtProtoWorkerConnectorUsesSessionStickyRoundRobinPrimary(t *testing.T) {
+	failover := workerFailoverSettings{
+		Enabled:           true,
+		MaxAttempts:       2,
+		SelectionStrategy: workerSelectionStrategyRoundRobin,
+		Candidates: []workerFailoverCandidate{
+			{ID: "first", Domain: "first.workers.dev"},
+			{ID: "second", Domain: "second.workers.dev"},
+		},
+	}
+	withRuntimeSettings(t, func(settings runtimeSettings) runtimeSettings {
+		settings.Worker.Enabled = true
+		settings.Worker.Domain = "first.workers.dev"
+		settings.Worker.Failover = failover
+		settings.Worker.DestinationMode = tgwsroute.WorkerDestinationPreserveOriginalDst
+		settings.MtProtoWorkerPreconnect = false
+		return settings
+	})
+
+	relayInit := buildTestInitWithSignedDC(t, 2)
+	request := mtproxyfrontend.OutboundRequest{
+		DCID:      2,
+		Transport: mtproxyfrontend.TransportAbridged,
+		RelayInit: relayInit,
+	}
+	sessionID := mtproxyfrontend.SessionIDForRequest(request)
+	expected, _ := workerCandidatesForSession(failover, "first.workers.dev", sessionID)
+	if len(expected) != 2 {
+		t.Fatalf("expected candidates=%d want=2", len(expected))
+	}
+
+	var attempts []string
+	connector := &mtProtoWorkerConnector{
+		dial: func(domain, _, _ string) (mtProtoFrameSocket, error) {
+			attempts = append(attempts, domain)
+			return &fakeMtProtoFrameSocket{}, nil
+		},
+	}
+	conn, result := connector.Connect(context.Background(), request)
+	if result.Err != nil {
+		t.Fatalf("connect: %v", result.Err)
+	}
+	defer conn.Close()
+
+	if len(attempts) != 1 || attempts[0] != expected[0].Domain {
+		t.Fatalf("dial attempts=%v want primary=%s session_id=%s", attempts, expected[0].Domain, sessionID)
+	}
+}
+
+func TestMtProtoWorkerConnectorRoundRobinFailoverWrapsAfterStickyPrimary(t *testing.T) {
+	failover := workerFailoverSettings{
+		Enabled:           true,
+		MaxAttempts:       2,
+		SelectionStrategy: workerSelectionStrategyRoundRobin,
+		Candidates: []workerFailoverCandidate{
+			{ID: "first", Domain: "first.workers.dev"},
+			{ID: "second", Domain: "second.workers.dev"},
+		},
+	}
+	withRuntimeSettings(t, func(settings runtimeSettings) runtimeSettings {
+		settings.Worker.Enabled = true
+		settings.Worker.Domain = "first.workers.dev"
+		settings.Worker.Failover = failover
+		settings.Worker.DestinationMode = tgwsroute.WorkerDestinationPreserveOriginalDst
+		settings.MtProtoWorkerPreconnect = false
+		return settings
+	})
+
+	request := mtproxyfrontend.OutboundRequest{
+		DCID:      2,
+		Transport: mtproxyfrontend.TransportAbridged,
+		RelayInit: buildTestInitWithSignedDC(t, 2),
+	}
+	sessionID := mtproxyfrontend.SessionIDForRequest(request)
+	expected, _ := workerCandidatesForSession(failover, "first.workers.dev", sessionID)
+	if len(expected) != 2 {
+		t.Fatalf("expected candidates=%d want=2", len(expected))
+	}
+
+	var attempts []string
+	connector := &mtProtoWorkerConnector{
+		dial: func(domain, _, _ string) (mtProtoFrameSocket, error) {
+			attempts = append(attempts, domain)
+			if len(attempts) == 1 {
+				return nil, errors.New("primary unavailable")
+			}
+			return &fakeMtProtoFrameSocket{}, nil
+		},
+	}
+	conn, result := connector.Connect(context.Background(), request)
+	if result.Err != nil {
+		t.Fatalf("connect: %v", result.Err)
+	}
+	defer conn.Close()
+
+	if len(attempts) != 2 || attempts[0] != expected[0].Domain || attempts[1] != expected[1].Domain {
+		t.Fatalf("dial attempts=%v want=%s,%s", attempts, expected[0].Domain, expected[1].Domain)
+	}
+}

--- a/native/tgwsproxy/worker_circuit_breaker.go
+++ b/native/tgwsproxy/worker_circuit_breaker.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	workerCircuitReasonQuotaExhausted  = "quota_exhausted"
+	workerCircuitReasonTemporaryFailed = "temporary_failure"
+	workerTemporaryFailureCooldown     = 45 * time.Second
+)
+
+type workerCircuitState struct {
+	Reason string
+	Until  time.Time
+}
+
+type workerCircuitOpenError struct {
+	Domain string
+	Reason string
+	Until  time.Time
+	Status int
+}
+
+func (e *workerCircuitOpenError) Error() string {
+	if e == nil {
+		return "worker circuit open"
+	}
+	if e.Until.IsZero() {
+		return fmt.Sprintf("worker circuit open: domain=%s reason=%s status=%d", e.Domain, e.Reason, e.Status)
+	}
+	return fmt.Sprintf("worker circuit open: domain=%s reason=%s until=%s status=%d", e.Domain, e.Reason, e.Until.UTC().Format(time.RFC3339), e.Status)
+}
+
+var workerCircuitRuntime = struct {
+	sync.Mutex
+	states map[string]workerCircuitState
+}{states: make(map[string]workerCircuitState)}
+
+func workerCircuitKey(domain string) string {
+	return strings.ToLower(strings.TrimSpace(NormalizeWorkerDomain(domain)))
+}
+
+func activeWorkerCircuit(domain string, now time.Time) (workerCircuitState, bool) {
+	key := workerCircuitKey(domain)
+	if key == "" {
+		return workerCircuitState{}, false
+	}
+	workerCircuitRuntime.Lock()
+	defer workerCircuitRuntime.Unlock()
+	state, ok := workerCircuitRuntime.states[key]
+	if !ok {
+		return workerCircuitState{}, false
+	}
+	if !state.Until.IsZero() && !now.Before(state.Until) {
+		delete(workerCircuitRuntime.states, key)
+		return workerCircuitState{}, false
+	}
+	return state, true
+}
+
+func markWorkerCircuit(domain, reason string, until time.Time) {
+	key := workerCircuitKey(domain)
+	if key == "" {
+		return
+	}
+	workerCircuitRuntime.Lock()
+	prev, hadPrev := workerCircuitRuntime.states[key]
+	if hadPrev && prev.Until.After(until) {
+		until = prev.Until
+		if prev.Reason == workerCircuitReasonQuotaExhausted {
+			reason = prev.Reason
+		}
+	}
+	workerCircuitRuntime.states[key] = workerCircuitState{Reason: reason, Until: until}
+	workerCircuitRuntime.Unlock()
+	if logWarn != nil && (!hadPrev || prev.Reason != reason || !prev.Until.Equal(until)) {
+		logWarn.Printf("Worker circuit opened: domain=%s reason=%s until=%s", key, reason, until.UTC().Format(time.RFC3339))
+	}
+}
+
+func clearWorkerCircuit(domain string) {
+	key := workerCircuitKey(domain)
+	if key == "" {
+		return
+	}
+	workerCircuitRuntime.Lock()
+	_, existed := workerCircuitRuntime.states[key]
+	delete(workerCircuitRuntime.states, key)
+	workerCircuitRuntime.Unlock()
+	if existed && logInfo != nil {
+		logInfo.Printf("Worker circuit recovered: domain=%s", key)
+	}
+}
+
+func markWorkerQuotaExhausted(domain string, until time.Time) {
+	if until.IsZero() {
+		until = nextWorkerQuotaReset(time.Now())
+	}
+	markWorkerCircuit(domain, workerCircuitReasonQuotaExhausted, until)
+}
+
+func markWorkerTemporaryFailure(domain string, now time.Time) time.Time {
+	until := now.Add(workerTemporaryFailureCooldown)
+	markWorkerCircuit(domain, workerCircuitReasonTemporaryFailed, until)
+	return until
+}
+
+func nextWorkerQuotaReset(now time.Time) time.Time {
+	u := now.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day()+1, 0, 1, 0, 0, time.UTC)
+}
+
+func workerCircuitError(err error) (*workerCircuitOpenError, bool) {
+	var target *workerCircuitOpenError
+	if errors.As(err, &target) {
+		return target, true
+	}
+	return nil, false
+}
+
+func filterWorkerCandidatesByCircuit(candidates []workerFailoverCandidate, now time.Time) []workerFailoverCandidate {
+	if len(candidates) == 0 {
+		return candidates
+	}
+	out := make([]workerFailoverCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if _, blocked := activeWorkerCircuit(candidate.Domain, now); blocked {
+			continue
+		}
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func resetWorkerCircuitForTests() {
+	workerCircuitRuntime.Lock()
+	workerCircuitRuntime.states = make(map[string]workerCircuitState)
+	workerCircuitRuntime.Unlock()
+}

--- a/native/tgwsproxy/worker_circuit_breaker_test.go
+++ b/native/tgwsproxy/worker_circuit_breaker_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestWorkerCircuitBreakerFiltersQuotaExhaustedCandidate(t *testing.T) {
+	resetWorkerCircuitForTests()
+	t.Cleanup(resetWorkerCircuitForTests)
+
+	now := time.Now()
+	markWorkerQuotaExhausted("first.workers.dev", now.Add(time.Hour))
+	candidates := []workerFailoverCandidate{
+		{ID: "first", Domain: "first.workers.dev"},
+		{ID: "second", Domain: "second.workers.dev"},
+	}
+
+	got := filterWorkerCandidatesByCircuit(candidates, now)
+	if len(got) != 1 || got[0].ID != "second" {
+		t.Fatalf("candidates=%+v want only second", got)
+	}
+}
+
+func TestWorkerCircuitBreakerRecoversAfterCooldown(t *testing.T) {
+	resetWorkerCircuitForTests()
+	t.Cleanup(resetWorkerCircuitForTests)
+
+	now := time.Now()
+	markWorkerCircuit("first.workers.dev", workerCircuitReasonTemporaryFailed, now.Add(-time.Second))
+	if _, blocked := activeWorkerCircuit("first.workers.dev", now); blocked {
+		t.Fatal("expired circuit remained blocked")
+	}
+}
+
+func TestWorkerCandidatesForSessionSkipsCircuitOpenPrimary(t *testing.T) {
+	resetWorkerCircuitForTests()
+	t.Cleanup(resetWorkerCircuitForTests)
+
+	settings := workerFailoverSettings{
+		Enabled:           true,
+		SelectionStrategy: workerSelectionStrategyRoundRobin,
+		Candidates: []workerFailoverCandidate{
+			{ID: "first", Domain: "first.workers.dev"},
+			{ID: "second", Domain: "second.workers.dev"},
+		},
+	}
+
+	ordered, _ := workerCandidatesForSession(settings, "", "session-a")
+	if len(ordered) != 2 {
+		t.Fatalf("initial candidates=%+v", ordered)
+	}
+	blockedDomain := ordered[0].Domain
+	markWorkerQuotaExhausted(blockedDomain, time.Now().Add(time.Hour))
+
+	got, _ := workerCandidatesForSession(settings, "", "session-a")
+	if len(got) != 1 || got[0].Domain == blockedDomain {
+		t.Fatalf("blocked domain %s was not removed: %+v", blockedDomain, got)
+	}
+}
+
+func TestChunkRelayCircuitErrorMarksQuotaUntilReset(t *testing.T) {
+	resetWorkerCircuitForTests()
+	t.Cleanup(resetWorkerCircuitForTests)
+
+	now := time.Date(2026, 9, 12, 18, 0, 0, 0, time.UTC)
+	reset := now.Add(6 * time.Hour)
+	headers := make(http.Header)
+	headers.Set(chunkRelayWorkerStateHeader, chunkRelayQuotaExhaustedState)
+	headers.Set(chunkRelayQuotaResetHeader, reset.Format(time.RFC3339))
+
+	err := chunkRelayCircuitErrorForResponse("quota.workers.dev", http.StatusServiceUnavailable, headers, now)
+	if err == nil {
+		t.Fatal("expected quota circuit error")
+	}
+	circuitErr, ok := workerCircuitError(err)
+	if !ok {
+		t.Fatalf("error type=%T want workerCircuitOpenError", err)
+	}
+	if circuitErr.Reason != workerCircuitReasonQuotaExhausted || !circuitErr.Until.Equal(reset) {
+		t.Fatalf("circuit=%+v", circuitErr)
+	}
+	state, blocked := activeWorkerCircuit("quota.workers.dev", now)
+	if !blocked || state.Reason != workerCircuitReasonQuotaExhausted || !state.Until.Equal(reset) {
+		t.Fatalf("state=%+v blocked=%t", state, blocked)
+	}
+}

--- a/native/tgwsproxy/worker_failover.go
+++ b/native/tgwsproxy/worker_failover.go
@@ -250,12 +250,21 @@ func tryWorkerFailoverConnect(
 	sessionID string,
 ) (*RawWebSocket, workerFailoverCandidate, int, string, bool) {
 	failover := settings.Worker.Failover
-	candidates := failover.effectiveCandidates(settings.Worker.Domain)
+	candidates, stickyIndex := workerCandidatesForSession(failover, settings.Worker.Domain, sessionID)
 	if len(candidates) == 0 {
 		return nil, workerFailoverCandidate{}, 0, "no_enabled_worker", false
 	}
 	maxAttempts := failover.maxAttemptsFor(len(candidates))
 	noteWorkerFailoverAttemptStarted(failover.SelectedID, len(candidates))
+	logInfo.Printf(
+		"Worker session selection session_id=%s strategy=%s candidate_count=%d sticky_index=%d primary_worker_id=%s primary_worker_host=%s",
+		sessionID,
+		mtProtoStatusField(failover.SelectionStrategy),
+		len(candidates),
+		stickyIndex,
+		candidates[0].ID,
+		candidates[0].Domain,
+	)
 
 	mTag := mediaTag(isMedia)
 	dstIP := strings.TrimSpace(workerDst)

--- a/native/tgwsproxy/worker_session_selection.go
+++ b/native/tgwsproxy/worker_session_selection.go
@@ -3,6 +3,7 @@ package main
 import (
 	"hash/fnv"
 	"strings"
+	"time"
 )
 
 const workerSelectionStrategyRoundRobin = "ROUND_ROBIN"
@@ -11,27 +12,27 @@ const workerSelectionStrategyRoundRobin = "ROUND_ROBIN"
 // strategies except ROUND_ROBIN. For ROUND_ROBIN, a stable hash of the opaque
 // session id rotates the candidate list once at session establishment. The
 // selected Worker therefore stays sticky for the whole session while different
-// sessions are spread across the configured Worker pool.
+// sessions are spread across the configured Worker pool. Workers with an open
+// runtime circuit are filtered after ordering so quota-exhausted endpoints do
+// not receive repeated connection attempts.
 func workerCandidatesForSession(
 	settings workerFailoverSettings,
 	fallbackDomain string,
 	sessionID string,
 ) ([]workerFailoverCandidate, int) {
 	candidates := settings.effectiveCandidates(fallbackDomain)
-	if len(candidates) <= 1 ||
-		!strings.EqualFold(strings.TrimSpace(settings.SelectionStrategy), workerSelectionStrategyRoundRobin) {
-		return candidates, 0
+	start := 0
+	if len(candidates) > 1 &&
+		strings.EqualFold(strings.TrimSpace(settings.SelectionStrategy), workerSelectionStrategyRoundRobin) {
+		start = workerStickyCandidateIndex(sessionID, len(candidates))
+		if start != 0 {
+			rotated := make([]workerFailoverCandidate, 0, len(candidates))
+			rotated = append(rotated, candidates[start:]...)
+			rotated = append(rotated, candidates[:start]...)
+			candidates = rotated
+		}
 	}
-
-	start := workerStickyCandidateIndex(sessionID, len(candidates))
-	if start == 0 {
-		return candidates, 0
-	}
-
-	rotated := make([]workerFailoverCandidate, 0, len(candidates))
-	rotated = append(rotated, candidates[start:]...)
-	rotated = append(rotated, candidates[:start]...)
-	return rotated, start
+	return filterWorkerCandidatesByCircuit(candidates, time.Now()), start
 }
 
 func workerStickyCandidateIndex(sessionID string, candidateCount int) int {

--- a/native/tgwsproxy/worker_session_selection.go
+++ b/native/tgwsproxy/worker_session_selection.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"hash/fnv"
+	"strings"
+)
+
+const workerSelectionStrategyRoundRobin = "ROUND_ROBIN"
+
+// workerCandidatesForSession keeps configured ordering for all selection
+// strategies except ROUND_ROBIN. For ROUND_ROBIN, a stable hash of the opaque
+// session id rotates the candidate list once at session establishment. The
+// selected Worker therefore stays sticky for the whole session while different
+// sessions are spread across the configured Worker pool.
+func workerCandidatesForSession(
+	settings workerFailoverSettings,
+	fallbackDomain string,
+	sessionID string,
+) ([]workerFailoverCandidate, int) {
+	candidates := settings.effectiveCandidates(fallbackDomain)
+	if len(candidates) <= 1 ||
+		!strings.EqualFold(strings.TrimSpace(settings.SelectionStrategy), workerSelectionStrategyRoundRobin) {
+		return candidates, 0
+	}
+
+	start := workerStickyCandidateIndex(sessionID, len(candidates))
+	if start == 0 {
+		return candidates, 0
+	}
+
+	rotated := make([]workerFailoverCandidate, 0, len(candidates))
+	rotated = append(rotated, candidates[start:]...)
+	rotated = append(rotated, candidates[:start]...)
+	return rotated, start
+}
+
+func workerStickyCandidateIndex(sessionID string, candidateCount int) int {
+	if candidateCount <= 1 {
+		return 0
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return 0
+	}
+
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(sessionID))
+	return int(h.Sum64() % uint64(candidateCount))
+}

--- a/native/tgwsproxy/worker_session_selection_test.go
+++ b/native/tgwsproxy/worker_session_selection_test.go
@@ -1,0 +1,77 @@
+package main
+
+import "testing"
+
+func TestWorkerCandidatesForSessionPreservesNonRoundRobinOrder(t *testing.T) {
+	settings := workerFailoverSettings{
+		Enabled:           true,
+		SelectionStrategy: "FAILOVER",
+		Candidates: []workerFailoverCandidate{
+			{ID: "first", Domain: "first.workers.dev"},
+			{ID: "second", Domain: "second.workers.dev"},
+		},
+	}
+
+	got, start := workerCandidatesForSession(settings, "", "session-a")
+	if start != 0 {
+		t.Fatalf("start=%d want=0", start)
+	}
+	if len(got) != 2 || got[0].ID != "first" || got[1].ID != "second" {
+		t.Fatalf("candidates=%+v", got)
+	}
+}
+
+func TestWorkerCandidatesForSessionRoundRobinIsStickyAndDistributed(t *testing.T) {
+	settings := workerFailoverSettings{
+		Enabled:           true,
+		SelectionStrategy: workerSelectionStrategyRoundRobin,
+		Candidates: []workerFailoverCandidate{
+			{ID: "first", Domain: "first.workers.dev"},
+			{ID: "second", Domain: "second.workers.dev"},
+		},
+	}
+
+	firstA, indexA := workerCandidatesForSession(settings, "", "session-a")
+	secondA, secondIndexA := workerCandidatesForSession(settings, "", "session-a")
+	firstB, indexB := workerCandidatesForSession(settings, "", "session-b")
+
+	if indexA != secondIndexA || firstA[0] != secondA[0] {
+		t.Fatalf("same session was not sticky: first=%+v/%d second=%+v/%d", firstA, indexA, secondA, secondIndexA)
+	}
+	if firstA[0].ID == firstB[0].ID || indexA == indexB {
+		t.Fatalf("expected the two deterministic sessions to use different primaries: a=%+v/%d b=%+v/%d", firstA, indexA, firstB, indexB)
+	}
+	if settings.Candidates[0].ID != "first" || settings.Candidates[1].ID != "second" {
+		t.Fatalf("configured candidate order was mutated: %+v", settings.Candidates)
+	}
+}
+
+func TestWorkerCandidatesForSessionRoundRobinFallbackWrapsAfterPrimary(t *testing.T) {
+	settings := workerFailoverSettings{
+		Enabled:           true,
+		SelectionStrategy: workerSelectionStrategyRoundRobin,
+		Candidates: []workerFailoverCandidate{
+			{ID: "first", Domain: "first.workers.dev"},
+			{ID: "second", Domain: "second.workers.dev"},
+			{ID: "third", Domain: "third.workers.dev"},
+		},
+	}
+
+	got, start := workerCandidatesForSession(settings, "", "alpha")
+	if len(got) != 3 {
+		t.Fatalf("len=%d want=3", len(got))
+	}
+	want := append([]workerFailoverCandidate{}, settings.Candidates[start:]...)
+	want = append(want, settings.Candidates[:start]...)
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate[%d]=%+v want=%+v start=%d", i, got[i], want[i], start)
+		}
+	}
+}
+
+func TestWorkerStickyCandidateIndexEmptySessionPreservesPrimary(t *testing.T) {
+	if got := workerStickyCandidateIndex("", 2); got != 0 {
+		t.Fatalf("index=%d want=0", got)
+	}
+}

--- a/scripts/cloudflare-worker/chunk-relay-worker.js
+++ b/scripts/cloudflare-worker/chunk-relay-worker.js
@@ -2,13 +2,17 @@ import baseWorker from "./worker.js";
 import { connect } from "cloudflare:sockets";
 import { DurableObject } from "cloudflare:workers";
 
-const REVISION = "chunk-relay-mtproto-v6";
+const REVISION = "chunk-relay-mtproto-v7";
 const RELAY_MAX_UPLOAD_CHUNK_BYTES = 12 * 1024;
 const RELAY_MAX_DOWN_CHUNK_BYTES = 8 * 1024;
 const DIAG_MAX_CHUNK_BYTES = 12 * 1024;
 const MAX_QUEUE_BYTES = 2 * 1024 * 1024;
 const MAX_POLL_WAIT_MS = 6000;
 const MAX_UPLOAD_REORDER_WINDOW = 16;
+const WORKER_STATE_HEADER = "X-Tgws-Worker-State";
+const QUOTA_RESET_HEADER = "X-Tgws-Quota-Reset";
+const DO_QUOTA_EXHAUSTED_STATE = "do-quota-exhausted";
+const DO_QUOTA_ERROR_FRAGMENT = "Exceeded allowed duration in Durable Objects free tier";
 
 function headers(extra = {}) {
   return { "Cache-Control": "no-store", "X-Tgws-Chunk-Relay-Revision": REVISION, ...extra };
@@ -33,6 +37,36 @@ function deferred() {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+function isDurableObjectQuotaError(error) {
+  return String(error || "").includes(DO_QUOTA_ERROR_FRAGMENT);
+}
+
+function nextQuotaReset(now = new Date()) {
+  const reset = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() + 1,
+    0,
+    1,
+    0,
+    0,
+  ));
+  return reset;
+}
+
+function durableObjectQuotaResponse(now = new Date()) {
+  const reset = nextQuotaReset(now);
+  const retryAfterSeconds = Math.max(60, Math.ceil((reset.getTime() - now.getTime()) / 1000));
+  return new Response("durable object quota exhausted", {
+    status: 503,
+    headers: headers({
+      [WORKER_STATE_HEADER]: DO_QUOTA_EXHAUSTED_STATE,
+      [QUOTA_RESET_HEADER]: reset.toISOString(),
+      "Retry-After": String(retryAfterSeconds),
+    }),
+  });
 }
 
 export class ChunkRelaySession extends DurableObject {
@@ -309,7 +343,15 @@ export default {
     if (url.pathname.startsWith("/chunk-relay/")) {
       const sid = (url.searchParams.get("sid") || "").trim();
       if (!/^[A-Za-z0-9_-]{8,128}$/.test(sid)) return new Response("invalid sid", { status: 400, headers: headers() });
-      return env.CHUNK_RELAY.getByName(sid).fetch(request);
+      try {
+        return await env.CHUNK_RELAY.getByName(sid).fetch(request);
+      } catch (error) {
+        if (isDurableObjectQuotaError(error)) {
+          console.log("chunk relay durable object quota exhausted", { revision: REVISION, sid });
+          return durableObjectQuotaResponse();
+        }
+        throw error;
+      }
     }
     return baseWorker.fetch(request, env, ctx);
   },

--- a/scripts/cloudflare-worker/chunk-relay-worker.test.mjs
+++ b/scripts/cloudflare-worker/chunk-relay-worker.test.mjs
@@ -123,3 +123,50 @@ test("backpressure waits when the next downstream chunk would exceed the queue l
   await wait;
   assert.equal(resolved, true);
 });
+
+test("top-level worker maps Durable Object free-tier duration exhaustion to a recoverable response", async () => {
+  const env = {
+    CHUNK_RELAY: {
+      getByName() {
+        return {
+          async fetch() {
+            throw new Error("Exceeded allowed duration in Durable Objects free tier.");
+          },
+        };
+      },
+    },
+  };
+
+  const response = await mod.default.fetch(new Request(
+    "https://example.workers.dev/chunk-relay/open?sid=session_quota_123&dst=149.154.167.51",
+    { method: "POST" },
+  ), env, {});
+
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get("X-Tgws-Worker-State"), "do-quota-exhausted");
+  assert.equal(response.headers.get("X-Tgws-Chunk-Relay-Revision"), "chunk-relay-mtproto-v7");
+  assert.ok(Number.parseInt(response.headers.get("Retry-After") || "0", 10) >= 60);
+  assert.ok(!Number.isNaN(Date.parse(response.headers.get("X-Tgws-Quota-Reset") || "")));
+});
+
+test("top-level worker does not hide unrelated Durable Object exceptions", async () => {
+  const env = {
+    CHUNK_RELAY: {
+      getByName() {
+        return {
+          async fetch() {
+            throw new Error("unexpected durable object failure");
+          },
+        };
+      },
+    },
+  };
+
+  await assert.rejects(
+    () => mod.default.fetch(new Request(
+      "https://example.workers.dev/chunk-relay/open?sid=session_error_123&dst=149.154.167.51",
+      { method: "POST" },
+    ), env, {}),
+    /unexpected durable object failure/,
+  );
+});


### PR DESCRIPTION
## Что меняется

Эксперимент поверх выигравшего профиля `12 KiB / window=3`.

### Sticky Worker pool
- Для `ROUND_ROBIN` каждая Worker-сессия один раз выбирает primary Worker по стабильному хэшу безопасного `session_id`.
- MTProto chunk relay и общий Worker failover используют одну и ту же sticky-селекцию.
- Все `open/up/down/close` одной chunk-relay сессии остаются на одном Worker; chunks между Worker не перемешиваются.
- Разные сессии распределяются по доступным Worker.
- При ошибке выбранного primary failover продолжает обход со следующего кандидата с циклическим порядком.
- Для `MANUAL`, `PRIORITY`, `FAILOVER` и `LOWEST_LATENCY` существующий порядок кандидатов сохраняется, кроме автоматического исключения Worker с открытым circuit breaker.
- Параметры relay (`12 KiB`, sliding window `3`, primary/global limits, HOL hedge) не изменяются.

### Durable Objects quota automation
- Worker revision поднят до `chunk-relay-mtproto-v7`.
- Ошибка Cloudflare `Exceeded allowed duration in Durable Objects free tier` теперь перехватывается на верхнем уровне Worker вместо raw `1101`.
- Worker возвращает `503`, `X-Tgws-Worker-State: do-quota-exhausted`, `X-Tgws-Quota-Reset` и `Retry-After`.
- Native-клиент автоматически открывает per-domain circuit breaker до quota reset и исключает такой Worker из новых sticky-сессий.
- После истечения cooldown Worker автоматически снова допускается к выбору; успешный `open` очищает circuit state.
- Старые Worker/неразмеченные `5xx` на `open` получают короткий `temporary_failure` cooldown 45 секунд, чтобы не создавать reconnect storm.
- Quota/circuit ошибки не проходят обычные retry/hedge циклы на том же Worker.

## Проверки

Добавлены/расширены тесты для:
- детерминированной sticky-селекции;
- распределения разных session id;
- сохранения не-RR семантики;
- циклического failover после выбранного primary;
- фактического выбора домена в `mtProtoWorkerConnector`;
- фактического перехода на второй Worker при отказе sticky primary;
- фильтрации quota-exhausted Worker;
- автоматического возврата Worker после cooldown;
- парсинга quota reset headers;
- преобразования Cloudflare DO free-tier exception в recoverable `503` response.

Важно: для device-теста quota-aware логики **оба Worker нужно передеплоить из этой ветки**, чтобы они отдавали revision `chunk-relay-mtproto-v7`.

Связано с #29. PR оставлен draft до device A/B на двух Worker.