### PR TITLE
[v1.10.14][Worker] Verify active 12 KiB / window=3 relay profile

### DIFF
--- a/native/tgwsproxy/flowseal_websocket_connect.go
+++ b/native/tgwsproxy/flowseal_websocket_connect.go
@@ -28,8 +28,19 @@ func dialFlowsealWorkerCandidateContext(ctx context.Context, domain, path, logPr
 			return nil, err
 		}
 		if logInfo != nil {
-			logInfo.Printf("%s Worker transport=chunk_relay_http host=%s path=%s chunk_bytes=%d max_retries=%d",
-				logPrefix, domain, path, mtProtoChunkRelayBytes, mtProtoChunkRelayMaxRetries)
+			logInfo.Printf(
+				"%s Worker transport=chunk_relay_http host=%s path=%s upload_chunk_bytes=%d window=%d primary_requests=%d global_http_requests=%d hol_hedge_delay_ms=%d pipeline=%s max_retries=%d",
+				logPrefix,
+				domain,
+				path,
+				mtProtoChunkRelayUploadBytes,
+				mtProtoChunkRelayUpWindow,
+				mtProtoChunkRelayPrimaryRequests,
+				mtProtoChunkRelayGlobalHTTPRequests,
+				mtProtoChunkRelayHOLHedgeDelay.Milliseconds(),
+				mtProtoChunkRelayPipelineMode,
+				mtProtoChunkRelayMaxRetries,
+			)
 		}
 		return socket, nil
 	}

