### PR TITLE
feat(worker): multiplex chunk relay sessions through shared hub

### DIFF
--- a/docs/architecture/chunk-relay-hub.md
+++ b/docs/architecture/chunk-relay-hub.md
@@ -1,0 +1,62 @@
+# Shared Durable Object relay hub
+
+## Scope
+
+The v1.10.14 MTProto HTTPS chunk relay uses one named Durable Object hub per Worker deployment instead of one Durable Object per MTProto session.
+
+All `/chunk-relay/*` requests are routed through:
+
+```text
+CHUNK_RELAY.getByName("relay-hub-v1")
+```
+
+The opaque `sid` remains the session key inside the hub. Worker stickiness on the Android/native side is unchanged: one MTProto session still selects one Worker host for its lifetime.
+
+## Session isolation
+
+`ChunkRelayHub` owns a `Map<sid, RelaySession>`. Each `RelaySession` owns its own:
+
+- Telegram TCP socket, reader, and writer;
+- upload sequence, reorder window, ACK state, and upload promise chain;
+- downstream sequence, pending ACK chunk, queue, and backpressure waiters;
+- lifecycle state and cumulative upload/download byte counters.
+
+There is no hub-global upload chain or mutex. A blocked write for one `sid` does not serialize writes for other sessions. Closing a session, an upstream EOF, or a per-session relay failure removes only that session from the map.
+
+The existing Durable Object export name `ChunkRelaySession` is retained as an alias of `ChunkRelayHub`, so the existing `CHUNK_RELAY` binding does not require a Durable Object class-name migration.
+
+## Diagnostics
+
+Chunk relay responses expose:
+
+```text
+X-Tgws-Chunk-Relay-Revision: chunk-relay-mtproto-v8
+X-Tgws-Relay-Hub-Revision: relay-hub-v1
+```
+
+Hub lifecycle logs include:
+
+- active session count;
+- total opened sessions;
+- explicitly closed sessions;
+- sessions reaped after upstream/relay termination;
+- per-session cumulative upload/download bytes and sequence counters on termination.
+
+The hub does not log the opaque `sid`, request payloads, or secrets.
+
+The existing `do-quota-exhausted` 503 mapping and reset metadata remain unchanged. Multiplexing reduces the number of simultaneously active Durable Object instances, but the actual Cloudflare duration reduction must be confirmed from Worker account metrics under comparable traffic.
+
+## Verification
+
+The Worker unit tests cover:
+
+- three parallel sessions in one hub;
+- absence of a hub-global upload lock;
+- duplicate and out-of-order upload ACK semantics;
+- per-session target binding and 12 KiB upload limit;
+- isolated close/reconnect;
+- isolated upstream reap;
+- downstream backpressure remaining session-local;
+- Durable Object quota-exhaustion mapping.
+
+Throughput and Durable Object duration are deployment properties and require an A/B Worker/device test before Issue #53 can be considered fully accepted.

--- a/docs/releases/RELEASE_NOTES_v1.10.14.md
+++ b/docs/releases/RELEASE_NOTES_v1.10.14.md
@@ -5,9 +5,11 @@ This release candidate stabilizes the working MTProto Worker transport from the 
 ## What is included
 
 - Fresh HTTPS chunk relay for MTProto Worker traffic. The Android/native side sends bounded short HTTPS requests while a Cloudflare Durable Object keeps the corresponding Telegram TCP stream.
+- Shared Durable Object relay hub (`relay-hub-v1`): multiple independent MTProto sessions now share one Durable Object instance while retaining separate Telegram sockets, ACK/reorder state, downstream queues, backpressure, and lifecycle state.
 - Stabilized upload profile: 12 KiB chunks, sliding window 3, ordered ACKs, bounded retry/backoff, HOL hedge for the oldest unacknowledged upload, and downstream queue backpressure.
 - Sticky Worker pool for `ROUND_ROBIN`: a stable opaque MTProto session id selects one primary Worker for the lifetime of that session. Chunks from one session are never split between Worker hosts.
-- Quota-aware Worker failover. Worker v7 converts Cloudflare Durable Objects Free Tier duration exhaustion into a recoverable 503 response with reset metadata. Native routing opens a per-domain circuit breaker, skips the exhausted Worker for new sessions, and automatically retries another enabled Worker.
+- Quota-aware Worker failover. Worker v8 keeps the v7 behavior that converts Cloudflare Durable Objects Free Tier duration exhaustion into a recoverable 503 response with reset metadata. Native routing opens a per-domain circuit breaker, skips the exhausted Worker for new sessions, and automatically retries another enabled Worker.
+- Hub diagnostics expose the relay/hub revisions and log active/opened/closed/reaped session counts plus per-session cumulative byte counters without logging payloads or opaque session ids.
 - Short cooldown for unclassified Worker 5xx responses to prevent reconnect storms while still allowing automatic recovery.
 - Worker preconnect disabled for the MTProto Worker route and strict preservation of explicit Worker-only route policy.
 - Go race tests and Worker handler tests in pull-request CI.
@@ -16,13 +18,15 @@ This release candidate stabilizes the working MTProto Worker transport from the 
 
 The source checkpoint used for this release candidate is `c59f860` from PR #51. On-device testing confirmed that a v7 Worker with exhausted Durable Objects quota was automatically removed from the candidate set and new MTProto sessions failed over to a healthy v7 Worker. The healthy Worker carried bidirectional MTProto traffic and multi-megabyte uploads through the chunk relay.
 
+The shared v8 Durable Object hub is covered by Worker unit tests, but its real Cloudflare duration reduction and A/B throughput still require deployment/device verification.
+
 ## Known limitations
 
 - The Worker route is currently slower than direct connectivity and still produces HOL hedges/timeouts under sustained bulk traffic.
-- Cloudflare Durable Objects quotas remain an operational constraint; the circuit breaker prevents retry storms but does not increase quota.
+- Cloudflare Durable Objects quotas remain an operational constraint. The shared hub reduces concurrent Durable Object instances by design, but the actual billed-duration improvement is not yet measured.
 - Some relay sessions can still terminate with HTTP 502 and require further error classification and transport tuning.
 - The Worker route remains non-default. This PR is a stabilization baseline for further work, not a claim that Issue #29 is fully solved.
 
 ## Release gate
 
-Do not merge or publish v1.10.14 until CI passes on the clean stabilization branch and a final Android smoke test confirms normal Telegram messages, media transfer, Worker failover, and no reconnect storm.
+Do not merge or publish v1.10.14 until CI passes on the clean stabilization branch and a final Android smoke test confirms normal Telegram messages, media transfer, Worker failover, and no reconnect storm. Issue #53 additionally requires an A/B Worker check showing no material throughput regression and lower Durable Object pressure with concurrent sessions.

--- a/scripts/cloudflare-worker/chunk-relay-worker.js
+++ b/scripts/cloudflare-worker/chunk-relay-worker.js
@@ -2,7 +2,9 @@ import baseWorker from "./worker.js";
 import { connect } from "cloudflare:sockets";
 import { DurableObject } from "cloudflare:workers";
 
-const REVISION = "chunk-relay-mtproto-v7";
+const REVISION = "chunk-relay-mtproto-v8";
+const HUB_REVISION = "relay-hub-v1";
+const RELAY_HUB_NAME = "relay-hub-v1";
 const RELAY_MAX_UPLOAD_CHUNK_BYTES = 12 * 1024;
 const RELAY_MAX_DOWN_CHUNK_BYTES = 8 * 1024;
 const DIAG_MAX_CHUNK_BYTES = 12 * 1024;
@@ -11,11 +13,17 @@ const MAX_POLL_WAIT_MS = 6000;
 const MAX_UPLOAD_REORDER_WINDOW = 16;
 const WORKER_STATE_HEADER = "X-Tgws-Worker-State";
 const QUOTA_RESET_HEADER = "X-Tgws-Quota-Reset";