--- a/native/tgwsproxy/mtproto_chunk_relay_active_path_test.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_active_path_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+type chunkRelayUploadObservation struct {
+	seq   int64
+	bytes int
+}
+
+func TestWorkerStreamUsesVerifiedChunkRelayUploadProfile(t *testing.T) {
+	if mtProtoChunkRelayUploadBytes != 12*1024 {
+		t.Fatalf("upload chunk bytes=%d want=%d", mtProtoChunkRelayUploadBytes, 12*1024)
+	}
+	if mtProtoChunkRelayUpWindow != 3 {
+		t.Fatalf("window=%d want=3", mtProtoChunkRelayUpWindow)
+	}
+	if mtProtoChunkRelayPrimaryRequests != 12 {
+		t.Fatalf("primary requests=%d want=12", mtProtoChunkRelayPrimaryRequests)
+	}
+	if mtProtoChunkRelayGlobalHTTPRequests != 18 {
+		t.Fatalf("global HTTP requests=%d want=18", mtProtoChunkRelayGlobalHTTPRequests)
+	}
+	if mtProtoChunkRelayHOLHedgeDelay != 900*time.Millisecond {
+		t.Fatalf("HOL hedge delay=%s want=%s", mtProtoChunkRelayHOLHedgeDelay, 900*time.Millisecond)
+	}
+	if mtProtoChunkRelayPipelineMode != "sliding-w3" {
+		t.Fatalf("pipeline mode=%q want=%q", mtProtoChunkRelayPipelineMode, "sliding-w3")
+	}
+
+	started := make(chan chunkRelayUploadObservation, mtProtoChunkRelayUpWindow)
+	release := make(chan struct{})
+	conn := newTestChunkRelayConn(t, func(_ context.Context, action string, query url.Values, body []byte) (int, http.Header, []byte, error) {
+		if action != "up" {
+			t.Fatalf("action=%s", action)
+		}
+		seq, err := strconv.ParseInt(query.Get("seq"), 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		started <- chunkRelayUploadObservation{seq: seq, bytes: len(body)}
+		<-release
+		headers := make(http.Header)
+		headers.Set("X-Tgws-Chunk-Ack", strconv.FormatInt(seq, 10))
+		return http.StatusNoContent, headers, nil, nil
+	})
+
+	stream := &mtProtoWebSocketStream{
+		socket: &mtProtoChunkRelayFrameSocket{conn: conn},
+	}
+	payload := make([]byte, mtProtoChunkRelayUploadBytes*mtProtoChunkRelayUpWindow)
+	done := make(chan error, 1)
+	go func() {
+		n, err := stream.Write(payload)
+		if err == nil && n != len(payload) {
+			err = fmt.Errorf("written=%d want=%d", n, len(payload))
+		}
+		done <- err
+	}()
+
+	observations := make([]chunkRelayUploadObservation, 0, mtProtoChunkRelayUpWindow)
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	for len(observations) < mtProtoChunkRelayUpWindow {
+		select {
+		case observation := <-started:
+			observations = append(observations, observation)
+		case <-deadline.C:
+			t.Fatalf("only %d uploads reached the scheduler before ACK release: %v", len(observations), observations)
+		}
+	}
+
+	sort.Slice(observations, func(i, j int) bool { return observations[i].seq < observations[j].seq })
+	for index, observation := range observations {
+		wantSeq := int64(index + 1)
+		if observation.seq != wantSeq {
+			t.Fatalf("observations=%v want seq 1..%d", observations, mtProtoChunkRelayUpWindow)
+		}
+		if observation.bytes != mtProtoChunkRelayUploadBytes {
+			t.Fatalf("seq=%d bytes=%d want=%d", observation.seq, observation.bytes, mtProtoChunkRelayUploadBytes)
+		}
+	}
+
+	close(release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Worker stream write: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Worker stream write did not complete")
+	}
+}
+
+func TestWorkerStreamRetryKeepsSequenceAndCommitsPayloadOnce(t *testing.T) {
+	payload := bytes.Repeat([]byte{0x5a}, mtProtoChunkRelayUploadBytes)
+	var mu sync.Mutex
+	var seqs []int64
+	var bodies [][]byte
+	failedFirst := false
+
+	conn := newTestChunkRelayConn(t, func(_ context.Context, action string, query url.Values, body []byte) (int, http.Header, []byte, error) {
+		if action != "up" {
+			t.Fatalf("action=%s", action)
+		}
+		seq, err := strconv.ParseInt(query.Get("seq"), 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mu.Lock()
+		seqs = append(seqs, seq)
+		bodies = append(bodies, append([]byte(nil), body...))
+		if !failedFirst {
+			failedFirst = true
+			mu.Unlock()
+			return 0, nil, nil, errors.New("synthetic timeout")
+		}
+		mu.Unlock()
+
+		headers := make(http.Header)
+		headers.Set("X-Tgws-Chunk-Ack", strconv.FormatInt(seq, 10))
+		return http.StatusNoContent, headers, nil, nil
+	})
+
+	stream := &mtProtoWebSocketStream{
+		socket: &mtProtoChunkRelayFrameSocket{conn: conn},
+	}
+	n, err := stream.Write(payload)
+	if err != nil {
+		t.Fatalf("Worker stream write: %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("written=%d want=%d", n, len(payload))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seqs) < 2 {
+		t.Fatalf("attempts=%d want at least 2", len(seqs))
+	}
+	for index, seq := range seqs {
+		if seq != 1 {
+			t.Fatalf("attempt %d seq=%d want=1; all retries must keep the same sequence", index+1, seq)
+		}
+		if !bytes.Equal(bodies[index], payload) {
+			t.Fatalf("attempt %d changed payload", index+1)
+		}
+	}
+	if conn.upSeq != 1 {
+		t.Fatalf("upSeq=%d want=1", conn.upSeq)
+	}
+	if conn.upBytes != int64(len(payload)) {
+		t.Fatalf("upBytes=%d want=%d", conn.upBytes, len(payload))
+	}
+}

--- a/native/tgwsproxy/mtproto_chunk_relay_frames.go
+++ b/native/tgwsproxy/mtproto_chunk_relay_frames.go
@@ -29,10 +29,14 @@ func dialMtProtoChunkRelayFrameSocket(ctx context.Context, domain, path, logPref
 		return nil, err
 	}
 	if chunkConn, ok := conn.(*mtProtoChunkRelayConn); ok {
+		// Worker uploads must stay on this frame wrapper. The underlying net.Conn
+		// keeps its serial Write implementation for compatibility, while Send
+		// below is the effective Worker upload path and uses the verified relay
+		// scheduler profile.
 		enableMtProtoChunkRelayRequestLimit(chunkConn)
 		if logInfo != nil {
 			logInfo.Printf(
-				"%s MTProto Worker chunk relay upload pipeline session_id=%s upload_chunk_bytes=%d window=%d primary_requests=%d global_http_requests=%d hol_hedge_delay_ms=%d hedge_policy=oldest_unacked",
+				"%s MTProto Worker chunk relay upload pipeline session_id=%s upload_chunk_bytes=%d window=%d primary_requests=%d global_http_requests=%d hol_hedge_delay_ms=%d hedge_policy=oldest_unacked pipeline=%s",
 				logPrefix,
 				sessionID,
 				mtProtoChunkRelayUploadBytes,
@@ -40,6 +44,7 @@ func dialMtProtoChunkRelayFrameSocket(ctx context.Context, domain, path, logPref
 				mtProtoChunkRelayPrimaryRequests,
 				mtProtoChunkRelayGlobalHTTPRequests,
 				mtProtoChunkRelayHOLHedgeDelay.Milliseconds(),
+				mtProtoChunkRelayPipelineMode,
 			)
 		}
 	}


### PR DESCRIPTION
## Что сделано

- подтверждён фактический upload path: `mtProtoWebSocketStream.Write` → `mtProtoChunkRelayFrameSocket.Send` → `writePipelinedMtProtoChunkRelay`;
- активный scheduler остаётся на проверенном профиле: `12 KiB`, sliding window `3`, `12` primary requests, `18` global HTTP requests, HOL hedge `900 ms`;
- исправлен runtime-лог `chunk_relay_http`: вместо неоднозначного `chunk_bytes=8192` он выводит параметры реального upload scheduler;
- в frame relay добавлено явное пояснение, что serial `mtProtoChunkRelayConn.Write` — совместимый низкоуровневый путь, а Worker upload идёт через `Send`/pipeline;
- добавлены regression-тесты, которые проходят через реальный Worker stream write path и проверяют три одновременных 12 KiB upload sequence до ACK;
- добавлен regression-тест retry: повторная попытка сохраняет тот же `seq` и payload, а подтверждённые байты учитываются один раз.

## Фактический профиль

```text
upload_chunk_bytes=12288
window=3
primary_requests=12
global_http_requests=18
hol_hedge_delay_ms=900
pipeline=sliding-w3
```

## Почему `mtProtoChunkRelayBytes = 8 KiB` остаётся

Это не значение активного Worker upload scheduler. Оно по-прежнему используется базовым `net.Conn`/receive path и его unit-тестами. Активный Worker transport создаёт `mtProtoChunkRelayFrameSocket`; его `Send()` всегда вызывает `writePipelinedMtProtoChunkRelay()`, где размер upload chunk равен `mtProtoChunkRelayUploadBytes = 12 KiB`.

Удалять низкоуровневый serial `Write()` в рамках #54 не требуется: после этой правки runtime diagnostics и regression-тест явно отделяют compatibility path от фактического Worker upload path.

## Проверки

CI должен выполнить:

- `go test -race ./...`;
- `node --test scripts/cloudflare-worker/*.test.mjs`;
- Windows `scripts/ci.ps1`.

## Осталось вручную

Перед merge требуется device A/B из критериев #54: тот же Worker, тот же файл/медиа, сравнение с подтверждённым baseline и проверка, что throughput не хуже.

Refs #54
Refs #29
Refs #52