+const HUB_REVISION_HEADER = "X-Tgws-Relay-Hub-Revision";
 const DO_QUOTA_EXHAUSTED_STATE = "do-quota-exhausted";
 const DO_QUOTA_ERROR_FRAGMENT = "Exceeded allowed duration in Durable Objects free tier";
 
 function headers(extra = {}) {
-  return { "Cache-Control": "no-store", "X-Tgws-Chunk-Relay-Revision": REVISION, ...extra };
+  return {
+    "Cache-Control": "no-store",
+    "X-Tgws-Chunk-Relay-Revision": REVISION,
+    [HUB_REVISION_HEADER]: HUB_REVISION,
+    ...extra,
+  };
 }
 
 function randomBytes(size) {
@@ -27,6 +35,10 @@ function randomBytes(size) {
 function validTarget(value) {
   const target = (value || "").trim();
   return target.length >= 3 && target.length <= 64 && /^[0-9A-Fa-f:.]+$/.test(target);
+}
+
+function validSessionId(value) {
+  return /^[A-Za-z0-9_-]{8,128}$/.test((value || "").trim());
 }
 
 function deferred() {
@@ -69,9 +81,11 @@ function durableObjectQuotaResponse(now = new Date()) {
   });
 }
 
-export class ChunkRelaySession extends DurableObject {
-  constructor(ctx, env) {
-    super(ctx, env);
+class RelaySession {
+  constructor(sid, callbacks) {
+    this.sid = sid;
+    this.onOpened = callbacks.onOpened;
+    this.onTerminated = callbacks.onTerminated;
     this.socket = null;
     this.writer = null;
     this.reader = null;
@@ -88,6 +102,7 @@ export class ChunkRelaySession extends DurableObject {
     this.queueBytes = 0;
     this.waiters = new Set();
     this.drainWaiters = new Set();
+    this.opened = false;
     this.closed = false;
   }
 
@@ -104,6 +119,37 @@ export class ChunkRelaySession extends DurableObject {
   rejectPendingUploads(error) {
     for (const entry of this.upPending.values()) entry.done.reject(error);
     this.upPending.clear();
+  }
+
+  terminate(reason, error = new Error(reason)) {
+    if (this.closed) return false;
+    this.closed = true;
+    this.rejectPendingUploads(error);
+    this.wake();
+    this.wakeDrain();
+    this.onTerminated(this, reason);
+    return true;
+  }
+
+  summary() {
+    return {
+      target: this.target,
+      up_seq: this.upSeq,
+      up_bytes: this.upBytes,
+      down_seq: this.downSeq,
+      down_bytes: this.downBytes,
+    };
+  }
+
+  isPristine() {
+    return !this.opened
+      && !this.socket
+      && !this.openPromise
+      && !this.target
+      && this.upSeq === 0
+      && this.upPending.size === 0
+      && this.downSeq === 0
+      && this.queue.length === 0;
   }
 
   async waitForDrain(requiredBytes) {
@@ -130,13 +176,16 @@ export class ChunkRelaySession extends DurableObject {
       this.socket = socket;
       this.writer = socket.writable.getWriter();
       this.reader = socket.readable.getReader();
-      console.log("chunk relay opened", { revision: REVISION, target });
+      this.opened = true;
+      this.onOpened(this);
       this.pump().catch((error) => {
-        console.log("chunk relay pump failed", { revision: REVISION, target, error: String(error) });
-        this.closed = true;
-        this.rejectPendingUploads(error);
-        this.wake();
-        this.wakeDrain();
+        console.log("chunk relay pump failed", {
+          revision: REVISION,
+          hub_revision: HUB_REVISION,
+          target,
+          error: String(error),
+        });
+        this.terminate("pump_failed", error);
       });
     })();
 
@@ -151,10 +200,7 @@ export class ChunkRelaySession extends DurableObject {
     while (!this.closed) {
       const { value, done } = await this.reader.read();
       if (done) {
-        this.closed = true;
-        this.rejectPendingUploads(new Error("upstream_closed"));
-        this.wake();
-        this.wakeDrain();
+        this.terminate("upstream_closed", new Error("upstream_closed"));
         return;
       }
       const bytes = value instanceof Uint8Array ? value : new Uint8Array(value || 0);
@@ -190,12 +236,9 @@ export class ChunkRelaySession extends DurableObject {
       try {
         await this.writer.write(entry.data);
       } catch (error) {
-        this.closed = true;
-        entry.done.reject(error);
         this.upPending.delete(nextSeq);
-        this.rejectPendingUploads(error);
-        this.wake();
-        this.wakeDrain();
+        entry.done.reject(error);
+        this.terminate("upload_write_failed", error);
         throw error;
       }
 
@@ -206,6 +249,7 @@ export class ChunkRelaySession extends DurableObject {
       if (nextSeq <= 2 || this.upBytes % (64 * 1024) < entry.data.byteLength) {
         console.log("chunk relay up", {
           revision: REVISION,
+          hub_revision: HUB_REVISION,
           target: this.target,
           seq: nextSeq,
           bytes: entry.data.byteLength,
@@ -299,29 +343,102 @@ export class ChunkRelaySession extends DurableObject {
       }
 
       if (action === "close") {
-        this.closed = true;
-        this.rejectPendingUploads(new Error("session_closed"));
-        this.wake();
-        this.wakeDrain();
+        this.terminate("client_close", new Error("session_closed"));
         try { await this.socket?.close(); } catch {}
-        console.log("chunk relay closed", {
-          revision: REVISION,
-          target: this.target,
-          up_seq: this.upSeq,
-          up_bytes: this.upBytes,
-          down_seq: this.downSeq,
-          down_bytes: this.downBytes,
-        });
         return new Response(null, { status: 204, headers: headers() });
       }
     } catch (error) {
-      console.log("chunk relay request failed", { revision: REVISION, action, target: this.target, error: String(error) });
+      console.log("chunk relay request failed", {
+        revision: REVISION,
+        hub_revision: HUB_REVISION,
+        action,
+        target: this.target,
+        error: String(error),
+      });
       return new Response("relay failed", { status: 502, headers: headers() });
     }
 
     return new Response("not found", { status: 404, headers: headers() });
   }
 }
+
+export class ChunkRelayHub extends DurableObject {
+  constructor(ctx, env) {
+    super(ctx, env);
+    this.sessions = new Map();
+    this.openedSessions = 0;
+    this.closedSessions = 0;
+    this.reapedSessions = 0;
+  }
+
+  getOrCreateSession(sid) {
+    let session = this.sessions.get(sid);
+    if (session) return session;
+
+    session = new RelaySession(sid, {
+      onOpened: (openedSession) => this.onSessionOpened(openedSession),
+      onTerminated: (terminatedSession, reason) => this.onSessionTerminated(terminatedSession, reason),
+    });
+    this.sessions.set(sid, session);
+    return session;
+  }
+
+  onSessionOpened(session) {
+    this.openedSessions += 1;
+    console.log("chunk relay hub session opened", {
+      revision: REVISION,
+      hub_revision: HUB_REVISION,
+      active_sessions: this.sessions.size,
+      opened_sessions: this.openedSessions,
+      closed_sessions: this.closedSessions,
+      reaped_sessions: this.reapedSessions,
+      target: session.target,
+    });
+  }
+
+  onSessionTerminated(session, reason) {
+    if (this.sessions.get(session.sid) !== session) return;
+    this.sessions.delete(session.sid);
+    if (reason === "client_close") this.closedSessions += 1;
+    else this.reapedSessions += 1;
+
+    console.log("chunk relay hub session terminated", {
+      revision: REVISION,
+      hub_revision: HUB_REVISION,
+      reason,
+      active_sessions: this.sessions.size,
+      opened_sessions: this.openedSessions,
+      closed_sessions: this.closedSessions,
+      reaped_sessions: this.reapedSessions,
+      ...session.summary(),
+    });
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+    const sid = (url.searchParams.get("sid") || "").trim();
+    if (!validSessionId(sid)) return new Response("invalid sid", { status: 400, headers: headers() });
+
+    const action = url.pathname.split("/").filter(Boolean).at(-1) || "";
+    if (!new Set(["open", "up", "down", "close"]).has(action)) {
+      return new Response("not found", { status: 404, headers: headers() });
+    }
+
+    if (action === "close" && !this.sessions.has(sid)) {
+      return new Response(null, { status: 204, headers: headers() });
+    }
+
+    const session = this.getOrCreateSession(sid);
+    const response = await session.fetch(request);
+    if (response.status >= 400 && session.isPristine() && this.sessions.get(sid) === session) {
+      this.sessions.delete(sid);
+    }
+    return response;
+  }
+}
+
+// Keep the existing Durable Object export name so deployments do not need a class migration.
+export { ChunkRelayHub as ChunkRelaySession };
 
 export default {
   async fetch(request, env, ctx) {
@@ -331,7 +448,7 @@ export default {
       if (request.method !== "POST") return new Response("method", { status: 405, headers: headers() });
       const body = new Uint8Array(await request.arrayBuffer());
       if (!body.byteLength || body.byteLength > DIAG_MAX_CHUNK_BYTES) return new Response("bad size", { status: 413, headers: headers() });
-      return Response.json({ ok: true, bytes: body.byteLength, revision: REVISION }, { headers: headers() });
+      return Response.json({ ok: true, bytes: body.byteLength, revision: REVISION, hub_revision: HUB_REVISION }, { headers: headers() });
     }
 
     if (url.pathname === "/diag/fresh-download") {
@@ -342,12 +459,15 @@ export default {
 
     if (url.pathname.startsWith("/chunk-relay/")) {
       const sid = (url.searchParams.get("sid") || "").trim();
-      if (!/^[A-Za-z0-9_-]{8,128}$/.test(sid)) return new Response("invalid sid", { status: 400, headers: headers() });
+      if (!validSessionId(sid)) return new Response("invalid sid", { status: 400, headers: headers() });
       try {
-        return await env.CHUNK_RELAY.getByName(sid).fetch(request);
+        return await env.CHUNK_RELAY.getByName(RELAY_HUB_NAME).fetch(request);
       } catch (error) {
         if (isDurableObjectQuotaError(error)) {
-          console.log("chunk relay durable object quota exhausted", { revision: REVISION, sid });
+          console.log("chunk relay durable object quota exhausted", {
+            revision: REVISION,
+            hub_revision: HUB_REVISION,
+          });
           return durableObjectQuotaResponse();
         }
         throw error;

--- a/scripts/cloudflare-worker/chunk-relay-worker.test.mjs
+++ b/scripts/cloudflare-worker/chunk-relay-worker.test.mjs
@@ -9,13 +9,16 @@ const source = (await readFile(new URL("./chunk-relay-worker.js", import.meta.ur
 
 const mod = await import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
 
-function makeSocket(writes) {
+function makeSocket(writes, beforeWrite = null) {
   return {
     opened: Promise.resolve(),
     writable: {
       getWriter() {
         return {
-          async write(data) { writes.push(new Uint8Array(data).slice()); },
+          async write(data) {
+            if (beforeWrite) await beforeWrite(data);
+            writes.push(new Uint8Array(data).slice());
+          },
         };
       },
     },
@@ -28,6 +31,16 @@ function makeSocket(writes) {
   };
 }
 
+function relayRequest(action, sid, { dst = "149.154.167.51", seq = null, ack = null, body = null } = {}) {
+  const url = new URL(`https://example.workers.dev/chunk-relay/${action}`);
+  url.searchParams.set("sid", sid);
+  if (dst) url.searchParams.set("dst", dst);
+  if (seq !== null) url.searchParams.set("seq", String(seq));
+  if (ack !== null) url.searchParams.set("ack", String(ack));
+  const method = action === "down" ? "GET" : "POST";
+  return new Request(url, { method, body: method === "POST" ? body : null });
+}
+
 test("duplicate upload sequence is written only once", async (t) => {
   const writes = [];
   const oldConnect = globalThis.__chunkRelayConnect;
@@ -37,18 +50,13 @@ test("duplicate upload sequence is written only once", async (t) => {
   };
   t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
 
-  const relay = new mod.ChunkRelaySession({}, {});
-  const open = await relay.fetch(new Request(
-    "https://example.workers.dev/chunk-relay/open?sid=session_test_123&dst=149.154.167.51",
-    { method: "POST" },
-  ));
+  const relay = new mod.ChunkRelayHub({}, {});
+  const sid = "session_test_123";
+  const open = await relay.fetch(relayRequest("open", sid));
   assert.equal(open.status, 204);
 
   const body = new Uint8Array([1, 2, 3, 4]);
-  const makeUp = () => relay.fetch(new Request(
-    "https://example.workers.dev/chunk-relay/up?sid=session_test_123&dst=149.154.167.51&seq=1",
-    { method: "POST", body },
-  ));
+  const makeUp = () => relay.fetch(relayRequest("up", sid, { seq: 1, body }));
 
   const [first, retry] = await Promise.all([makeUp(), makeUp()]);
   assert.equal(first.status, 204);
@@ -59,23 +67,18 @@ test("duplicate upload sequence is written only once", async (t) => {
   assert.deepEqual([...writes[0]], [...body]);
 });
 
-test("relay binds a session to one target", async (t) => {
+test("relay binds one sid to one target", async (t) => {
   const writes = [];
   const oldConnect = globalThis.__chunkRelayConnect;
   globalThis.__chunkRelayConnect = () => makeSocket(writes);
   t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
 
-  const relay = new mod.ChunkRelaySession({}, {});
-  const first = await relay.fetch(new Request(
-    "https://example.workers.dev/chunk-relay/open?sid=session_test_456&dst=149.154.167.51",
-    { method: "POST" },
-  ));
+  const relay = new mod.ChunkRelayHub({}, {});
+  const sid = "session_test_456";
+  const first = await relay.fetch(relayRequest("open", sid, { dst: "149.154.167.51" }));
   assert.equal(first.status, 204);
 
-  const second = await relay.fetch(new Request(
-    "https://example.workers.dev/chunk-relay/open?sid=session_test_456&dst=149.154.167.91",
-    { method: "POST" },
-  ));
+  const second = await relay.fetch(relayRequest("open", sid, { dst: "149.154.167.91" }));
   assert.equal(second.status, 502);
 });
 
@@ -85,49 +88,198 @@ test("relay accepts 12 KiB upload chunks and rejects larger bodies", async (t) =
   globalThis.__chunkRelayConnect = () => makeSocket(writes);
   t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
 
-  const relay = new mod.ChunkRelaySession({}, {});
-  const open = await relay.fetch(new Request(
-    "https://example.workers.dev/chunk-relay/open?sid=session_size_123&dst=149.154.167.51",
-    { method: "POST" },
-  ));
+  const relay = new mod.ChunkRelayHub({}, {});
+  const sid = "session_size_123";
+  const open = await relay.fetch(relayRequest("open", sid));
   assert.equal(open.status, 204);
 
-  const ok = await relay.fetch(new Request(
-    "https://example.workers.dev/chunk-relay/up?sid=session_size_123&dst=149.154.167.51&seq=1",
-    { method: "POST", body: new Uint8Array(12 * 1024) },
-  ));
+  const ok = await relay.fetch(relayRequest("up", sid, {
+    seq: 1,
+    body: new Uint8Array(12 * 1024),
+  }));
   assert.equal(ok.status, 204);
   assert.equal(ok.headers.get("X-Tgws-Chunk-Ack"), "1");
   assert.equal(writes.length, 1);
   assert.equal(writes[0].byteLength, 12 * 1024);
 
-  const tooLarge = await relay.fetch(new Request(
-    "https://example.workers.dev/chunk-relay/up?sid=session_size_123&dst=149.154.167.51&seq=2",
-    { method: "POST", body: new Uint8Array(12 * 1024 + 1) },
-  ));
+  const tooLarge = await relay.fetch(relayRequest("up", sid, {
+    seq: 2,
+    body: new Uint8Array(12 * 1024 + 1),
+  }));
   assert.equal(tooLarge.status, 413);
   assert.equal(writes.length, 1);
 });
 
-test("backpressure waits when the next downstream chunk would exceed the queue limit", async () => {
-  const relay = new mod.ChunkRelaySession({}, {});
-  relay.queueBytes = 2 * 1024 * 1024 - 1;
+test("backpressure remains isolated inside one relay session", async (t) => {
+  const oldConnect = globalThis.__chunkRelayConnect;
+  globalThis.__chunkRelayConnect = () => makeSocket([]);
+  t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
+
+  const relay = new mod.ChunkRelayHub({}, {});
+  const sid = "session_backpressure_123";
+  assert.equal((await relay.fetch(relayRequest("open", sid))).status, 204);
+  const session = relay.sessions.get(sid);
+  session.queueBytes = 2 * 1024 * 1024 - 1;
 
   let resolved = false;
-  const wait = relay.waitForDrain(2).then(() => { resolved = true; });
+  const wait = session.waitForDrain(2).then(() => { resolved = true; });
   await Promise.resolve();
   assert.equal(resolved, false);
 
-  relay.queueBytes -= 2;
-  relay.wakeDrain();
+  session.queueBytes -= 2;
+  session.wakeDrain();
   await wait;
   assert.equal(resolved, true);
 });
 
-test("top-level worker maps Durable Object free-tier duration exhaustion to a recoverable response", async () => {
+test("top-level worker routes different sids through one named Durable Object hub", async () => {
+  const names = [];
   const env = {
     CHUNK_RELAY: {
-      getByName() {
+      getByName(name) {
+        names.push(name);
+        return { fetch: async () => new Response(null, { status: 204 }) };
+      },
+    },
+  };
+
+  for (const sid of ["session_hub_001", "session_hub_002", "session_hub_003"]) {
+    const response = await mod.default.fetch(relayRequest("open", sid), env, {});
+    assert.equal(response.status, 204);
+  }
+
+  assert.deepEqual(names, ["relay-hub-v1", "relay-hub-v1", "relay-hub-v1"]);
+});
+
+test("three parallel sessions do not share an upload lock", async (t) => {
+  const oldConnect = globalThis.__chunkRelayConnect;
+  const writesByHost = new Map();
+  let releaseSlowWrite;
+  let markSlowWriteStarted;
+  const slowWriteStarted = new Promise((resolve) => { markSlowWriteStarted = resolve; });
+  const slowWriteGate = new Promise((resolve) => { releaseSlowWrite = resolve; });
+
+  globalThis.__chunkRelayConnect = ({ hostname }) => {
+    const writes = [];
+    writesByHost.set(hostname, writes);
+    const beforeWrite = hostname === "149.154.167.51"
+      ? async () => { markSlowWriteStarted(); await slowWriteGate; }
+      : null;
+    return makeSocket(writes, beforeWrite);
+  };
+  t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
+
+  const relay = new mod.ChunkRelayHub({}, {});
+  const sessions = [
+    ["session_parallel_1", "149.154.167.51"],
+    ["session_parallel_2", "149.154.167.91"],
+    ["session_parallel_3", "149.154.167.92"],
+  ];
+  await Promise.all(sessions.map(([sid, dst]) => relay.fetch(relayRequest("open", sid, { dst }))));
+  assert.equal(relay.sessions.size, 3);
+
+  const slow = relay.fetch(relayRequest("up", sessions[0][0], {
+    dst: sessions[0][1],
+    seq: 1,
+    body: new Uint8Array([1]),
+  }));
+  await slowWriteStarted;
+
+  const fast = Promise.all(sessions.slice(1).map(([sid, dst], index) => relay.fetch(relayRequest("up", sid, {
+    dst,
+    seq: 1,
+    body: new Uint8Array([index + 2]),
+  }))));
+  const fastCompleted = await Promise.race([
+    fast.then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 100)),
+  ]);
+  assert.equal(fastCompleted, true);
+
+  releaseSlowWrite();
+  const slowResponse = await slow;
+  assert.equal(slowResponse.status, 204);
+  assert.equal(writesByHost.get("149.154.167.51").length, 1);
+  assert.equal(writesByHost.get("149.154.167.91").length, 1);
+  assert.equal(writesByHost.get("149.154.167.92").length, 1);
+});
+
+test("closing one sid does not disturb another and the sid can reconnect", async (t) => {
+  const oldConnect = globalThis.__chunkRelayConnect;
+  const socketsByHost = new Map();
+  globalThis.__chunkRelayConnect = ({ hostname }) => {
+    const writes = [];
+    const sockets = socketsByHost.get(hostname) || [];
+    sockets.push(writes);
+    socketsByHost.set(hostname, sockets);
+    return makeSocket(writes);
+  };
+  t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
+
+  const relay = new mod.ChunkRelayHub({}, {});
+  const sidA = "session_isolated_A";
+  const sidB = "session_isolated_B";
+  await relay.fetch(relayRequest("open", sidA, { dst: "149.154.167.51" }));
+  await relay.fetch(relayRequest("open", sidB, { dst: "149.154.167.91" }));
+  assert.equal(relay.sessions.size, 2);
+
+  const closed = await relay.fetch(relayRequest("close", sidA, { dst: "149.154.167.51" }));
+  assert.equal(closed.status, 204);
+  assert.equal(relay.sessions.size, 1);
+
+  const bUpload = await relay.fetch(relayRequest("up", sidB, {
+    dst: "149.154.167.91",
+    seq: 1,
+    body: new Uint8Array([9]),
+  }));
+  assert.equal(bUpload.status, 204);
+
+  const reopened = await relay.fetch(relayRequest("open", sidA, { dst: "149.154.167.51" }));
+  assert.equal(reopened.status, 204);
+  const aUpload = await relay.fetch(relayRequest("up", sidA, {
+    dst: "149.154.167.51",
+    seq: 1,
+    body: new Uint8Array([7]),
+  }));
+  assert.equal(aUpload.status, 204);
+  assert.equal(socketsByHost.get("149.154.167.51").length, 2);
+  assert.equal(socketsByHost.get("149.154.167.91")[0].length, 1);
+});
+
+test("upstream close reaps only the affected session", async (t) => {
+  const oldConnect = globalThis.__chunkRelayConnect;
+  globalThis.__chunkRelayConnect = ({ hostname }) => {
+    if (hostname === "149.154.167.51") {
+      return {
+        opened: Promise.resolve(),
+        writable: { getWriter() { return { async write() {} }; } },
+        readable: { getReader() { return { async read() { return { value: undefined, done: true }; } }; } },
+        async close() {},
+      };
+    }
+    return makeSocket([]);
+  };
+  t.after(() => { globalThis.__chunkRelayConnect = oldConnect; });
+
+  const relay = new mod.ChunkRelayHub({}, {});
+  const reapedSid = "session_reaped_01";
+  const healthySid = "session_reaped_02";
+  assert.equal((await relay.fetch(relayRequest("open", healthySid, { dst: "149.154.167.91" }))).status, 204);
+  assert.equal((await relay.fetch(relayRequest("open", reapedSid, { dst: "149.154.167.51" }))).status, 204);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(relay.sessions.has(reapedSid), false);
+  assert.equal(relay.sessions.has(healthySid), true);
+  assert.equal(relay.reapedSessions, 1);
+  assert.equal(relay.closedSessions, 0);
+});
+
+test("top-level worker maps Durable Object free-tier duration exhaustion to a recoverable response", async () => {
+  const names = [];
+  const env = {
+    CHUNK_RELAY: {
+      getByName(name) {
+        names.push(name);
         return {
           async fetch() {
             throw new Error("Exceeded allowed duration in Durable Objects free tier.");
@@ -137,14 +289,13 @@ test("top-level worker maps Durable Object free-tier duration exhaustion to a re
     },
   };
 
-  const response = await mod.default.fetch(new Request(
-    "https://example.workers.dev/chunk-relay/open?sid=session_quota_123&dst=149.154.167.51",
-    { method: "POST" },
-  ), env, {});
+  const response = await mod.default.fetch(relayRequest("open", "session_quota_123"), env, {});
 
   assert.equal(response.status, 503);
   assert.equal(response.headers.get("X-Tgws-Worker-State"), "do-quota-exhausted");
-  assert.equal(response.headers.get("X-Tgws-Chunk-Relay-Revision"), "chunk-relay-mtproto-v7");
+  assert.equal(response.headers.get("X-Tgws-Chunk-Relay-Revision"), "chunk-relay-mtproto-v8");
+  assert.equal(response.headers.get("X-Tgws-Relay-Hub-Revision"), "relay-hub-v1");
+  assert.deepEqual(names, ["relay-hub-v1"]);
   assert.ok(Number.parseInt(response.headers.get("Retry-After") || "0", 10) >= 60);
   assert.ok(!Number.isNaN(Date.parse(response.headers.get("X-Tgws-Quota-Reset") || "")));
 });
@@ -163,10 +314,7 @@ test("top-level worker does not hide unrelated Durable Object exceptions", async
   };
 
   await assert.rejects(
-    () => mod.default.fetch(new Request(
-      "https://example.workers.dev/chunk-relay/open?sid=session_error_123&dst=149.154.167.51",
-      { method: "POST" },
-    ), env, {}),
+    () => mod.default.fetch(relayRequest("open", "session_error_123"), env, {}),
     /unexpected durable object failure/,
   );
 });


### PR DESCRIPTION
Closes #53.

## What changed

- routes all `/chunk-relay/*` traffic for one Worker deployment to the shared `relay-hub-v1` Durable Object name instead of `getByName(sid)`;
- adds `ChunkRelayHub` with `Map<sid, RelaySession>`;
- keeps socket, upload ACK/reorder state, downstream queue/backpressure, and lifecycle state inside each `RelaySession`;
- keeps upload serialization per session only; there is no hub-global upload lock;
- removes only the affected session on client close, upstream EOF, or relay failure, allowing the same `sid` to reconnect cleanly;
- preserves the existing Wrangler class binding by exporting `ChunkRelayHub` under the legacy `ChunkRelaySession` name as an alias;
- preserves `do-quota-exhausted` 503/reset behavior from #52;
- bumps Worker relay diagnostics to `chunk-relay-mtproto-v8` / `relay-hub-v1` and adds active/opened/closed/reaped counters without logging payloads or opaque session ids;
- documents the hub architecture and updates v1.10.14 release notes.

## Automated verification

Executed locally against the modified Worker source:

```text
node --test scripts/cloudflare-worker/chunk-relay-worker.test.mjs scripts/cloudflare-worker/chunk-relay-window.test.mjs
11 tests, 11 passed, 0 failed
```

Coverage includes:

- three parallel sessions in one hub;
- one blocked upload not blocking the other two sessions;
- duplicate and out-of-order upload ACK semantics;
- 12 KiB upload limit;
- target binding per `sid`;
- per-session downstream backpressure;
- isolated close + reconnect;
- isolated upstream reap;
- `do-quota-exhausted` mapping.

GitHub Actions CI run #155 for head `952b6fc` completed successfully.

## Manual acceptance — completed

Acceptance was run on real Android + three deployed Cloudflare Workers using `chunk-relay-mtproto-v8` / `relay-hub-v1`.

- round-robin pool confirmed with `candidate_count=3` and all three Worker endpoints selected;
- multiple independent MTProto sessions ran concurrently through shared hubs;
- closing individual sessions did not terminate neighboring sessions;
- 12 KiB upload chunks with `window=3` were exercised under sustained load;
- repeated upload of the same 20 MiB file completed successfully;
- four heavy relay sessions in the final run completed with `error=none`:
  - legionleg795: 6,311,669 B in 100.375 s;
  - bbupovic: 6,047,979 B in 100.355 s;
  - carkov195: 5,785,234 B in 114.011 s;
  - carkov195: 5,521,133 B in 117.050 s;
- total upstream transport volume for those four sessions: 23,666,015 B;
- the previous run of the same file produced essentially the same transport volume but took about 169.5 s, so no sustained-throughput regression was observed;
- Cloudflare Durable Objects metrics for the post-deployment hour showed 0 errors on all three deployments and billable duration of approximately 307 GB-s (legionleg795), 277 GB-s (bbupovic), and 269 GB-s (carkov195), with the large pre-hub duration spikes no longer present in the new-period graphs;
- no CPU-limit, memory-limit, internal, or Worker-thrown-exception failures were observed in the current deployment metrics.

The deployment/device acceptance gate for #53 is considered passed.